### PR TITLE
fix: Correct child process stdio handling and remove redundant flag

### DIFF
--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -230,8 +230,14 @@ export function run(
   ensureRenderInterval();
   renderTable();
 
-  const child = spawn(command, args, { stdio: ["ignore", "pipe", "inherit"], detached: true });
+  const child = spawn(command, args, { stdio: ["pipe", "pipe", "pipe"], detached: true });
   childProcesses.set(id, child);
+
+  child.stdin?.on("error", () => {});
+  child.stdin?.write("/exit\n");
+  child.stdin?.end();
+
+  child.stderr?.resume();
 
   const outputChunks: Buffer[] = [];
   child.stdout?.on("data", (chunk: Buffer) => {

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -63,7 +63,6 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
                 model,
                 "--effort",
                 effort,
-                "-p",
                 prompt,
                 "--worktree",
                 worktreeId,

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -64,7 +64,6 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
                 model,
                 "--effort",
                 effort,
-                "-p",
                 `${config.command} ${pr.number}`,
                 "--worktree",
                 worktreeId,


### PR DESCRIPTION
Closes #26

## 変更内容

- 子プロセスの `stdio` 設定を `["ignore", "pipe", "inherit"]` から `["pipe", "pipe", "pipe"]` に修正
- `child.stdin` に `/exit\n` を書き込んでから `end()` する処理を追加
- `child.stdin` に EPIPE エラーリスナーを追加し、プロセス終了後の書き込みでクラッシュしないよう対処
- `child.stderr` を `resume()` してバッファが溜まらないよう対処
- `issue-worker.ts` と `pr-worker.ts` の重複していた `-p` フラグを削除

## テスト方法

- [x] `npm run build` でビルドエラーがないことを確認
- [x] `npm run lint` でエラーがないことを確認
- [ ] 子プロセスが正常に起動・終了することを確認
- [ ] ワーカーの動作に影響がないことを確認