### PR TITLE
feat: ~/.config/claude-task-worker.json による設定ファイル管理の追加

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+interface Config {
+  maxConcurrentTasks: number;
+}
+
+const DEFAULT_CONFIG: Config = {
+  maxConcurrentTasks: 4,
+};
+
+function loadConfig(): Config {
+  const configPath = join(homedir(), ".config", "claude-task-worker.json");
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ...DEFAULT_CONFIG };
+    }
+    throw err;
+  }
+
+  const result: Config = { ...DEFAULT_CONFIG };
+
+  if ("maxConcurrentTasks" in raw) {
+    const val = raw["maxConcurrentTasks"];
+    if (typeof val !== "number" || !Number.isInteger(val) || val <= 0) {
+      console.warn(`[config] invalid maxConcurrentTasks: ${val}, using default ${DEFAULT_CONFIG.maxConcurrentTasks}`);
+    } else {
+      result.maxConcurrentTasks = val;
+    }
+  }
+
+  return result;
+}
+
+export const config = loadConfig();

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -1,4 +1,5 @@
 import { spawn, ChildProcess } from "node:child_process";
+import { config } from "./config.js";
 
 type TaskStatus = "running" | "completed" | "failed";
 
@@ -78,8 +79,6 @@ export function isRunning(id: number): boolean {
   return task?.status === "running";
 }
 
-const MAX_CONCURRENT_TASKS_PER_WORKER = 4;
-
 export function isWorkerRunning(workerName: string): boolean {
   for (const task of tasks.values()) {
     if (task.workerName === workerName && task.status === "running") {
@@ -96,7 +95,7 @@ export function isWorkerAtCapacity(workerName: string): boolean {
       count++;
     }
   }
-  return count >= MAX_CONCURRENT_TASKS_PER_WORKER;
+  return count >= config.maxConcurrentTasks;
 }
 
 function formatDuration(start: Date, end: Date = new Date()): string {


### PR DESCRIPTION
## 概要

`~/.config/claude-task-worker.json` から設定を読み込む機能を追加しました。

## 変更内容

- `src/config.ts` を新規作成: 設定ファイルの読み込みモジュール
- `src/process-manager.ts` を修正: ハードコードされた `MAX_CONCURRENT_TASKS_PER_WORKER = 4` を `config.maxConcurrentTasks` に置き換え

## 設定ファイル仕様

`~/.config/claude-task-worker.json`:
```json
{
  "maxConcurrentTasks": 4
}
```

- ファイルが存在しない場合はデフォルト値（4）で動作
- 不正な値（負の数、0、非整数など）の場合はデフォルト値にフォールバックし、警告ログを出力
- アプリケーション起動時に1回だけ読み込む

Closes #20