### PR TITLE
fix: Create named branch for epic sub-issue worktrees instead of detached HEAD

### DIFF
--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -31,10 +31,14 @@ export function getWorktreePath(worktreeId: string): string {
 
 export async function createWorktreeFromBranch(worktreeId: string, baseBranch: string): Promise<void> {
   const worktreePath = `${WORKTREES_DIR}/${worktreeId}`;
+  // detached HEAD だと後段の commit-push スキルの `git push origin HEAD` が
+  // refspec を解決できず失敗するため、worktreeId と同名のブランチを切って checkout する。
+  // -B を使うことで孤児ブランチが残っていても origin/${baseBranch} から強制再作成して安全に回復できる。
   await execFileAsync("git", [
     "worktree",
     "add",
-    "--detach",
+    "-B",
+    worktreeId,
     worktreePath,
     `origin/${baseBranch}`,
   ]);


### PR DESCRIPTION
## 概要

Epicフロー検証で見つかった問題の修正です: parent（Epic）を持つサブIssueの実行時、ワーカーが `git worktree add --detach` でworktreeを作るため HEAD が detached 状態になり、後段の `commit-push` スキルの `git push origin HEAD` が refspec を解決できず exit 1 で失敗します（実測で再現確認済み）。

## 変更内容

- `createWorktreeFromBranch` で `--detach` の代わりに `-B <worktreeId>` を指定し、worktree IDと同名のブランチを作成してcheckoutするように変更

これにより:
- `commit-push` の `git push origin HEAD` がworktree ID名のブランチとしてpushされる（検証済み: `* [new branch] HEAD -> happy-falcon-0042`）
- PRのheadブランチ名がworktree名と一致し、`removeWorktreeByBranch(pr.headRefName)` との整合も保たれる
- `-B` により、過去の異常終了などでworktreeだけ削除されローカルブランチ（worktree ID名）が孤児として残っていても、`origin/${baseBranch}` を起点にブランチを強制再作成して安全にworktreeを作成できる（`-b` では `fatal: a branch named '<worktreeId>' already exists` で失敗していた）
- 同名ブランチが別worktreeで現在チェックアウト中の場合のみ `worktree add` は失敗するが、既存の setup error パス（ラベルクリーンアップ→次tickで別名リトライ）で安全に回復する

## 検証

- `npm run build` / `npm run lint`（`eslint .`）パス
- スクラッチgitリポジトリで `git worktree add -B <id> <path> origin/cc-epic-2` → commit → `git push origin HEAD` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worktrees now start on a named branch instead of a detached state, making it easier to push changes back to the remote without refspec issues.
  * New worktrees are now based directly on the selected branch, improving the checkout flow for branch-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 修正履歴

### 2026-07-04: レビュー指摘対応（1件）
- `git worktree add` のブランチ作成オプションを `-b` → `-B` に変更し、過去の異常終了でworktreeだけ削除され孤児化したローカルブランチ（worktree ID名）が残っていても `origin/${baseBranch}` から強制再作成して安全に回復できるようにした（@gemini-code-assist の high priority 指摘。対応コミット: be4ae9a）
