### PR TITLE
feat: Double token percentage in Slack notification

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -58,7 +58,7 @@ async function getActiveBlockInfo(): Promise<ActiveBlockInfo | null> {
 
     return {
       tokenLimitStatus: {
-        percentUsed: parseFloat(currentUsageMatch[2]),
+        percentUsed: parseFloat(currentUsageMatch[2]) * 2,
         limit: parseInt(limitMatch[1].replace(/,/g, "")),
         currentUsage: parseInt(currentUsageMatch[1].replace(/,/g, "")),
         status,


### PR DESCRIPTION
## Summary

Doubles the CCU (Claude Code Usage) token percentage displayed in Slack notifications for better visualization of token usage trends.

## Changes

- Modified `src/slack.ts` to multiply token percentage by 2 in `getActiveBlockInfo()` function
- Slack notification messages now show 2x the actual token usage percentage
- Token counts and other display elements remain unchanged

## Testing

- Build verification: ✅ `npm run build` passes
- No test or lint scripts configured in this project

Closes #14