### PR TITLE
feat: Make worker skills configurable via claude-task-worker.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,29 +225,30 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|
 | `fixReviewPointCallbackCommentMessage` | string | - | fix-review-point 完了時にPRへ投稿するコメント（未設定の場合は投稿しない） |
-| `workers` | object | `{}` | ワーカーごとに Claude CLI の `--model` / `--effort`、ポーリング間隔、クールダウン時間、最大同時実行数を上書きする設定（詳細は下記） |
+| `workers` | object | `{}` | ワーカーごとに Claude CLI に渡すスキル、`--model` / `--effort`、ポーリング間隔、クールダウン時間、最大同時実行数を上書きする設定（詳細は下記） |
 
 ### ワーカーごとの設定
 
-`workers` キーにワーカー名ごとの設定オブジェクトを指定することで、Claude CLI に渡す `--model` / `--effort`、ポーリング間隔、タスク完了後のクールダウン時間、最大同時実行数を個別に上書きできる。未指定のワーカー・フィールドは下記のワーカー別デフォルト値が使用される。
+`workers` キーにワーカー名ごとの設定オブジェクトを指定することで、Claude CLI の `-p` に渡すスキル（スラッシュコマンド）、`--model` / `--effort`、ポーリング間隔、タスク完了後のクールダウン時間、最大同時実行数を個別に上書きできる。未指定のワーカー・フィールドは下記のワーカー別デフォルト値が使用される。
 
-| ワーカー名 | デフォルト `model` | デフォルト `effort` | デフォルト `pollingIntervalSeconds` | デフォルト `cooldownSeconds` | デフォルト `maxConcurrentTasks` |
-|---|---|---|---|---|---|
-| `answer-issue-questions` | `opus` | `xhigh` | 60 | 0 | 1 |
-| `create-issue` | `opus` | `xhigh` | 60 | 0 | 1 |
-| `update-issue` | `sonnet` | `xhigh` | 60 | 0 | 1 |
-| `exec-issue` | `sonnet` | `xhigh` | 60 | 0 | 1 |
-| `fix-review-point` | `sonnet` | `xhigh` | 60 | 0 | 1 |
-| `triage-created-issue` | `sonnet` | `xhigh` | 60 | 0 | 1 |
-| `triage-pr` | `sonnet` | `xhigh` | 60 | 0 | 1 |
-| `resolve-conflict` | `sonnet` | `xhigh` | 60 | 0 | 1 |
-| `check-dependabot` | `sonnet` | `xhigh` | 3600 | 0 | 1 |
-| `epic-issue` | `sonnet` | `xhigh` | 300 | 0 | 1 |
+| ワーカー名 | デフォルト `skill` | デフォルト `model` | デフォルト `effort` | デフォルト `pollingIntervalSeconds` | デフォルト `cooldownSeconds` | デフォルト `maxConcurrentTasks` |
+|---|---|---|---|---|---|---|
+| `answer-issue-questions` | `/base-tools:answer-issue-questions` | `opus` | `xhigh` | 60 | 0 | 1 |
+| `create-issue` | `/base-tools:create-issue-from-issue-number` | `opus` | `xhigh` | 60 | 0 | 1 |
+| `update-issue` | `/base-tools:update-issue` | `sonnet` | `xhigh` | 60 | 0 | 1 |
+| `exec-issue` | `/base-tools:exec-issue` | `sonnet` | `xhigh` | 60 | 0 | 1 |
+| `fix-review-point` | `/base-tools:fix-review-point` | `sonnet` | `xhigh` | 60 | 0 | 1 |
+| `triage-created-issue` | `/base-tools:triage-created-issue` | `sonnet` | `xhigh` | 60 | 0 | 1 |
+| `triage-pr` | `/base-tools:triage-pr` | `sonnet` | `xhigh` | 60 | 0 | 1 |
+| `resolve-conflict` | `/base-tools:resolve-pr-conflict` | `sonnet` | `xhigh` | 60 | 0 | 1 |
+| `check-dependabot` | `/base-tools:check-dependabot` | `sonnet` | `xhigh` | 3600 | 0 | 1 |
+| `epic-issue` | `/base-tools:create-epic-pr` | `sonnet` | `xhigh` | 300 | 0 | 1 |
 
 各フィールドの値:
 
 | フィールド | 型 | 説明 |
 |---|---|---|
+| `skill` | string | Claude CLI の `-p` に渡すスラッシュコマンド（例: `/base-tools:exec-issue`, `/my-plugin:my-skill`）。ワーカーは `"<skill> <issue-or-pr-number>"` の形で Claude を起動する |
 | `model` | string | Claude CLI の `--model` に渡す値（例: `sonnet`, `opus`, `haiku`） |
 | `effort` | string | Claude CLI の `--effort` に渡す値（例: `high`, `medium`, `low`） |
 | `pollingIntervalSeconds` | number | GitHub をポーリングする間隔（秒）。正の数を指定する |
@@ -259,8 +260,8 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 ```json
 {
   "workers": {
-    "exec-issue":        { "model": "opus",   "effort": "high", "pollingIntervalSeconds": 60, "cooldownSeconds": 600, "maxConcurrentTasks": 3 },
-    "fix-review-point":  { "model": "sonnet", "effort": "high", "maxConcurrentTasks": 2 },
+    "exec-issue":        { "skill": "/my-plugin:exec-issue", "model": "opus", "effort": "high", "pollingIntervalSeconds": 60, "cooldownSeconds": 600, "maxConcurrentTasks": 3 },
+    "fix-review-point":  { "skill": "/base-tools:fix-review-point", "model": "sonnet", "effort": "high", "maxConcurrentTasks": 2 },
     "triage-pr":         { "effort": "medium", "pollingIntervalSeconds": 120 },
     "check-dependabot":  { "model": "haiku", "pollingIntervalSeconds": 7200 }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export type WorkerName =
   | "epic-issue";
 
 export interface WorkerRuntimeConfig {
+  skill: string;
   model: string;
   effort: string;
   pollingIntervalSeconds: number;
@@ -27,6 +28,7 @@ interface Config {
 }
 
 export const DEFAULT_WORKER_CONFIG: WorkerRuntimeConfig = {
+  skill: "",
   model: "sonnet",
   effort: "xhigh",
   pollingIntervalSeconds: 60,
@@ -35,16 +37,16 @@ export const DEFAULT_WORKER_CONFIG: WorkerRuntimeConfig = {
 };
 
 export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
-  "answer-issue-questions": { model: "opus", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
-  "create-issue": { model: "opus", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
-  "update-issue": { model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
-  "exec-issue": { model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
-  "fix-review-point": { model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
-  "triage-created-issue": { model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
-  "triage-pr": { model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
-  "resolve-conflict": { model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
-  "check-dependabot": { model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 3600, cooldownSeconds: 0, maxConcurrentTasks: 1 },
-  "epic-issue": { model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 300, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "answer-issue-questions": { skill: "/base-tools:answer-issue-questions", model: "opus", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "create-issue": { skill: "/base-tools:create-issue-from-issue-number", model: "opus", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "update-issue": { skill: "/base-tools:update-issue", model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "exec-issue": { skill: "/base-tools:exec-issue", model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "fix-review-point": { skill: "/base-tools:fix-review-point", model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "triage-created-issue": { skill: "/base-tools:triage-created-issue", model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "triage-pr": { skill: "/base-tools:triage-pr", model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "resolve-conflict": { skill: "/base-tools:resolve-pr-conflict", model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 60, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "check-dependabot": { skill: "/base-tools:check-dependabot", model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 3600, cooldownSeconds: 0, maxConcurrentTasks: 1 },
+  "epic-issue": { skill: "/base-tools:create-epic-pr", model: "sonnet", effort: "xhigh", pollingIntervalSeconds: 300, cooldownSeconds: 0, maxConcurrentTasks: 1 },
 };
 
 export const DEFAULT_CONFIG: Config = {
@@ -66,6 +68,13 @@ function parseWorkerEntry(name: string, val: unknown): WorkerRuntimeConfig | nul
   }
   const entry = val as Record<string, unknown>;
   const result: WorkerRuntimeConfig = { ...base };
+  if ("skill" in entry) {
+    if (typeof entry.skill === "string" && entry.skill.length > 0) {
+      result.skill = entry.skill;
+    } else {
+      console.warn(`[config] invalid workers.${name}.skill: ${String(entry.skill)}, using default ${base.skill}`);
+    }
+  }
   if ("model" in entry) {
     if (typeof entry.model === "string" && entry.model.length > 0) {
       result.model = entry.model;

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -72,13 +72,14 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
           try {
             const issueUrl = `https://github.com/${owner}/${name}/issues/${issue.number}`;
             syncDefaultBranch(defaultBranch);
-            const { model, effort } = getWorkerConfig(config.name);
+            const { model, effort, skill } = getWorkerConfig(config.name);
+            const command = skill || config.command;
 
             const parentNumber = issue.parent?.number;
             let cwd: string | undefined;
             const claudeArgs: string[] = [
               "-p",
-              `"${config.command} ${issue.number}"`,
+              `"${command} ${issue.number}"`,
               "--dangerously-skip-permissions",
               "--model",
               model,

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -57,12 +57,13 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
             await removeWorktreeByBranch(pr.headRefName);
             const worktreeId = generateWorktreeName();
             syncDefaultBranch(defaultBranch);
-            const { model, effort } = getWorkerConfig(config.name);
+            const { model, effort, skill } = getWorkerConfig(config.name);
+            const command = skill || config.command;
             run(
               "claude",
               [
                 "-p",
-                `"${config.command} ${pr.number}"`,
+                `"${command} ${pr.number}"`,
                 "--dangerously-skip-permissions",
                 "--model",
                 model,


### PR DESCRIPTION
## Summary
- ワーカーごとに Claude CLI へ渡すスキル（スラッシュコマンド）を `claude-task-worker.json` の `workers.<name>.skill` で上書き可能にした
- `WORKER_DEFAULTS` に各ワーカーの現行スキルを明示し、`init` 時に書き出される初期 config に含まれるようにした
- `issue-worker` / `pr-worker` は config の `skill` を優先し、未指定なら従来のハードコード `command` にフォールバック

## Test plan
- [ ] `npm run build` が通ることを確認
- [ ] `claude-task-worker init --force` で生成される `claude-task-worker.json` に各ワーカーの `skill` フィールドが含まれる
- [ ] `workers.exec-issue.skill` を `/my-plugin:xxx` に書き換えて `exec-issue` を実行し、その skill が Claude CLI に渡されることを確認
- [ ] `skill` フィールドを削除した場合、従来通り `/base-tools:xxx` が使われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)