### PR TITLE
refactor: トリガーラベル除去タイミングをタスク完了時に統一する

### DIFF
--- a/src/workers/create-issue.ts
+++ b/src/workers/create-issue.ts
@@ -14,9 +14,9 @@ export async function createIssueWorker(): Promise<void> {
       const issues = await listIssues(user, "cc-create-issue");
 
       for (const issue of issues) {
+        if (issue.labels.some(l => l.name === "cc-in-progress")) continue;
         if (isRunning(issue.number)) continue;
 
-        await removeLabel("issue", issue.number, "cc-create-issue");
         await addLabel("issue", issue.number, "cc-in-progress");
 
         const body = await getIssueBody(issue.number);
@@ -28,6 +28,7 @@ export async function createIssueWorker(): Promise<void> {
           issue.title,
           async (status) => {
             try {
+              await removeLabel("issue", issue.number, "cc-create-issue");
               await removeLabel("issue", issue.number, "cc-in-progress");
               await closeIssue(issue.number);
             } catch (err) {

--- a/src/workers/fix-review-point.ts
+++ b/src/workers/fix-review-point.ts
@@ -35,7 +35,7 @@ export async function fixReviewPointWorker(): Promise<void> {
           const labelsToRemove = [LABEL_IN_PROGRESS];
           if (isOnetime) labelsToRemove.push(LABEL_FIX_ONETIME);
           for (const label of labelsToRemove) {
-            removeLabel("pr", pr.number, label);
+            await removeLabel("pr", pr.number, label);
           }
           if (status === "completed") {
             await notifyTaskCompleted("fix-review-point", pr.number, `PR #${pr.number} (${pr.headRefName})`, prUrl);

--- a/src/workers/update-issue.ts
+++ b/src/workers/update-issue.ts
@@ -14,13 +14,14 @@ export async function updateIssueWorker(): Promise<void> {
       const issues = await listIssues(user, "cc-update-issue");
 
       for (const issue of issues) {
+        if (issue.labels.some(l => l.name === "cc-in-progress")) continue;
         if (isRunning(issue.number)) continue;
 
-        await removeLabel("issue", issue.number, "cc-update-issue");
         await addLabel("issue", issue.number, "cc-in-progress");
 
         const lastComment = await getLastIssueComment(issue.number);
         if (!lastComment) {
+          await removeLabel("issue", issue.number, "cc-update-issue");
           await removeLabel("issue", issue.number, "cc-in-progress");
           continue;
         }
@@ -34,6 +35,7 @@ export async function updateIssueWorker(): Promise<void> {
           issue.title,
           async (status) => {
             try {
+              await removeLabel("issue", issue.number, "cc-update-issue");
               await removeLabel("issue", issue.number, "cc-in-progress");
               await commentOnIssue(issue.number, `@${lastComment.author} Updated`);
             } catch (err) {


### PR DESCRIPTION
## 概要

各ワーカーのトリガーラベル除去タイミングを統一し、すべてのワーカーでタスク完了時に除去するよう変更しました。

## 変更内容

### create-issue ワーカー
- トリガーラベル（`cc-create-issue`）の除去を実行開始時から完了時コールバックに移動
- 重複実行防止のため、ポーリング時に `cc-in-progress` ラベルチェックを追加

### update-issue ワーカー
- トリガーラベル（`cc-update-issue`）の除去を実行開始時から完了時コールバックに移動
- 早期終了時（`lastComment` 取得失敗時）にもラベル除去を実施
- 重複実行防止のため、ポーリング時に `cc-in-progress` ラベルチェックを追加

### fix-review-point ワーカー
- 完了時コールバック内の `removeLabel` 呼び出しに `await` を付与

### exec-issue ワーカー
- 変更なし（既に完了時除去の仕様になっている）

## 非機能要件への対応

- ✅ 重複実行防止メカニズムが引き続き正しく機能
- ✅ `cc-in-progress` ラベルの付与・除去タイミングは変更なし
- ✅ ビルド・型チェック完了

## テスト

- npm run build: ✅ 成功
- npx tsc --noEmit: ✅ 成功

Closes #8