### PR TITLE
fix: Harden ensureEpicBranch to prevent worktree 'invalid reference' errors

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -18,18 +18,61 @@ export function syncDefaultBranch(branch: string): void {
   }
 }
 
+/**
+ * epic ブランチの remote-tracking ref (refs/remotes/origin/<epicBranch>) を
+ * ローカルに用意する。remote に epic ブランチが無ければ defaultBranch から派生させて push する。
+ * 完了時点で origin/<epicBranch> が必ず解決できることを保証する（できなければ throw）。
+ */
 export async function ensureEpicBranch(epicBranch: string, defaultBranch: string): Promise<void> {
   try {
-    await execFileAsync("git", ["fetch", "origin", `${epicBranch}:refs/remotes/origin/${epicBranch}`]);
+    await fetchRemoteTracking(epicBranch);
+    await assertRemoteTrackingExists(epicBranch);
     return;
-  } catch {
-    // remote に epicBranch が無い → defaultBranch から派生作成して push
+  } catch (error) {
+    // remote に epic ブランチが存在しない場合のみ派生作成に進む。
+    // それ以外（ネットワーク・認証・ロック競合など）は握りつぶさず throw する。
+    if (!isMissingRemoteRefError(error)) {
+      throw error;
+    }
   }
-  await execFileAsync("git", ["fetch", "origin", defaultBranch]);
+
+  // defaultBranch を「一意な名前の」remote-tracking ref に明示 dst で取り込み、
+  // それを push source にして epic ブランチを作成する。
+  // FETCH_HEAD のような共有スロットを避けることで、並行実行時に別 fetch が
+  // source を上書きして誤コミットを push してしまう競合を防ぐ。
+  await fetchRemoteTracking(defaultBranch);
   await execFileAsync("git", [
     "push",
     "origin",
     `refs/remotes/origin/${defaultBranch}:refs/heads/${epicBranch}`,
   ]);
-  await execFileAsync("git", ["fetch", "origin", `${epicBranch}:refs/remotes/origin/${epicBranch}`]);
+  await fetchRemoteTracking(epicBranch);
+
+  // ここまで来ても remote-tracking ref が無ければ worktree add に進ませない。
+  await assertRemoteTrackingExists(epicBranch);
+}
+
+/** origin/<branch> を refs/remotes/origin/<branch> に force で取り込む（標準の remote-tracking と同じ挙動）。 */
+async function fetchRemoteTracking(branch: string): Promise<void> {
+  await execFileAsync("git", [
+    "fetch",
+    "origin",
+    `+${branch}:refs/remotes/origin/${branch}`,
+  ]);
+}
+
+/** fetch エラーが「remote に該当 ref が無い」ことによるものかを判定する。 */
+function isMissingRemoteRefError(error: unknown): boolean {
+  const stderr = String((error as { stderr?: unknown } | null | undefined)?.stderr ?? "");
+  return /couldn't find remote ref/i.test(stderr);
+}
+
+/** refs/remotes/origin/<epicBranch> がローカルに存在することを保証する（無ければ throw）。 */
+async function assertRemoteTrackingExists(epicBranch: string): Promise<void> {
+  await execFileAsync("git", [
+    "rev-parse",
+    "--verify",
+    "--quiet",
+    `refs/remotes/origin/${epicBranch}`,
+  ]);
 }


### PR DESCRIPTION
## 概要

epic ブランチの派生作成が壊れ、`git worktree add ... origin/cc-epic-<n>` が `invalid reference` で失敗する問題を修正します。

## 変更内容

- **push source の安定化**: FETCH_HEAD ではなく一意名の remote-tracking ref を使用。step3 を明示 dst refspec (`+<defaultBranch>:refs/remotes/origin/<defaultBranch>`) で確実に最新化し、並行実行時に別 fetch が source を上書きして誤コミットを push する競合を防止（FETCH_HEAD は共有スロットで決定論的に競合する）。
- **エラーの握りつぶし廃止**: 空の catch を廃止し、`'couldn't find remote ref'` のときだけ派生作成に進む。ネットワーク・認証・ロック競合などは throw する。
- **存在保証**: 完了前に `git rev-parse --verify` で `origin/<epicBranch>` の存在を保証し、壊れた状態のまま worktree add に進ませない。

## テスト

- `src/git.ts` のみの変更（+48 / -5）

🤖 Generated with [Claude Code](https://claude.com/claude-code)