### PR TITLE
Add CLI tool for polling GitHub Issues/PRs and delegating to Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
 # claude-task-worker
+
+GitHub IssueやPRを定期ポーリングし、Claude CLIに処理を委譲するCLIツール。
+
+## インストール
+
+```bash
+npm install -g claude-task-worker
+```
+
+## 使い方
+
+```bash
+claude-task-worker <worker-type> <interval-minutes>
+```
+
+### exec-issue
+
+`dev-ready` ラベルが付いた自分にアサインされたIssueを定期的に取得し、Claude CLIで処理を実行する。
+
+- `dev-ready` ラベルを外し、`in-progress` ラベルを付与
+- `claude -p /exec-issue <issue番号>` を非同期で実行
+
+```bash
+claude-task-worker exec-issue 5
+```
+
+### fix-review-point
+
+未解決のレビューコメントがあるPRを定期的に取得し、Claude CLIで修正を実行する。
+
+- `in-progress` ラベルが付いていないPRが対象
+- `in-progress` ラベルを付与
+- `claude -p /fix-review-point <ブランチ名>` を非同期で実行
+
+```bash
+claude-task-worker fix-review-point 3
+```
+
+## 前提条件
+
+- [GitHub CLI (`gh`)](https://cli.github.com/) がインストール・認証済みであること
+- [Claude CLI (`claude`)](https://docs.anthropic.com/en/docs/claude-code) がインストール済みであること
+
+## 開発
+
+```bash
+npm install
+npm run build
+```
+
+## ライセンス
+
+MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "claude-task-worker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-task-worker",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "claude-task-worker": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "claude-task-worker",
+  "version": "0.1.0",
+  "description": "CLI tool that polls GitHub Issues/PRs and delegates work to Claude CLI",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "claude-task-worker": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -1,0 +1,94 @@
+import { execFile } from "node:child_process";
+
+interface Issue {
+  number: number;
+  title: string;
+  labels: { name: string }[];
+}
+
+interface PullRequest {
+  number: number;
+  headRefName: string;
+  labels: { name: string }[];
+}
+
+interface RepoInfo {
+  owner: string;
+  name: string;
+}
+
+function execGh(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("gh", args, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`gh ${args.join(" ")} failed: ${stderr || error.message}`));
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+export async function getCurrentUser(): Promise<string> {
+  return execGh(["api", "user", "--jq", ".login"]);
+}
+
+export async function getRepoInfo(): Promise<RepoInfo> {
+  const output = await execGh(["repo", "view", "--json", "owner,name"]);
+  const parsed = JSON.parse(output);
+  return { owner: parsed.owner.login, name: parsed.name };
+}
+
+export async function listIssues(assignee: string, label: string): Promise<Issue[]> {
+  const output = await execGh([
+    "issue", "list",
+    "--assignee", assignee,
+    "--label", label,
+    "--json", "number,title,labels",
+    "--limit", "100",
+  ]);
+  return JSON.parse(output);
+}
+
+export async function listPullRequests(): Promise<PullRequest[]> {
+  const output = await execGh([
+    "pr", "list",
+    "--json", "number,headRefName,labels",
+    "--limit", "100",
+  ]);
+  return JSON.parse(output);
+}
+
+export async function addLabel(type: "issue" | "pr", number: number, label: string): Promise<void> {
+  await execGh([type, "edit", String(number), "--add-label", label]);
+}
+
+export async function removeLabel(number: number, label: string): Promise<void> {
+  await execGh(["issue", "edit", String(number), "--remove-label", label]);
+}
+
+export async function hasUnresolvedReviews(owner: string, repo: string, prNumber: number): Promise<boolean> {
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            nodes { isResolved }
+          }
+        }
+      }
+    }
+  `;
+
+  const output = await execGh([
+    "api", "graphql",
+    "-F", `owner=${owner}`,
+    "-F", `repo=${repo}`,
+    "-F", `number=${prNumber}`,
+    "-f", `query=${query}`,
+  ]);
+
+  const parsed = JSON.parse(output);
+  const threads = parsed.data.repository.pullRequest.reviewThreads.nodes as { isResolved: boolean }[];
+  return threads.some((t) => !t.isResolved);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { execIssueWorker } from "./workers/exec-issue.js";
+import { fixReviewPointWorker } from "./workers/fix-review-point.js";
+
+const WORKERS: Record<string, (interval: number) => Promise<void>> = {
+  "exec-issue": execIssueWorker,
+  "fix-review-point": fixReviewPointWorker,
+};
+
+function printUsage(): void {
+  console.log(`Usage: claude-task-worker <worker-type> <interval-minutes>
+
+Worker types:
+  exec-issue        Poll issues and run /exec-issue
+  fix-review-point  Poll PRs and run /fix-review-point
+
+Example:
+  claude-task-worker exec-issue 5`);
+}
+
+const workerType = process.argv[2];
+const intervalArg = process.argv[3];
+
+if (!workerType || !intervalArg) {
+  printUsage();
+  process.exit(1);
+}
+
+const worker = WORKERS[workerType];
+if (!worker) {
+  console.error(`Unknown worker type: ${workerType}`);
+  printUsage();
+  process.exit(1);
+}
+
+const interval = parseInt(intervalArg, 10);
+if (isNaN(interval) || interval <= 0) {
+  console.error(`Invalid interval: ${intervalArg} (must be a positive integer)`);
+  process.exit(1);
+}
+
+process.on("unhandledRejection", (err) => {
+  console.error("[worker] unhandled rejection:", err);
+  process.exit(1);
+});
+
+worker(interval);

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -1,0 +1,25 @@
+import { spawn } from "node:child_process";
+
+const running = new Set<number>();
+
+export function isRunning(id: number): boolean {
+  return running.has(id);
+}
+
+export function run(command: string, args: string[], id: number): void {
+  running.add(id);
+
+  const child = spawn(command, args, { stdio: "inherit" });
+
+  child.on("close", (code) => {
+    running.delete(id);
+    if (code !== 0) {
+      console.error(`[worker] process for #${id} exited with code ${code}`);
+    }
+  });
+
+  child.on("error", (err) => {
+    running.delete(id);
+    console.error(`[worker] failed to spawn process for #${id}: ${err.message}`);
+  });
+}

--- a/src/workers/exec-issue.ts
+++ b/src/workers/exec-issue.ts
@@ -1,0 +1,27 @@
+import { getCurrentUser, listIssues, removeLabel, addLabel } from "../gh.js";
+import { isRunning, run } from "../process-manager.js";
+
+export async function execIssueWorker(intervalMinutes: number): Promise<void> {
+  const user = await getCurrentUser();
+  console.log(`[exec-issue] Polling issues every ${intervalMinutes} minutes for user ${user}`);
+
+  const tick = async () => {
+    try {
+      const issues = await listIssues(user, "dev-ready");
+
+      for (const issue of issues) {
+        if (isRunning(issue.number)) continue;
+
+        console.log(`[exec-issue] Processing issue #${issue.number}: ${issue.title}`);
+        await removeLabel(issue.number, "dev-ready");
+        await addLabel("issue", issue.number, "in-progress");
+        run("claude", ["-p", "/exec-issue", String(issue.number)], issue.number);
+      }
+    } catch (err) {
+      console.error(`[exec-issue] tick error: ${err}`);
+    }
+  };
+
+  await tick();
+  setInterval(tick, intervalMinutes * 60 * 1000);
+}

--- a/src/workers/fix-review-point.ts
+++ b/src/workers/fix-review-point.ts
@@ -1,0 +1,30 @@
+import { getRepoInfo, listPullRequests, hasUnresolvedReviews, addLabel } from "../gh.js";
+import { isRunning, run } from "../process-manager.js";
+
+export async function fixReviewPointWorker(intervalMinutes: number): Promise<void> {
+  const { owner, name } = await getRepoInfo();
+  console.log(`[fix-review-point] Polling PRs every ${intervalMinutes} minutes for ${owner}/${name}`);
+
+  const tick = async () => {
+    try {
+      const prs = await listPullRequests();
+      const candidates = prs.filter((pr) => !pr.labels.some((l) => l.name === "in-progress"));
+
+      for (const pr of candidates) {
+        if (isRunning(pr.number)) continue;
+
+        const unresolved = await hasUnresolvedReviews(owner, name, pr.number);
+        if (!unresolved) continue;
+
+        console.log(`[fix-review-point] Processing PR #${pr.number} (branch: ${pr.headRefName})`);
+        await addLabel("pr", pr.number, "in-progress");
+        run("claude", ["-p", "/fix-review-point", pr.headRefName], pr.number);
+      }
+    } catch (err) {
+      console.error(`[fix-review-point] tick error: ${err}`);
+    }
+  };
+
+  await tick();
+  setInterval(tick, intervalMinutes * 60 * 1000);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- GitHub IssueやPRを定期ポーリングし、Claude CLIに処理を委譲するCLIツールを実装
- `exec-issue`: dev-readyラベル付きIssueを検出し、`claude -p /exec-issue` を非同期実行
- `fix-review-point`: unresolvedレビューコメント付きPRを検出し、`claude -p /fix-review-point` を非同期実行

## Test plan
- [ ] `npm run build` でコンパイル成功を確認
- [ ] 引数なしで実行し、usage表示を確認
- [ ] 不正なworker typeで実行し、エラーメッセージを確認
- [ ] 実リポジトリで `claude-task-worker exec-issue 1` を実行し、ポーリング動作を確認
- [ ] dev-readyラベル付きIssueを作成し、ラベル切り替え + claude起動を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)