### PR TITLE
feat: Add GitHub Project-based branch routing for workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,25 @@ claude-task-worker <command>
 
 通常ワーカー5つ（exec-issue, fix-review-point, create-issue, update-issue, answer-issue-questions）を同時にポーリングする。
 
+`all` と `yolo` には以下のオプションを指定できる。
+
+| オプション | 説明 |
+|---|---|
+| `--project <owner/number>` | 監視対象のIssue/PRをGitHub Projectで絞り込む。`owner` はUser名またはOrganization名、`number` はProject番号（例: `myorg/3`） |
+| `--branch <branchName>` | worktreeのチェックアウト元およびPR作成先のベースブランチを指定する |
+
+オプションの挙動:
+
+- **指定なし**: 設定ファイルの `projects` ルーティングに従い、Issueが所属するプロジェクトに応じてベースブランチを切り替える（マッチしないIssueはデフォルトブランチ）
+- **`--project` のみ**: 指定プロジェクトのIssue/PRに絞る。ベースブランチは `projects[projectId]` があればそれ、なければデフォルトブランチ
+- **`--branch` のみ**: 全Issue/PRを対象に、指定されたブランチをベースとして使用する（`projects` ルーティングは適用されない）
+- **`--project` と `--branch` 両方**: 指定プロジェクトのIssue/PRに絞る。ベースブランチは `projects[projectId]` があればそれを優先し、なければ `--branch` で指定された値
+
+worktree作成時のチェックアウト元ブランチが切り替わるとともに、子プロセスには環境変数 `CC_BASE_BRANCH` が渡される。
+
 ### yolo
 
-すべてのワーカー9つ（`all` + triage-issue + triage-created-issue + triage-pr + check-dependabot）を同時にポーリングする。
+すべてのワーカー9つ（`all` + triage-issue + triage-created-issue + triage-pr + check-dependabot）を同時にポーリングする。`all` と同じく `--project` / `--branch` オプションをサポートする。
 
 ### usage
 
@@ -178,6 +194,7 @@ claude-task-worker <command>
 |---|---|---|---|
 | `fixReviewPointCallbackCommentMessage` | string | - | fix-review-point 完了時にPRへ投稿するコメント（未設定の場合は投稿しない） |
 | `workers` | object | `{}` | ワーカーごとに Claude CLI の `--model` / `--effort`、ポーリング間隔、クールダウン時間、最大同時実行数を上書きする設定（詳細は下記） |
+| `projects` | object | `{}` | GitHub Projectの識別子（`owner/number` 形式）をキー、ベースブランチ名を値に持つマップ。`all` / `yolo` 起動時に、Issueが所属するプロジェクトに応じてworktreeのチェックアウト元・PRのベースブランチを切り替える |
 
 ### ワーカーごとの設定
 
@@ -214,6 +231,10 @@ claude-task-worker <command>
     "fix-review-point":  { "model": "sonnet", "effort": "high", "maxConcurrentTasks": 2 },
     "triage-pr":         { "effort": "medium", "pollingIntervalSeconds": 120 },
     "check-dependabot":  { "model": "haiku", "pollingIntervalSeconds": 7200 }
+  },
+  "projects": {
+    "myorg/3": "develop",
+    "myorg/7": "release/v2"
   }
 }
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export interface WorkerRuntimeConfig {
 interface Config {
   fixReviewPointCallbackCommentMessage?: string;
   workers: Record<string, WorkerRuntimeConfig>;
+  projects: Record<string, string>;
 }
 
 export const DEFAULT_WORKER_CONFIG: WorkerRuntimeConfig = {
@@ -48,6 +49,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
 export const DEFAULT_CONFIG: Config = {
   fixReviewPointCallbackCommentMessage: "",
   workers: {},
+  projects: {},
 };
 
 export const CONFIG_PATH = join(process.cwd(), "claude-task-worker.json");
@@ -118,17 +120,32 @@ export function loadConfig(): Config {
     raw = JSON.parse(readFileSync(configPath, "utf-8"));
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return { ...DEFAULT_CONFIG, workers: {} };
+      return { ...DEFAULT_CONFIG, workers: {}, projects: {} };
     }
     throw err;
   }
 
-  const result: Config = { ...DEFAULT_CONFIG, workers: {} };
+  const result: Config = { ...DEFAULT_CONFIG, workers: {}, projects: {} };
 
   if ("fixReviewPointCallbackCommentMessage" in raw) {
     const val = raw["fixReviewPointCallbackCommentMessage"];
     if (typeof val === "string") {
       result.fixReviewPointCallbackCommentMessage = val;
+    }
+  }
+
+  if ("projects" in raw) {
+    const projects = raw["projects"];
+    if (typeof projects !== "object" || projects === null || Array.isArray(projects)) {
+      console.warn(`[config] invalid projects: expected object, ignoring`);
+    } else {
+      for (const [projectId, branch] of Object.entries(projects as Record<string, unknown>)) {
+        if (typeof branch === "string" && branch.length > 0) {
+          result.projects[projectId] = branch;
+        } else {
+          console.warn(`[config] invalid projects.${projectId}: expected string, ignoring`);
+        }
+      }
     }
   }
 

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -198,6 +198,76 @@ export async function commentOnPR(prNumber: number, body: string): Promise<void>
   await execGh(["pr", "comment", String(prNumber), "--body", body]);
 }
 
+async function fetchProjectIds(
+  resource: "issue" | "pullRequest",
+  owner: string,
+  name: string,
+  number: number,
+): Promise<string[]> {
+  const query = `query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){${resource}(number:$number){projectItems(first:20){nodes{project{id}}}}}}`;
+  try {
+    const output = await execGh([
+      "api",
+      "graphql",
+      "-f",
+      `query=${query}`,
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `name=${name}`,
+      "-F",
+      `number=${number}`,
+    ]);
+    const parsed = JSON.parse(output);
+    const nodes = parsed?.data?.repository?.[resource]?.projectItems?.nodes ?? [];
+    return nodes
+      .map((n: { project?: { id?: string } }) => n?.project?.id)
+      .filter((id: unknown): id is string => typeof id === "string" && id.length > 0);
+  } catch (err) {
+    console.error(`[gh] failed to fetch projectIds for ${resource} #${number}: ${err}`);
+    return [];
+  }
+}
+
+export function getIssueProjectIds(owner: string, name: string, issueNumber: number): Promise<string[]> {
+  return fetchProjectIds("issue", owner, name, issueNumber);
+}
+
+export function getPullRequestProjectIds(owner: string, name: string, prNumber: number): Promise<string[]> {
+  return fetchProjectIds("pullRequest", owner, name, prNumber);
+}
+
+async function tryResolveProjectAsOwner(
+  ownerType: "user" | "organization",
+  owner: string,
+  number: number,
+): Promise<string | null> {
+  const query = `query($owner:String!,$number:Int!){${ownerType}(login:$owner){projectV2(number:$number){id}}}`;
+  try {
+    const output = await execGh([
+      "api",
+      "graphql",
+      "-f",
+      `query=${query}`,
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `number=${number}`,
+    ]);
+    const parsed = JSON.parse(output);
+    const id = parsed?.data?.[ownerType]?.projectV2?.id;
+    return typeof id === "string" && id.length > 0 ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveProjectNodeId(owner: string, number: number): Promise<string | null> {
+  const asUser = await tryResolveProjectAsOwner("user", owner, number);
+  if (asUser) return asUser;
+  return tryResolveProjectAsOwner("organization", owner, number);
+}
+
 export async function createLabel(name: string, color?: string, force?: boolean): Promise<boolean> {
   try {
     const args = ["label", "create", name];

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,12 @@ import { triagePrWorker } from "./workers/triage-pr";
 import { checkDependabotWorker } from "./workers/check-dependabot";
 import { shutdown, waitForAllProcesses, setShuttingDown, isShuttingDown } from "./process-manager";
 import { init } from "./commands/init";
+import { loadConfig } from "./config";
+import { resolveProjectNodeId } from "./gh";
 import { buildTokenLimitText, send } from "./slack";
+import type { WorkerOptions } from "./worker-options";
 
-const WORKERS: Record<string, () => Promise<void>> = {
+const WORKERS: Record<string, (options?: WorkerOptions) => Promise<void>> = {
   "exec-issue": execIssueWorker,
   "fix-review-point": fixReviewPointWorker,
   "create-issue": createIssueWorker,
@@ -26,7 +29,7 @@ const WORKERS: Record<string, () => Promise<void>> = {
 };
 
 function printUsage(): void {
-  console.log(`Usage: claude-task-worker <command>
+  console.log(`Usage: claude-task-worker <command> [options]
 
 Commands:
   init [--force]    Create required GitHub labels and config file (use --force to overwrite existing files)
@@ -45,9 +48,86 @@ Workers:
   all               Poll all workers except triage-issue, triage-created-issue, triage-pr, check-dependabot
   yolo              Poll all workers including triage-issue, triage-created-issue, triage-pr, check-dependabot
 
+Options for all/yolo:
+  --project <owner/number>  Filter target issues/PRs by GitHub Project (e.g. myorg/3)
+  --branch <name>           Base branch for worktree checkout and PR creation
+
 Example:
   claude-task-worker init
-  claude-task-worker exec-issue`);
+  claude-task-worker exec-issue
+  claude-task-worker yolo --project myorg/3 --branch develop`);
+}
+
+function parseFlags(args: string[]): { project?: string; branch?: string } {
+  let project: string | undefined;
+  let branch: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--project" && args[i + 1]) {
+      project = args[i + 1];
+      i++;
+    } else if (a === "--branch" && args[i + 1]) {
+      branch = args[i + 1];
+      i++;
+    }
+  }
+  return { project, branch };
+}
+
+function parseProjectKey(key: string): { owner: string; number: number } | null {
+  const match = key.match(/^([^/\s]+)\/(\d+)$/);
+  if (!match) return null;
+  return { owner: match[1], number: Number(match[2]) };
+}
+
+async function resolveProjectKey(key: string): Promise<string | null> {
+  const parsed = parseProjectKey(key);
+  if (!parsed) {
+    console.error(`[worker] invalid project key: ${key} (expected "owner/number")`);
+    return null;
+  }
+  const nodeId = await resolveProjectNodeId(parsed.owner, parsed.number);
+  if (!nodeId) {
+    console.error(`[worker] could not resolve project ${key} to a node ID`);
+  }
+  return nodeId;
+}
+
+async function resolveProjectsMap(input: Record<string, string>): Promise<Record<string, string>> {
+  const entries = await Promise.all(
+    Object.entries(input).map(async ([key, branch]) => {
+      const nodeId = await resolveProjectKey(key);
+      return nodeId ? ([nodeId, branch] as const) : null;
+    }),
+  );
+  const result: Record<string, string> = {};
+  for (const e of entries) {
+    if (e) result[e[0]] = e[1];
+  }
+  return result;
+}
+
+async function buildWorkerOptions(args: string[]): Promise<WorkerOptions> {
+  const { project, branch } = parseFlags(args);
+  const config = loadConfig();
+  const configProjects = config.projects ?? {};
+
+  if (!project && !branch) {
+    return { projects: await resolveProjectsMap(configProjects) };
+  }
+  if (!project && branch) {
+    return { branch };
+  }
+  const projectNodeId = project ? await resolveProjectKey(project) : undefined;
+  if (project && !projectNodeId) {
+    console.error(`[worker] aborting: --project ${project} could not be resolved`);
+    process.exit(1);
+  }
+  return {
+    projectId: projectNodeId ?? undefined,
+    branch,
+    projects: await resolveProjectsMap(configProjects),
+  };
 }
 
 const workerType = process.argv[2];
@@ -117,25 +197,29 @@ if (workerType === "init") {
     await send({ text: `📊 Usage${text}` });
   })();
 } else if (workerType === "all") {
-  Promise.all([
-    execIssueWorker(),
-    fixReviewPointWorker(),
-    createIssueWorker(),
-    updateIssueWorker(),
-    answerIssueQuestionsWorker(),
-  ]);
+  (async () => {
+    const options = await buildWorkerOptions(process.argv.slice(3));
+    await Promise.all([
+      execIssueWorker(options),
+      fixReviewPointWorker(options),
+      createIssueWorker(options),
+      updateIssueWorker(options),
+      answerIssueQuestionsWorker(options),
+    ]);
+  })();
 } else if (workerType === "yolo") {
   (async () => {
+    const options = await buildWorkerOptions(process.argv.slice(3));
     await Promise.all([
-      execIssueWorker(),
-      fixReviewPointWorker(),
-      createIssueWorker(),
-      updateIssueWorker(),
-      answerIssueQuestionsWorker(),
-      triageIssueWorker(),
-      triageCreatedIssueWorker(),
-      checkDependabotWorker(),
-      triagePrWorker(),
+      execIssueWorker(options),
+      fixReviewPointWorker(options),
+      createIssueWorker(options),
+      updateIssueWorker(options),
+      answerIssueQuestionsWorker(options),
+      triageIssueWorker(options),
+      triageCreatedIssueWorker(options),
+      checkDependabotWorker(options),
+      triagePrWorker(options),
     ]);
   })();
 } else {

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -217,6 +217,7 @@ export function run(
   workerName: string,
   path?: string,
   onComplete?: (status: "completed" | "failed", output: string) => Promise<void>,
+  envOverrides?: Record<string, string>,
 ): void {
   tasks.set(id, {
     id,
@@ -230,7 +231,11 @@ export function run(
   ensureRenderInterval();
   renderTable();
 
-  const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"], detached: true });
+  const child = spawn(command, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
+    env: envOverrides ? { ...process.env, ...envOverrides } : undefined,
+  });
   childProcesses.set(id, child);
 
   child.stderr?.resume();

--- a/src/worker-options.ts
+++ b/src/worker-options.ts
@@ -1,0 +1,25 @@
+export interface WorkerOptions {
+  projectId?: string;
+  branch?: string;
+  projects?: Record<string, string>;
+}
+
+export function resolveBranch(
+  issueProjectIds: string[],
+  projects: Record<string, string> | undefined,
+  cliBranch: string | undefined,
+  defaultBranch: string,
+): string {
+  if (projects) {
+    for (const pid of issueProjectIds) {
+      const branch = projects[pid];
+      if (branch) return branch;
+    }
+  }
+  if (cliBranch) return cliBranch;
+  return defaultBranch;
+}
+
+export function needsProjectLookup(options: WorkerOptions): boolean {
+  return Boolean(options.projectId || (options.projects && Object.keys(options.projects).length > 0));
+}

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -1,9 +1,17 @@
 import { getWorkerConfig } from "../config";
-import { getCurrentUser, getRepoInfo, listIssuesByLabel, removeLabel, addLabel } from "../gh";
+import {
+  getCurrentUser,
+  getIssueProjectIds,
+  getRepoInfo,
+  listIssuesByLabel,
+  removeLabel,
+  addLabel,
+} from "../gh";
 import { syncDefaultBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isShuttingDown, run } from "../process-manager";
 import { generateWorktreeName } from "../random-name";
 import { notifyTaskCompleted, notifyTaskFailed, notifyError } from "../slack";
+import { needsProjectLookup, resolveBranch, type WorkerOptions } from "../worker-options";
 import { removeWorktree } from "../worktree";
 
 const LABEL_TRIAGE_SCOPE = "cc-triage-scope";
@@ -16,15 +24,19 @@ interface IssueWorkerConfig {
   onCompleted?: (issueNumber: number) => Promise<void>;
 }
 
-export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promise<void> {
-  return async () => {
+export function createIssuePollingWorker(
+  config: IssueWorkerConfig,
+): (options?: WorkerOptions) => Promise<void> {
+  return async (options: WorkerOptions = {}) => {
     const { owner, name, defaultBranch } = await getRepoInfo();
     const user = await getCurrentUser();
     const { pollingIntervalSeconds, cooldownSeconds } = getWorkerConfig(config.name);
     const pollingIntervalMs = pollingIntervalSeconds * 1000;
     const cooldownMs = cooldownSeconds * 1000;
+    const filterLog = options.projectId ? ` project=${options.projectId}` : "";
+    const branchLog = options.branch ? ` branch=${options.branch}` : "";
     console.log(
-      `[${config.name}] Polling issues every ${pollingIntervalSeconds} seconds for ${owner}/${name} (assignee: ${user})`,
+      `[${config.name}] Polling issues every ${pollingIntervalSeconds} seconds for ${owner}/${name} (assignee: ${user})${filterLog}${branchLog}`,
     );
 
     let lastCompletionAt = 0;
@@ -34,9 +46,17 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
       if (cooldownMs > 0 && lastCompletionAt > 0 && Date.now() - lastCompletionAt < cooldownMs) return;
       try {
         const excludeLabels = ["cc-in-progress", "cc-need-human-check", ...(config.excludeLabels ?? [])];
-        const candidates = await listIssuesByLabel(user, config.triggerLabels, excludeLabels);
+        const rawCandidates = await listIssuesByLabel(user, config.triggerLabels, excludeLabels);
 
-        for (const issue of candidates) {
+        const lookupRequired = needsProjectLookup(options);
+        const candidates: { issue: (typeof rawCandidates)[number]; projectIds: string[] }[] = [];
+        for (const issue of rawCandidates) {
+          const projectIds = lookupRequired ? await getIssueProjectIds(owner, name, issue.number) : [];
+          if (options.projectId && !projectIds.includes(options.projectId)) continue;
+          candidates.push({ issue, projectIds });
+        }
+
+        for (const { issue, projectIds } of candidates) {
           if (isRunning(issue.number)) continue;
           if (isWorkerAtCapacity(config.name)) break;
 
@@ -46,7 +66,8 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
           try {
             const issueUrl = `https://github.com/${owner}/${name}/issues/${issue.number}`;
             const worktreeId = generateWorktreeName();
-            syncDefaultBranch(defaultBranch);
+            const resolvedBranch = resolveBranch(projectIds, options.projects, options.branch, defaultBranch);
+            syncDefaultBranch(resolvedBranch);
             const { model, effort } = getWorkerConfig(config.name);
             run(
               "claude",
@@ -97,6 +118,7 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
                   );
                 }
               },
+              { CC_BASE_BRANCH: resolvedBranch },
             );
           } catch (err) {
             console.error(`[${config.name}] setup error for #${issue.number}: ${err}`);

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -2,6 +2,7 @@ import { getWorkerConfig } from "../config";
 import {
   type PullRequestWithChecks,
   getCurrentUser,
+  getPullRequestProjectIds,
   getRepoInfo,
   listPullRequestsWithChecks,
   addLabel,
@@ -11,6 +12,7 @@ import { syncDefaultBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isShuttingDown, run } from "../process-manager";
 import { generateWorktreeName } from "../random-name";
 import { notifyTaskCompleted, notifyTaskFailed, notifyError } from "../slack";
+import { type WorkerOptions } from "../worker-options";
 import { removeWorktree, removeWorktreeByBranch } from "../worktree";
 
 const LABEL_IN_PROGRESS = "cc-in-progress";
@@ -25,15 +27,18 @@ interface PrWorkerConfig {
   onFinally?: (pr: PullRequestWithChecks) => Promise<void>;
 }
 
-export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<void> {
-  return async () => {
+export function createPrPollingWorker(
+  config: PrWorkerConfig,
+): (options?: WorkerOptions) => Promise<void> {
+  return async (options: WorkerOptions = {}) => {
     const { owner, name, defaultBranch } = await getRepoInfo();
     const user = await getCurrentUser();
     const { pollingIntervalSeconds, cooldownSeconds } = getWorkerConfig(config.name);
     const pollingIntervalMs = pollingIntervalSeconds * 1000;
     const cooldownMs = cooldownSeconds * 1000;
+    const filterLog = options.projectId ? ` project=${options.projectId}` : "";
     console.log(
-      `[${config.name}] Polling PRs every ${pollingIntervalSeconds} seconds for ${owner}/${name} (assignee: ${user})`,
+      `[${config.name}] Polling PRs every ${pollingIntervalSeconds} seconds for ${owner}/${name} (assignee: ${user})${filterLog}`,
     );
 
     let lastCompletionAt = 0;
@@ -43,7 +48,16 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
       if (cooldownMs > 0 && lastCompletionAt > 0 && Date.now() - lastCompletionAt < cooldownMs) return;
       try {
         const excludeLabels = [LABEL_IN_PROGRESS, ...(config.excludeLabels ?? [])];
-        const candidates = await listPullRequestsWithChecks(user, config.triggerLabel, excludeLabels);
+        const rawCandidates = await listPullRequestsWithChecks(user, config.triggerLabel, excludeLabels);
+
+        const candidates: PullRequestWithChecks[] = [];
+        for (const pr of rawCandidates) {
+          if (options.projectId) {
+            const projectIds = await getPullRequestProjectIds(owner, name, pr.number);
+            if (!projectIds.includes(options.projectId)) continue;
+          }
+          candidates.push(pr);
+        }
 
         for (const pr of candidates) {
           if (isRunning(pr.number)) continue;


### PR DESCRIPTION
## Summary

- GitHub Projectで監視対象のIssue/PRを絞り込み、worktreeのチェックアウト元およびPR作成先のベースブランチを切り替えられるようにした
- Configに `projects` プロパティ（`owner/number` → ベースブランチ のマップ）を追加し、起動時に各識別子をProject Node IDに解決
- `all` / `yolo` モードに `--project <owner/number>` / `--branch <name>` フラグを追加
- 子プロセスに `CC_BASE_BRANCH` 環境変数を渡し、PR作成先のbase指定に利用できるようにした

## オプションの挙動

- **指定なし**: Configの `projects` ルーティングを各Issueに適用、マッチしなければデフォルトブランチ
- **`--project` のみ**: 指定プロジェクトのIssue/PRに絞り、branch = `Config.projects[id]` ?? デフォルトブランチ
- **`--branch` のみ**: 全Issue/PR対象、すべて指定ブランチをベースに（`projects` 無視）
- **両方**: 指定プロジェクトに絞り、branch = `Config.projects[id]` ?? `--branch`（Config優先）

## Test plan

- [ ] \`npm run build\` が通る
- [ ] \`npx eslint src/\` が通る
- [ ] \`claude-task-worker yolo\` （引数なし）でConfig.projectsルーティングが反映される
- [ ] \`claude-task-worker yolo --project myorg/3\` で対象Projectに紐づくIssueのみが処理される
- [ ] \`claude-task-worker yolo --branch develop\` で全Issueがdevelopブランチをベースに処理される
- [ ] \`claude-task-worker yolo --project myorg/3 --branch develop\` でConfig優先のルーティング動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)