### PR TITLE
refactor: Remove completion comment posting from update-issue worker

### DIFF
--- a/src/workers/update-issue.ts
+++ b/src/workers/update-issue.ts
@@ -1,4 +1,4 @@
-import { getCurrentUser, getRepoInfo, listIssues, removeLabel, addLabel, getLastIssueComment, commentOnIssue } from "../gh.js";
+import { getCurrentUser, getRepoInfo, listIssues, removeLabel, addLabel, getLastIssueComment } from "../gh.js";
 import { isRunning, run } from "../process-manager.js";
 import { notifyTaskCompleted, notifyTaskFailed } from "../slack.js";
 
@@ -35,7 +35,6 @@ export async function updateIssueWorker(): Promise<void> {
           async (status) => {
             try {
               await removeLabel("issue", issue.number, "cc-in-progress");
-              await commentOnIssue(issue.number, `@${lastComment.author} Updated`);
             } catch (err) {
               console.error(`[update-issue] Failed to finalize issue #${issue.number}: ${err}`);
             }


### PR DESCRIPTION
## Summary

Remove the @{author} Updated comment that was posted when the update-issue worker completed. This simplifies the completion flow while preserving label cleanup (cc-in-progress removal) and Slack notifications.

## Changes

- Remove `commentOnIssue()` call from completion callback
- Remove `commentOnIssue` import
- Restore `lastComment` variable and `getLastIssueComment()` call to ensure issue request content is included in the Claude CLI prompt (as required by review feedback)

## Testing

- TypeScript build: ✅ Passes (no type errors)
- Linting: ✅ No issues
- Functionality: Label cleanup, Slack notifications, and issue request content in prompts continue to work as expected

Closes #4