### PR TITLE
fix: Remove redundant quoting from claude -p prompt argument

### DIFF
--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -79,7 +79,7 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
             let cwd: string | undefined;
             const claudeArgs: string[] = [
               "-p",
-              `"${command} ${issue.number}"`,
+              `${command} ${issue.number}`,
               "--dangerously-skip-permissions",
               "--model",
               model,

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -63,7 +63,7 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
               "claude",
               [
                 "-p",
-                `"${command} ${pr.number}"`,
+                `${command} ${pr.number}`,
                 "--dangerously-skip-permissions",
                 "--model",
                 model,


### PR DESCRIPTION
Closes #35

## 概要

`pr-worker` / `issue-worker` が `claude -p` に渡すスキルコマンドをリテラルのダブルクォートで囲んでいたため、shell を経由しない `spawn` ではクォートが値の一部として残り、claude 側でスラッシュコマンド（スキル）として認識されませんでした。

## 原因

`spawn(command, args, { detached: true })` は shell を経由しないため、`` `"${config.command} ${pr.number}"` `` のようにリテラルの `"` で囲むと、その `"` が剥がされずそのまま claude に渡り、プロンプト先頭が `/` にならず、スキルとして起動されず素のプロンプトとして扱われていました（`triage-pr` などが終端アクションに到達できず無限に再トリアージされる原因）。

## 修正内容

- `src/workers/pr-worker.ts` の `-p` 引数からリテラルのダブルクォート囲みを除去
- `src/workers/issue-worker.ts` の `-p` 引数からリテラルのダブルクォート囲みを除去

## 確認事項

- `npm run build`（tsc --noEmit + esbuild）
- `npm run lint`（eslint）