### PR TITLE
fix: Slack通知のトークン使用量を実績値に修正

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -23,7 +23,7 @@ interface ActiveBlockInfo {
   tokenLimitStatus: {
     percentUsed: number;
     limit: number;
-    projectedUsage: number;
+    currentUsage: number;
     status: string;
   };
   endTime: string;
@@ -34,17 +34,23 @@ async function getActiveBlockInfo(): Promise<ActiveBlockInfo | null> {
     const { stdout } = await execAsync("ccusage blocks --token-limit max --active");
 
     const timeRemainingMatch = stdout.match(/Time Remaining:\s+(\d+)h\s+(\d+)m/);
-    if (!timeRemainingMatch) return null;
+    if (!timeRemainingMatch) {
+      console.error("[slack] Failed to parse Time Remaining from ccusage output");
+      return null;
+    }
     const endDate = new Date(Date.now() + (parseInt(timeRemainingMatch[1]) * 60 + parseInt(timeRemainingMatch[2])) * 60 * 1000);
 
-    const currentUsageMatch = stdout.match(/Current Usage:\s+[\d,]+\s+\(([\d.]+)%\)/);
-    if (!currentUsageMatch) return null;
+    const currentUsageMatch = stdout.match(/Current Usage:\s+([\d,]+)\s+\(([\d.]+)%\)/);
+    if (!currentUsageMatch) {
+      console.error("[slack] Failed to parse Current Usage from ccusage output");
+      return null;
+    }
 
     const limitMatch = stdout.match(/Limit:\s+([\d,]+)\s+tokens/);
-    if (!limitMatch) return null;
-
-    const projectedTokensMatch = stdout.match(/Total Tokens:\s+([\d,]+)/);
-    if (!projectedTokensMatch) return null;
+    if (!limitMatch) {
+      console.error("[slack] Failed to parse Limit from ccusage output");
+      return null;
+    }
 
     const projectedStatusMatch = stdout.match(/Projected Usage:\s+[\d.]+%\s+(\w+)/);
     const statusWord = projectedStatusMatch?.[1]?.toLowerCase() ?? "ok";
@@ -52,14 +58,15 @@ async function getActiveBlockInfo(): Promise<ActiveBlockInfo | null> {
 
     return {
       tokenLimitStatus: {
-        percentUsed: parseFloat(currentUsageMatch[1]),
+        percentUsed: parseFloat(currentUsageMatch[2]),
         limit: parseInt(limitMatch[1].replace(/,/g, "")),
-        projectedUsage: parseInt(projectedTokensMatch[1].replace(/,/g, "")),
+        currentUsage: parseInt(currentUsageMatch[1].replace(/,/g, "")),
         status,
       },
       endTime: endDate.toISOString(),
     };
-  } catch {
+  } catch (err) {
+    console.error(`[slack] Failed to get active block info: ${err}`);
     return null;
   }
 }
@@ -87,7 +94,7 @@ async function buildTokenLimitText(): Promise<string> {
 
   const { tokenLimitStatus: status, endTime } = info;
   const emoji = status.status === "ok" ? "🟢" : status.status === "warning" ? "🟡" : "🔴";
-  return ` | ${emoji} Token: ${status.percentUsed.toFixed(1)}% (${formatTokenCount(status.projectedUsage)} / ${formatTokenCount(status.limit)}) | Ends: ${formatEndTimeJST(endTime)}`;
+  return ` | ${emoji} Token: ${status.percentUsed.toFixed(1)}% (${formatTokenCount(status.currentUsage)} / ${formatTokenCount(status.limit)}) | Ends: ${formatEndTimeJST(endTime)}`;
 }
 
 export async function notifyTaskCompleted(workerName: string, id: number, title: string, url: string): Promise<void> {


### PR DESCRIPTION
## 概要

Slack通知で表示されるトークンのバジェット（上限）と使用済みトークン量が、実際の利用量と合っていないという問題を修正しました。

`ccusage blocks --token-limit max --active` コマンドのテキスト出力をパースしていますが、予測値（Projected Usage）を実績値として表示していたことが主原因でした。

## 変更内容

### 修正箇所

**`src/slack.ts`**

- `getActiveBlockInfo()` の正規表現を修正
  - `Current Usage` から実績トークン数も抽出するよう正規表現を拡張
  - 不要だった `Total Tokens` の予測値パース処理を削除
  - パース失敗時に `console.error` でログ出力を追加

- 型定義の変更
  - `ActiveBlockInfo` 型の `projectedUsage` → `currentUsage` に変更

- 表示フォーマットの更新
  - `buildTokenLimitText()` を実績値ベースに更新
  - `Token: 5.6% (10.2M / 181.9M)` という形式で実績値を表示

## テスト

- ✅ `npm run build` - ビルド成功
- テストとLint設定なし

## 関連Issue

Closes #5