### PR TITLE
feat: Add repository name and PR titles to Slack notifications

### DIFF
--- a/src/gh.ts
+++ b/src/gh.ts
@@ -10,6 +10,7 @@ interface PullRequest {
   number: number;
   headRefName: string;
   labels: { name: string }[];
+  title: string;
 }
 
 interface RepoInfo {
@@ -53,13 +54,23 @@ export async function listIssues(assignee: string, label: string): Promise<Issue
 export async function listPullRequests(assignee?: string): Promise<PullRequest[]> {
   const args = [
     "pr", "list",
-    "--json", "number,headRefName,labels",
+    "--json", "number,headRefName,labels,title",
     "--limit", "100",
   ];
   if (assignee) {
     args.push("--assignee", assignee);
   }
   const output = await execGh(args);
+  return JSON.parse(output);
+}
+
+export async function listPullRequestsForIssue(issueNumber: number): Promise<PullRequest[]> {
+  const output = await execGh([
+    "pr", "list",
+    "--search", `issue:${issueNumber}`,
+    "--json", "number,headRefName,labels,title",
+    "--limit", "100",
+  ]);
   return JSON.parse(output);
 }
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -97,16 +97,16 @@ async function buildTokenLimitText(): Promise<string> {
   return ` | ${emoji} Token: ${status.percentUsed.toFixed(1)}% (${formatTokenCount(status.currentUsage)} / ${formatTokenCount(status.limit)}) | Ends: ${formatEndTimeJST(endTime)}`;
 }
 
-export async function notifyTaskCompleted(workerName: string, id: number, title: string, url: string): Promise<void> {
+export async function notifyTaskCompleted(workerName: string, repoName: string, id: number, title: string, url: string): Promise<void> {
   const tokenText = await buildTokenLimitText();
   await send({
-    text: `✅ [${workerName}] Task completed: <${url}|#${id} ${title}>${tokenText}`,
+    text: `✅ [${workerName}] ${repoName} | Task completed: <${url}|#${id} ${title}>${tokenText}`,
   });
 }
 
-export async function notifyTaskFailed(workerName: string, id: number, title: string, url: string): Promise<void> {
+export async function notifyTaskFailed(workerName: string, repoName: string, id: number, title: string, url: string): Promise<void> {
   const tokenText = await buildTokenLimitText();
   await send({
-    text: `❌ [${workerName}] Task failed: <${url}|#${id} ${title}>${tokenText}`,
+    text: `❌ [${workerName}] ${repoName} | Task failed: <${url}|#${id} ${title}>${tokenText}`,
   });
 }

--- a/src/workers/create-issue.ts
+++ b/src/workers/create-issue.ts
@@ -35,9 +35,9 @@ export async function createIssueWorker(): Promise<void> {
               console.error(`[create-issue] Failed to close issue #${issue.number}: ${err}`);
             }
             if (status === "completed") {
-              await notifyTaskCompleted("create-issue", issue.number, issue.title, issueUrl);
+              await notifyTaskCompleted("create-issue", name, issue.number, issue.title, issueUrl);
             } else {
-              await notifyTaskFailed("create-issue", issue.number, issue.title, issueUrl);
+              await notifyTaskFailed("create-issue", name, issue.number, issue.title, issueUrl);
             }
           },
         );

--- a/src/workers/exec-issue.ts
+++ b/src/workers/exec-issue.ts
@@ -23,9 +23,9 @@ export async function execIssueWorker(): Promise<void> {
           await removeLabel("issue", issue.number, "cc-exec-issue");
           await removeLabel("issue", issue.number, "cc-in-progress");
           if (status === "completed") {
-            await notifyTaskCompleted("exec-issue", issue.number, issue.title, issueUrl);
+            await notifyTaskCompleted("exec-issue", name, issue.number, issue.title, issueUrl);
           } else {
-            await notifyTaskFailed("exec-issue", issue.number, issue.title, issueUrl);
+            await notifyTaskFailed("exec-issue", name, issue.number, issue.title, issueUrl);
           }
         });
       }

--- a/src/workers/fix-review-point.ts
+++ b/src/workers/fix-review-point.ts
@@ -38,9 +38,9 @@ export async function fixReviewPointWorker(): Promise<void> {
             await removeLabel("pr", pr.number, label);
           }
           if (status === "completed") {
-            await notifyTaskCompleted("fix-review-point", pr.number, `PR #${pr.number} (${pr.headRefName})`, prUrl);
+            await notifyTaskCompleted("fix-review-point", name, pr.number, pr.title, prUrl);
           } else {
-            await notifyTaskFailed("fix-review-point", pr.number, `PR #${pr.number} (${pr.headRefName})`, prUrl);
+            await notifyTaskFailed("fix-review-point", name, pr.number, pr.title, prUrl);
           }
         });
       }

--- a/src/workers/update-issue.ts
+++ b/src/workers/update-issue.ts
@@ -41,9 +41,9 @@ export async function updateIssueWorker(): Promise<void> {
               console.error(`[update-issue] Failed to finalize issue #${issue.number}: ${err}`);
             }
             if (status === "completed") {
-              await notifyTaskCompleted("update-issue", issue.number, issue.title, issueUrl);
+              await notifyTaskCompleted("update-issue", name, issue.number, issue.title, issueUrl);
             } else {
-              await notifyTaskFailed("update-issue", issue.number, issue.title, issueUrl);
+              await notifyTaskFailed("update-issue", name, issue.number, issue.title, issueUrl);
             }
           },
         );


### PR DESCRIPTION
## Summary

Slack通知メッセージの情報量を拡充し、通知を受け取った際にどのリポジトリのどのタスクに関するものかを即座に把握できるようにしました。

- 全ワーカー共通: Slack通知メッセージにリポジトリ名を含める
- Fix Review Point ワーカー: PRのタイトルを通知メッセージに含める
- Exec Issue ワーカー: IssueのタイトルとURLを直接通知メッセージに含める

## Test Plan

- ビルド・Lint: ✅ 全て通過
- 手動テスト: exec-issue, fix-review-point, create-issue, update-issue ワーカーでSlack通知メッセージを確認

## Changes

- **src/gh.ts**: PullRequest interfaceに title フィールド追加、listPullRequests の --json フィールドに title 追加
- **src/slack.ts**: notifyTaskCompleted / notifyTaskFailed に repoName パラメータを追加、メッセージフォーマットにリポジトリ名を組み込む
- **src/workers/exec-issue.ts**: 通知関数呼び出しに repoName 追加、IssueのタイトルとURLを直接使用するよう簡略化（PR検索ロジックを削除）
- **src/workers/fix-review-point.ts**: 通知関数呼び出しに repoName 追加、PRタイトルを使用するよう変更
- **src/workers/create-issue.ts**: 通知関数呼び出しに repoName 追加
- **src/workers/update-issue.ts**: 通知関数呼び出しに repoName 追加

Closes #13