### PR TITLE
feat: fix-review-point完了時にPRコメントを投稿するオプション追加

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 interface Config {
   maxConcurrentTasks: number;
+  fixReviewPointCallbackCommentMessage?: string;
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -30,6 +31,13 @@ function loadConfig(): Config {
       console.warn(`[config] invalid maxConcurrentTasks: ${val}, using default ${DEFAULT_CONFIG.maxConcurrentTasks}`);
     } else {
       result.maxConcurrentTasks = val;
+    }
+  }
+
+  if ("fixReviewPointCallbackCommentMessage" in raw) {
+    const val = raw["fixReviewPointCallbackCommentMessage"];
+    if (typeof val === "string") {
+      result.fixReviewPointCallbackCommentMessage = val;
     }
   }
 

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -136,6 +136,10 @@ export async function commentOnIssue(issueNumber: number, body: string): Promise
   await execGh(["issue", "comment", String(issueNumber), "--body", body]);
 }
 
+export async function commentOnPR(prNumber: number, body: string): Promise<void> {
+  await execGh(["pr", "comment", String(prNumber), "--body", body]);
+}
+
 export async function createLabel(name: string, color?: string, force?: boolean): Promise<boolean> {
   try {
     const args = ["label", "create", name];

--- a/src/workers/fix-review-point.ts
+++ b/src/workers/fix-review-point.ts
@@ -1,8 +1,9 @@
-import { getCurrentUser, getRepoInfo, listPullRequestsWithChecks, isCICompleted, addLabel, removeLabel } from "../gh";
+import { getCurrentUser, getRepoInfo, listPullRequestsWithChecks, isCICompleted, addLabel, removeLabel, commentOnPR } from "../gh";
 import { syncDefaultBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isWorkerRunning, isShuttingDown, run } from "../process-manager";
 import { generateWorktreeName } from "../random-name";
 import { notifyTaskCompleted, notifyTaskFailed, notifyError } from "../slack";
+import { config } from "../config";
 import { removeWorktree } from "../worktree";
 const POLLING_INTERVAL_MS = 30 * 1000;
 const LABEL_FIX_ONETIME = "cc-fix-onetime";
@@ -42,6 +43,13 @@ export async function fixReviewPointWorker(): Promise<void> {
           if (isOnetime) await removeLabel("pr", pr.number, LABEL_FIX_ONETIME);
           await removeLabel("pr", pr.number, LABEL_IN_PROGRESS);
           if (status === "completed") {
+            if (config.fixReviewPointCallbackCommentMessage) {
+              try {
+                await commentOnPR(pr.number, config.fixReviewPointCallbackCommentMessage);
+              } catch (err) {
+                console.error(`[fix-review-point] failed to post comment on PR #${pr.number}: ${err}`);
+              }
+            }
             await notifyTaskCompleted("fix-review-point", name, pr.number, pr.title, prUrl);
           } else {
             await notifyTaskFailed("fix-review-point", name, pr.number, pr.title, prUrl, output);


### PR DESCRIPTION
## 概要

fix-review-pointワーカーのタスク完了時にPRへコメントを自動投稿するオプションを追加。

## 変更内容

- `Config`インターフェースに `fixReviewPointCallbackCommentMessage?: string` を追加
- `src/gh.ts` に `commentOnPR()` 関数を追加
- fix-review-pointワーカーの完了コールバックで、設定値が存在する場合にPRコメントを投稿
- コメント投稿失敗時のエラーハンドリングを追加（try-catch で例外をキャッチし、ログ出力するが処理は継続）

Closes #22