### PR TITLE
feat: Issue系ワーカーに --label フィルタを追加し --epic を複数指定対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,16 +106,33 @@ claude-task-worker init --force   # 既存ファイルを強制上書き
 ## コマンド
 
 ```bash
-claude-task-worker <command> [--epic <issue-number>]
+claude-task-worker <command> [--epic <issue-number>]... [--label <label-name>]...
 ```
 
 ### `--epic <issue-number>` オプション
 
-`all` / `yolo` および Issue 系の各ワーカー（`exec-issue` / `create-issue` / `update-issue` / `answer-issue-questions` / `triage-created-issue`）で、指定したエピックIssueのサブIssueのみを処理対象に絞り込む。エピック単位でロールアウトしたいときに使用する。
+`all` / `yolo` および Issue 系の各ワーカー（`exec-issue` / `create-issue` / `update-issue` / `answer-issue-questions` / `triage-created-issue` / `epic-issue`）で、指定したエピックIssueのサブIssueのみを処理対象に絞り込む。エピック単位でロールアウトしたいときに使用する。
+
+複数指定可能で、複数指定した場合はいずれかのエピックを親に持つサブIssueが対象になる（OR）。
 
 ```bash
 claude-task-worker all --epic 100
+claude-task-worker all --epic 100 --epic 200    # #100 または #200 の sub-issue
 ```
+
+### `--label <label-name>` オプション
+
+`all` / `yolo` および Issue 系の各ワーカーで、トリガーラベルに加えて指定したラベルが付いているIssueのみを処理対象に絞り込む。優先度・スプリント・スコープ等で対象を限定したいときに使用する。
+
+複数指定可能で、複数指定した場合は指定したすべてのラベルが付いているIssueが対象になる（AND）。`--epic` と併用すれば両条件のANDで絞り込まれる。
+
+```bash
+claude-task-worker all --label priority-high
+claude-task-worker all --label priority-high --label needs-design   # 両方付いている Issue のみ
+claude-task-worker yolo --epic 100 --epic 200 --label priority-high
+```
+
+> ℹ️ `--label` で指定したラベルはユーザーのスコープ指定なので、タスク完了時にワーカー側で除去されることはない（トリガーラベルだけが除去される）。
 
 ### exec-issue
 
@@ -181,11 +198,11 @@ claude-task-worker all --epic 100
 
 ### all
 
-通常ワーカー6つ（exec-issue, fix-review-point, create-issue, update-issue, answer-issue-questions, epic-issue）を同時にポーリングする。`--epic` オプションでIssue系ワーカーをサブIssueに絞り込み可能。
+通常ワーカー6つ（exec-issue, fix-review-point, create-issue, update-issue, answer-issue-questions, epic-issue）を同時にポーリングする。`--epic` / `--label` オプションでIssue系ワーカーの処理対象を絞り込み可能（どちらも複数指定可）。
 
 ### yolo
 
-すべてのワーカー（`all` + triage-created-issue + triage-pr + check-dependabot）を同時にポーリングする。`--epic` オプションでIssue系ワーカーをサブIssueに絞り込み可能。
+すべてのワーカー（`all` + triage-created-issue + triage-pr + check-dependabot）を同時にポーリングする。`--epic` / `--label` オプションでIssue系ワーカーの処理対象を絞り込み可能（どちらも複数指定可）。
 
 ### usage
 

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -69,7 +69,7 @@ export async function listIssuesByLabel(
   assignee: string,
   labels: string[],
   excludeLabels: string[] = [],
-  epicFilter?: { owner: string; repo: string; number: number },
+  epicFilter?: { owner: string; repo: string; numbers: number[] },
 ): Promise<Issue[]> {
   const labelArgs = labels.flatMap((label) => ["--label", label]);
   const searchTerms = [
@@ -77,8 +77,10 @@ export async function listIssuesByLabel(
     "-is:blocked",
     ...excludeLabels.map((label) => `-label:"${label}"`),
   ];
-  if (epicFilter) {
-    searchTerms.push(`parent-issue:${epicFilter.owner}/${epicFilter.repo}#${epicFilter.number}`);
+  if (epicFilter && epicFilter.numbers.length > 0) {
+    for (const number of epicFilter.numbers) {
+      searchTerms.push(`parent-issue:${epicFilter.owner}/${epicFilter.repo}#${number}`);
+    }
   }
   const search = searchTerms.join(" ");
   const output = await execGh([

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { shutdown, waitForAllProcesses, setShuttingDown, isShuttingDown } from "
 import { init } from "./commands/init";
 import { buildTokenLimitText, send } from "./slack";
 
-const WORKERS: Record<string, (opts?: { epicFilter?: number }) => Promise<void>> = {
+const WORKERS: Record<string, (opts?: { epicFilters?: number[]; labelFilters?: string[] }) => Promise<void>> = {
   "exec-issue": execIssueWorker,
   "fix-review-point": fixReviewPointWorker,
   "create-issue": createIssueWorker,
@@ -26,7 +26,7 @@ const WORKERS: Record<string, (opts?: { epicFilter?: number }) => Promise<void>>
 };
 
 function printUsage(): void {
-  console.log(`Usage: claude-task-worker <command> [--epic <issue-number>]
+  console.log(`Usage: claude-task-worker <command> [--epic <issue-number>] [--label <label-name>]
 
 Commands:
   init [--force]    Create required GitHub labels and config file (use --force to overwrite existing files)
@@ -46,12 +46,17 @@ Workers:
   yolo              Poll all workers including triage-created-issue, triage-pr, check-dependabot
 
 Options:
-  --epic <number>   Limit issue-based workers to sub-issues of the specified epic issue (for 'all' and 'yolo')
+  --epic <number>   Limit issue-based workers to sub-issues of the specified epic issue. Repeatable: any matching parent (OR).
+  --label <name>    Limit issue-based workers to issues that also carry the specified label. Repeatable: all must be present (AND).
 
 Example:
   claude-task-worker init
   claude-task-worker exec-issue
-  claude-task-worker all --epic 100`);
+  claude-task-worker all --epic 100
+  claude-task-worker all --epic 100 --epic 200
+  claude-task-worker all --label priority-high
+  claude-task-worker all --label priority-high --label needs-design
+  claude-task-worker yolo --epic 100 --epic 200 --label priority-high`);
 }
 
 const workerType = process.argv[2];
@@ -73,20 +78,34 @@ if (
   process.exit(1);
 }
 
-function parseEpicFilter(): number | undefined {
-  const idx = process.argv.indexOf("--epic");
-  if (idx === -1) return undefined;
-  const raw = process.argv[idx + 1];
-  if (!raw) {
-    console.error("--epic requires a numeric issue number");
-    process.exit(1);
+function collectFlagValues(flag: string): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] !== flag) continue;
+    const raw = process.argv[i + 1];
+    if (!raw || raw.startsWith("--")) {
+      console.error(`${flag} requires a value`);
+      process.exit(1);
+    }
+    values.push(raw);
   }
-  const num = Number(raw);
-  if (!Number.isFinite(num) || !Number.isInteger(num) || num <= 0) {
-    console.error(`--epic requires a positive integer issue number, got: ${raw}`);
-    process.exit(1);
-  }
-  return num;
+  return values;
+}
+
+function parseEpicFilters(): number[] {
+  const raws = collectFlagValues("--epic");
+  return raws.map((raw) => {
+    const num = Number(raw);
+    if (!Number.isFinite(num) || !Number.isInteger(num) || num <= 0) {
+      console.error(`--epic requires a positive integer issue number, got: ${raw}`);
+      process.exit(1);
+    }
+    return num;
+  });
+}
+
+function parseLabelFilters(): string[] {
+  return collectFlagValues("--label");
 }
 
 process.on("unhandledRejection", (err) => {
@@ -137,30 +156,34 @@ if (workerType === "init") {
     await send({ text: `📊 Usage${text}` });
   })();
 } else if (workerType === "all") {
-  const epicFilter = parseEpicFilter();
+  const epicFilters = parseEpicFilters();
+  const labelFilters = parseLabelFilters();
   Promise.all([
-    execIssueWorker({ epicFilter }),
+    execIssueWorker({ epicFilters, labelFilters }),
     fixReviewPointWorker(),
-    createIssueWorker({ epicFilter }),
-    updateIssueWorker({ epicFilter }),
-    answerIssueQuestionsWorker({ epicFilter }),
-    epicIssueWorker(),
+    createIssueWorker({ epicFilters, labelFilters }),
+    updateIssueWorker({ epicFilters, labelFilters }),
+    answerIssueQuestionsWorker({ epicFilters, labelFilters }),
+    epicIssueWorker({ labelFilters }),
   ]);
 } else if (workerType === "yolo") {
-  const epicFilter = parseEpicFilter();
+  const epicFilters = parseEpicFilters();
+  const labelFilters = parseLabelFilters();
   (async () => {
     await Promise.all([
-      execIssueWorker({ epicFilter }),
+      execIssueWorker({ epicFilters, labelFilters }),
       fixReviewPointWorker(),
-      createIssueWorker({ epicFilter }),
-      updateIssueWorker({ epicFilter }),
-      answerIssueQuestionsWorker({ epicFilter }),
-      triageCreatedIssueWorker({ epicFilter }),
+      createIssueWorker({ epicFilters, labelFilters }),
+      updateIssueWorker({ epicFilters, labelFilters }),
+      answerIssueQuestionsWorker({ epicFilters, labelFilters }),
+      triageCreatedIssueWorker({ epicFilters, labelFilters }),
       checkDependabotWorker(),
       triagePrWorker(),
-      epicIssueWorker(),
+      epicIssueWorker({ labelFilters }),
     ]);
   })();
 } else {
-  WORKERS[workerType]();
+  const epicFilters = parseEpicFilters();
+  const labelFilters = parseLabelFilters();
+  WORKERS[workerType]({ epicFilters, labelFilters });
 }

--- a/src/workers/answer-issue-questions.ts
+++ b/src/workers/answer-issue-questions.ts
@@ -1,12 +1,13 @@
 import { addLabel } from "../gh";
 import { createIssuePollingWorker } from "./issue-worker";
 
-export const answerIssueQuestionsWorker = (opts: { epicFilter?: number } = {}) =>
+export const answerIssueQuestionsWorker = (opts: { epicFilters?: number[]; labelFilters?: string[] } = {}) =>
   createIssuePollingWorker({
     name: "answer-issue-questions",
     command: "/base-tools:answer-issue-questions",
     triggerLabels: ["cc-answer-issue-questions"],
-    epicFilter: opts.epicFilter,
+    epicFilters: opts.epicFilters,
+    labelFilters: opts.labelFilters,
     onCompleted: async (issueNumber) => {
       await addLabel("issue", issueNumber, "cc-update-issue");
     },

--- a/src/workers/create-issue.ts
+++ b/src/workers/create-issue.ts
@@ -1,7 +1,7 @@
 import { createIssuePollingWorker } from "./issue-worker";
 import { addLabel } from "../gh";
 
-export const createIssueWorker = (opts: { epicFilter?: number } = {}) =>
+export const createIssueWorker = (opts: { epicFilters?: number[]; labelFilters?: string[] } = {}) =>
   createIssuePollingWorker({
     name: "create-issue",
     command: "/base-tools:create-issue-from-issue-number",
@@ -13,7 +13,8 @@ export const createIssueWorker = (opts: { epicFilter?: number } = {}) =>
       "cc-answer-issue-questions",
       "cc-exec-issue",
     ],
-    epicFilter: opts.epicFilter,
+    epicFilters: opts.epicFilters,
+    labelFilters: opts.labelFilters,
     onCompleted: async (issueNumber) => {
       await addLabel("issue", issueNumber, "cc-issue-created");
     },

--- a/src/workers/epic-issue.ts
+++ b/src/workers/epic-issue.ts
@@ -1,12 +1,13 @@
 import { addLabel, getIssueSubIssuesSummary } from "../gh";
 import { createIssuePollingWorker } from "./issue-worker";
 
-export const epicIssueWorker = () =>
+export const epicIssueWorker = (opts: { labelFilters?: string[] } = {}) =>
   createIssuePollingWorker({
     name: "epic-issue",
     command: "/base-tools:create-epic-pr",
     triggerLabels: ["cc-epic-issue"],
     excludeLabels: ["cc-pr-created"],
+    labelFilters: opts.labelFilters,
     preflight: async (epic) => {
       const summary = await getIssueSubIssuesSummary(epic.number);
       if (summary.total === 0) return "skip";

--- a/src/workers/exec-issue.ts
+++ b/src/workers/exec-issue.ts
@@ -1,12 +1,13 @@
 import { addLabel } from "../gh";
 import { createIssuePollingWorker } from "./issue-worker";
 
-export const execIssueWorker = (opts: { epicFilter?: number } = {}) =>
+export const execIssueWorker = (opts: { epicFilters?: number[]; labelFilters?: string[] } = {}) =>
   createIssuePollingWorker({
     name: "exec-issue",
     command: "/base-tools:exec-issue",
     triggerLabels: ["cc-exec-issue"],
-    epicFilter: opts.epicFilter,
+    epicFilters: opts.epicFilters,
+    labelFilters: opts.labelFilters,
     onCompleted: async (issueNumber) => {
       await addLabel("issue", issueNumber, "cc-pr-created");
     },

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -16,7 +16,8 @@ interface IssueWorkerConfig {
   command: string;
   triggerLabels: string[];
   excludeLabels?: string[];
-  epicFilter?: number;
+  epicFilters?: number[];
+  labelFilters?: string[];
   preflight?: (issue: Issue) => Promise<PreflightResult>;
   onCompleted?: (issueNumber: number) => Promise<void>;
 }
@@ -40,10 +41,14 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
       try {
         const excludeLabels = ["cc-in-progress", "cc-need-human-check", ...(config.excludeLabels ?? [])];
         const epicFilter =
-          config.epicFilter !== undefined
-            ? { owner, repo: name, number: config.epicFilter }
+          config.epicFilters && config.epicFilters.length > 0
+            ? { owner, repo: name, numbers: config.epicFilters }
             : undefined;
-        const candidates = await listIssuesByLabel(user, config.triggerLabels, excludeLabels, epicFilter);
+        const labels =
+          config.labelFilters && config.labelFilters.length > 0
+            ? [...config.triggerLabels, ...config.labelFilters]
+            : config.triggerLabels;
+        const candidates = await listIssuesByLabel(user, labels, excludeLabels, epicFilter);
 
         for (const issue of candidates) {
           if (isRunning(issue.number)) continue;

--- a/src/workers/triage-created-issue.ts
+++ b/src/workers/triage-created-issue.ts
@@ -1,13 +1,14 @@
 import { createIssuePollingWorker } from "./issue-worker";
 import { addLabel } from "../gh";
 
-export const triageCreatedIssueWorker = (opts: { epicFilter?: number } = {}) =>
+export const triageCreatedIssueWorker = (opts: { epicFilters?: number[]; labelFilters?: string[] } = {}) =>
   createIssuePollingWorker({
     name: "triage-created-issue",
     command: "/base-tools:triage-created-issue",
     triggerLabels: ["cc-issue-created", "cc-triage-scope"],
     excludeLabels: ["cc-pr-created", "cc-update-issue", "cc-answer-issue-questions", "cc-exec-issue"],
-    epicFilter: opts.epicFilter,
+    epicFilters: opts.epicFilters,
+    labelFilters: opts.labelFilters,
     onCompleted: async (issueNumber) => {
       await addLabel("issue", issueNumber, "cc-issue-created");
     },

--- a/src/workers/update-issue.ts
+++ b/src/workers/update-issue.ts
@@ -1,9 +1,10 @@
 import { createIssuePollingWorker } from "./issue-worker";
 
-export const updateIssueWorker = (opts: { epicFilter?: number } = {}) =>
+export const updateIssueWorker = (opts: { epicFilters?: number[]; labelFilters?: string[] } = {}) =>
   createIssuePollingWorker({
     name: "update-issue",
     command: "/base-tools:update-issue",
     triggerLabels: ["cc-update-issue"],
-    epicFilter: opts.epicFilter,
+    epicFilters: opts.epicFilters,
+    labelFilters: opts.labelFilters,
   })();


### PR DESCRIPTION
## Summary

- Issue 系ワーカー（`exec-issue` / `create-issue` / `update-issue` / `answer-issue-questions` / `triage-created-issue` / `epic-issue`）に `--label <label-name>` オプションを追加。トリガーラベルに加えて指定ラベルが付いている Issue だけを処理対象にする。
- `--epic` / `--label` の両方を複数指定可能に変更。`--label` は AND（`gh issue list --label` の仕様）、`--epic` は OR（gh search の同名 qualifier 並列指定が OR 解釈される動作）。
- `all` / `yolo` および各 Issue ワーカー単体実行のどちらでも利用可能。PR ワーカー（`fix-review-point` / `triage-pr` / `check-dependabot`）は影響範囲外。
- 完了処理ではトリガーラベルのみ除去し、`--label` で指定したスコープラベルは保持する（ユーザー指定のフィルタを勝手に剥がさない）。

## Test plan

- [x] `npm run build` (tsc --noEmit + esbuild) が成功
- [x] `node dist/index.js` の usage に `--epic`/`--label` の repeatable 説明と複数指定の例が表示される
- [x] `--label` / `--epic` の値なし・非数値・0 が適切にエラーで弾かれる
- [ ] 実環境で `claude-task-worker all --epic 100 --epic 200` が両エピックの sub-issue を OR で取得する
- [ ] 実環境で `claude-task-worker all --label priority-high --label needs-design` が両ラベル付き Issue だけを AND で取得する
- [ ] タスク完了後、トリガーラベルは除去され、`--label` 指定ラベルは Issue に残ったまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)