### PR TITLE
feat: initコマンドでconfigファイルを自動作成する

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,5 +1,7 @@
 import { mkdir, writeFile, access } from "node:fs/promises";
+import { dirname } from "node:path";
 import { createLabel } from "../gh";
+import { DEFAULT_CONFIG, CONFIG_PATH } from "../config.js";
 
 const LABELS: { name: string; color: string }[] = [
   { name: "cc-create-issue", color: "0075ca" },
@@ -62,6 +64,12 @@ async function createFileIfNotExists(path: string, content: string): Promise<boo
   }
 }
 
+async function createConfigIfNotExists(): Promise<void> {
+  await mkdir(dirname(CONFIG_PATH), { recursive: true });
+  const created = await createFileIfNotExists(CONFIG_PATH, JSON.stringify(DEFAULT_CONFIG, null, 2));
+  console.log(created ? `[init] Created: ${CONFIG_PATH}` : `[init] Already exists: ${CONFIG_PATH}`);
+}
+
 export async function init(): Promise<void> {
   console.log("[init] Creating labels...");
 
@@ -85,6 +93,9 @@ export async function init(): Promise<void> {
   const workflowPath = ".github/workflows/assign-creator-on-cc-create-issue.yml";
   const workflowCreated = await createFileIfNotExists(workflowPath, ASSIGN_CREATOR_WORKFLOW);
   console.log(workflowCreated ? `[init] Created: ${workflowPath}` : `[init] Already exists: ${workflowPath}`);
+
+  console.log("[init] Creating config file...");
+  await createConfigIfNotExists();
 
   console.log("[init] Done.");
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,12 +7,14 @@ interface Config {
   fixReviewPointCallbackCommentMessage?: string;
 }
 
-const DEFAULT_CONFIG: Config = {
+export const DEFAULT_CONFIG: Config = {
   maxConcurrentTasks: 4,
 };
 
+export const CONFIG_PATH = join(homedir(), ".config", "claude-task-worker.json");
+
 function loadConfig(): Config {
-  const configPath = join(homedir(), ".config", "claude-task-worker.json");
+  const configPath = CONFIG_PATH;
   let raw: Record<string, unknown>;
   try {
     raw = JSON.parse(readFileSync(configPath, "utf-8"));

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ function printUsage(): void {
   console.log(`Usage: claude-task-worker <command>
 
 Commands:
-  init              Create required GitHub labels
+  init              Create required GitHub labels and config file
   usage             Notify current usage to Slack
 
 Workers:


### PR DESCRIPTION
## 概要

`claude-task-worker init` コマンド実行時に `~/.config/claude-task-worker.json` をデフォルト設定で自動作成するようにしました。

## 変更内容

- `src/config.ts`: `DEFAULT_CONFIG` と `CONFIG_PATH` をエクスポート
- `src/commands/init.ts`: `createConfigIfNotExists()` 関数を追加し、`init()` 内で呼び出す
- `src/index.ts`: ヘルプテキストを更新

## 動作

- configファイルが存在しない場合: `~/.config` ディレクトリを作成し、デフォルト設定でconfigファイルを作成
- configファイルが既に存在する場合: スキップ（既存設定を上書きしない）
- 作成結果をコンソールに出力（`Created` / `Already exists`）

Closes #24