### PR TITLE
feat: Add resolve-conflict PR worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ claude-task-worker がGitHubラベルを検知してタスクを起動し、base
 │  Issue (cc-epic-issue, all sub-issues closed)     ──┤  │
 │  PR    (cc-fix-onetime)                           ──┤  │
 │  PR    (cc-triage-scope)                          ──┤  │
+│  PR    (cc-resolve-conflict)                      ──┤  │
 │  PR    (dependencies, Dependabot)                 ──┤  │
 └─────────────────────────────────────────────────────┼──┘
                                                       │
@@ -46,6 +47,7 @@ claude-task-worker がGitHubラベルを検知してタスクを起動し、base
 | `fix-review-point` | `cc-fix-onetime` | `/base-tools:fix-review-point` | 1分 |
 | `triage-created-issue` | `cc-issue-created` + `cc-triage-scope` (Issue) | `/base-tools:triage-created-issue` | 1分 |
 | `triage-pr` | `cc-triage-scope` (PR) | `/base-tools:triage-pr` | 1分 |
+| `resolve-conflict` | `cc-resolve-conflict` (PR) | `/base-tools:resolve-conflict` | 1分 |
 | `check-dependabot` | `dependencies` (PR) | `/base-tools:check-dependabot` | 1時間 |
 | `epic-issue` | `cc-epic-issue` (Issue, sub-issues が全て Close) | `/base-tools:create-epic-pr` | 5分 |
 
@@ -91,6 +93,7 @@ claude-task-worker init --force   # 既存ファイルを強制上書き
 | `cc-exec-issue` | Issue実行トリガー |
 | `cc-fix-onetime` | PR修正トリガー（1回） |
 | `cc-triage-scope` | トリアージ対象マーク（Issue/PR） |
+| `cc-resolve-conflict` | PRコンフリクト解消トリガー |
 | `cc-in-progress` | 処理中ステータス |
 | `cc-need-human-check` | 人間の確認が必要なマーク（付与中はIssueワーカーの処理対象から除外される） |
 | `cc-issue-created` | `/base-tools:create-issue` 由来のIssueマーク（triage-created-issue のトリガー条件） |
@@ -180,6 +183,13 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 `cc-triage-scope` ラベルが付いたPRを定期取得し、Claude Codeでトリアージを実行する。（1分間隔）
 
 - `cc-fix-onetime` が付いているPRは除外
+- `cc-resolve-conflict` が付いているPRは除外
+
+### resolve-conflict
+
+`cc-resolve-conflict` ラベルが付いたPRを定期取得し、`/base-tools:resolve-conflict` を実行してコンフリクト解消を行う。（1分間隔）
+
+- 完了後、`cc-resolve-conflict` ラベルを除去
 
 ### check-dependabot
 
@@ -198,7 +208,7 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 
 ### all
 
-通常ワーカー6つ（exec-issue, fix-review-point, create-issue, update-issue, answer-issue-questions, epic-issue）を同時にポーリングする。`--epic` / `--label` オプションでIssue系ワーカーの処理対象を絞り込み可能（どちらも複数指定可）。
+通常ワーカー7つ（exec-issue, fix-review-point, create-issue, update-issue, answer-issue-questions, resolve-conflict, epic-issue）を同時にポーリングする。`--epic` / `--label` オプションでIssue系ワーカーの処理対象を絞り込み可能（どちらも複数指定可）。
 
 ### yolo
 
@@ -230,6 +240,7 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 | `fix-review-point` | `sonnet` | `high` | 60 | 0 | 1 |
 | `triage-created-issue` | `sonnet` | `high` | 60 | 0 | 1 |
 | `triage-pr` | `sonnet` | `high` | 60 | 0 | 1 |
+| `resolve-conflict` | `sonnet` | `high` | 60 | 0 | 1 |
 | `check-dependabot` | `sonnet` | `high` | 3600 | 0 | 1 |
 | `epic-issue` | `sonnet` | `high` | 300 | 0 | 1 |
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,6 +12,7 @@ const LABELS: { name: string; color: string }[] = [
   { name: "cc-issue-created", color: "f9a825" },
   { name: "cc-pr-created", color: "006b75" },
   { name: "cc-triage-scope", color: "c5def5" },
+  { name: "cc-resolve-conflict", color: "fbca04" },
   { name: "cc-epic-issue", color: "8b5cf6" },
 ];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export type WorkerName =
   | "fix-review-point"
   | "check-dependabot"
   | "triage-pr"
+  | "resolve-conflict"
   | "epic-issue";
 
 export interface WorkerRuntimeConfig {
@@ -41,6 +42,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "fix-review-point": { model: "sonnet", effort: "high", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
   "triage-created-issue": { model: "sonnet", effort: "high", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
   "triage-pr": { model: "sonnet", effort: "high", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "resolve-conflict": { model: "sonnet", effort: "high", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
   "check-dependabot": { model: "sonnet", effort: "high", pollingIntervalSeconds: 3600, cooldownSeconds: 0, maxConcurrentTasks: 1 },
   "epic-issue": { model: "sonnet", effort: "high", pollingIntervalSeconds: 300, cooldownSeconds: 0, maxConcurrentTasks: 1 },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { updateIssueWorker } from "./workers/update-issue";
 import { answerIssueQuestionsWorker } from "./workers/answer-issue-questions";
 import { triageCreatedIssueWorker } from "./workers/triage-created-issue";
 import { triagePrWorker } from "./workers/triage-pr";
+import { resolveConflictWorker } from "./workers/resolve-conflict";
 import { checkDependabotWorker } from "./workers/check-dependabot";
 import { epicIssueWorker } from "./workers/epic-issue";
 import { shutdown, waitForAllProcesses, setShuttingDown, isShuttingDown } from "./process-manager";
@@ -21,6 +22,7 @@ const WORKERS: Record<string, (opts?: { epicFilters?: number[]; labelFilters?: s
   "answer-issue-questions": answerIssueQuestionsWorker,
   "triage-created-issue": triageCreatedIssueWorker,
   "triage-pr": triagePrWorker,
+  "resolve-conflict": resolveConflictWorker,
   "check-dependabot": checkDependabotWorker,
   "epic-issue": epicIssueWorker,
 };
@@ -40,6 +42,7 @@ Workers:
   answer-issue-questions  Poll issues and run /answer-issue-questions
   triage-created-issue  Poll cc-issue-created + cc-triage-scope issues and run /triage-created-issue
   triage-pr         Poll and triage PRs every 5 minutes
+  resolve-conflict  Poll cc-resolve-conflict PRs and run /resolve-conflict
   check-dependabot  Poll dependabot PRs every 1 hour
   epic-issue        Poll cc-epic-issue issues and create epic PR when all sub-issues are closed
   all               Poll all workers except triage-created-issue, triage-pr, check-dependabot
@@ -164,6 +167,7 @@ if (workerType === "init") {
     createIssueWorker({ epicFilters, labelFilters }),
     updateIssueWorker({ epicFilters, labelFilters }),
     answerIssueQuestionsWorker({ epicFilters, labelFilters }),
+    resolveConflictWorker(),
     epicIssueWorker({ labelFilters }),
   ]);
 } else if (workerType === "yolo") {
@@ -179,6 +183,7 @@ if (workerType === "init") {
       triageCreatedIssueWorker({ epicFilters, labelFilters }),
       checkDependabotWorker(),
       triagePrWorker(),
+      resolveConflictWorker(),
       epicIssueWorker({ labelFilters }),
     ]);
   })();

--- a/src/workers/resolve-conflict.ts
+++ b/src/workers/resolve-conflict.ts
@@ -1,0 +1,7 @@
+import { createPrPollingWorker } from "./pr-worker";
+
+export const resolveConflictWorker = createPrPollingWorker({
+  name: "resolve-conflict",
+  command: "/base-tools:resolve-conflict",
+  triggerLabel: "cc-resolve-conflict",
+});

--- a/src/workers/triage-pr.ts
+++ b/src/workers/triage-pr.ts
@@ -4,5 +4,5 @@ export const triagePrWorker = createPrPollingWorker({
   name: "triage-pr",
   command: "/base-tools:triage-pr",
   triggerLabel: "cc-triage-scope",
-  excludeLabels: ["cc-fix-onetime"],
+  excludeLabels: ["cc-fix-onetime", "cc-resolve-conflict"],
 });


### PR DESCRIPTION
## Summary
- `cc-resolve-conflict` ラベル付きPRをポーリングして `/base-tools:resolve-conflict` を起動する新ワーカー `resolve-conflict` を追加（PR系共通の `createPrPollingWorker` に乗せた1行設定）
- `triage-pr` の `excludeLabels` に `cc-resolve-conflict` を追加し、コンフリクト解消中のPRがトリアージ対象にならないよう除外
- `init` で作成するラベル一覧・`WORKER_DEFAULTS`・`all` / `yolo` の起動セット・README に新ワーカーを反映

## Test plan
- [ ] `npm run build` が通る
- [ ] `claude-task-worker init` で `cc-resolve-conflict` ラベルがリポジトリに作成される
- [ ] `claude-task-worker resolve-conflict` 起動時にポーリングログが出力される
- [ ] `cc-resolve-conflict` 付きPRで `/base-tools:resolve-conflict` が起動し、完了後に `cc-resolve-conflict` / `cc-in-progress` ラベルが除去される
- [ ] `triage-pr` と同時起動した状態で、`cc-resolve-conflict` 付きPRが `triage-pr` 側で拾われない
- [ ] `claude-task-worker all` / `yolo` の起動ログに `resolve-conflict` ワーカーが含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)