### PR TITLE
fix: Apply --epic filter to epic-issue worker by epic issue number

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ claude-task-worker <command> [--epic <issue-number>]... [--label <label-name>]..
 
 複数指定可能で、複数指定した場合はいずれかのエピックを親に持つサブIssueが対象になる（OR）。
 
+> ℹ️ `epic-issue` ワーカーはエピックIssue自体を処理対象とするため、`--epic` で指定した番号は「サブIssueの親」ではなく「エピックIssue自身の番号」として照合される。`--epic 100` を指定した場合、Epic PR が作成されるのは #100 のみになる。
+
 ```bash
 claude-task-worker all --epic 100
 claude-task-worker all --epic 100 --epic 200    # #100 または #200 の sub-issue

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -99,6 +99,43 @@ export async function listIssuesByLabel(
   return JSON.parse(output);
 }
 
+export async function listIssuesByNumbers(
+  assignee: string,
+  labels: string[],
+  excludeLabels: string[],
+  numbers: number[],
+): Promise<Issue[]> {
+  const results: Issue[] = [];
+  for (const number of numbers) {
+    try {
+      const output = await execGh([
+        "issue",
+        "view",
+        String(number),
+        "--json",
+        "number,title,labels,parent,assignees,state",
+      ]);
+      const parsed = JSON.parse(output);
+      // -is:blocked は listIssuesByLabel の search 由来の絞り込みだが、
+      // エピックIssue自体はサブIssueにブロックされる対象ではないため再現しない。
+      if (parsed.state !== "OPEN") continue;
+      if (!parsed.assignees.some((a: { login: string }) => a.login === assignee)) continue;
+      const labelNames = new Set(parsed.labels.map((l: { name: string }) => l.name));
+      if (!labels.every((label) => labelNames.has(label))) continue;
+      if (excludeLabels.some((label) => labelNames.has(label))) continue;
+      results.push({
+        number: parsed.number,
+        title: parsed.title,
+        labels: parsed.labels,
+        parent: parsed.parent,
+      });
+    } catch (err) {
+      console.error(`[gh] listIssuesByNumbers failed for #${number}: ${err}`);
+    }
+  }
+  return results;
+}
+
 export async function getIssueSubIssuesSummary(issueNumber: number): Promise<SubIssuesSummary> {
   const output = await execGh(["issue", "view", String(issueNumber), "--json", "subIssuesSummary"]);
   const parsed = JSON.parse(output);

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,7 @@ if (workerType === "init") {
     updateIssueWorker({ epicFilters, labelFilters }),
     answerIssueQuestionsWorker({ epicFilters, labelFilters }),
     resolveConflictWorker(),
-    epicIssueWorker({ labelFilters }),
+    epicIssueWorker({ epicFilters, labelFilters }),
   ]);
 } else if (workerType === "yolo") {
   const epicFilters = parseEpicFilters();
@@ -184,7 +184,7 @@ if (workerType === "init") {
       checkDependabotWorker(),
       triagePrWorker(),
       resolveConflictWorker(),
-      epicIssueWorker({ labelFilters }),
+      epicIssueWorker({ epicFilters, labelFilters }),
     ]);
   })();
 } else {

--- a/src/workers/epic-issue.ts
+++ b/src/workers/epic-issue.ts
@@ -1,12 +1,13 @@
 import { addLabel, getIssueSubIssuesSummary } from "../gh";
 import { createIssuePollingWorker } from "./issue-worker";
 
-export const epicIssueWorker = (opts: { labelFilters?: string[] } = {}) =>
+export const epicIssueWorker = (opts: { epicFilters?: number[]; labelFilters?: string[] } = {}) =>
   createIssuePollingWorker({
     name: "epic-issue",
     command: "/base-tools:create-epic-pr",
     triggerLabels: ["cc-epic-issue"],
     excludeLabels: ["cc-pr-created"],
+    ownNumberFilters: opts.epicFilters,
     labelFilters: opts.labelFilters,
     preflight: async (epic) => {
       const summary = await getIssueSubIssuesSummary(epic.number);

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -1,5 +1,5 @@
 import { getWorkerConfig } from "../config";
-import { getCurrentUser, getRepoInfo, listIssuesByLabel, removeLabel, addLabel } from "../gh";
+import { getCurrentUser, getRepoInfo, listIssuesByLabel, listIssuesByNumbers, removeLabel, addLabel } from "../gh";
 import type { Issue } from "../gh";
 import { syncDefaultBranch, ensureEpicBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isShuttingDown, run } from "../process-manager";
@@ -17,6 +17,7 @@ interface IssueWorkerConfig {
   triggerLabels: string[];
   excludeLabels?: string[];
   epicFilters?: number[];
+  ownNumberFilters?: number[];
   labelFilters?: string[];
   preflight?: (issue: Issue) => Promise<PreflightResult>;
   onCompleted?: (issueNumber: number) => Promise<void>;
@@ -48,7 +49,10 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
           config.labelFilters && config.labelFilters.length > 0
             ? [...config.triggerLabels, ...config.labelFilters]
             : config.triggerLabels;
-        const candidates = await listIssuesByLabel(user, labels, excludeLabels, epicFilter);
+        const candidates =
+          config.ownNumberFilters && config.ownNumberFilters.length > 0
+            ? await listIssuesByNumbers(user, labels, excludeLabels, config.ownNumberFilters)
+            : await listIssuesByLabel(user, labels, excludeLabels, epicFilter);
 
         for (const issue of candidates) {
           if (isRunning(issue.number)) continue;


### PR DESCRIPTION
## 概要

READMEでは `--epic` オプションの対象ワーカーに `epic-issue` が含まれると記載されていたが、実装では `epicIssueWorker` に `epicFilters` が渡されておらず、`--epic` 指定時もすべての `cc-epic-issue` Issue が処理されていた（ドキュメントと実装の不一致）。

## 変更内容

- `epicIssueWorker` が `epicFilters` を受け取り、**エピックIssue自身の番号**で処理対象を絞り込む
- `epic-issue` ワーカーはエピックIssue自体を処理するため、他ワーカーの「サブIssueの親番号」フィルタ（`parent-issue:` 検索）とは意味が異なる（`--epic 100` なら Epic PR が作成されるのは #100 のみ）
- フィルタリングは候補取得段階（サーバー側）で行う。`src/gh.ts` に `listIssuesByNumbers` を追加し、`--epic` 指定時は該当番号を `gh issue view` で直接取得する。これにより `listIssuesByLabel` の `--limit 10` に阻まれて指定エピックが候補から取りこぼされる問題を回避する
- `all` / `yolo` の配線で `epicFilters` を渡すよう修正
- README に epic-issue ワーカーでの `--epic` の意味を明記

## 動作確認

- `npm run build` / `npm run lint` パス

## 修正履歴

### 2026-07-04: レビュー指摘対応（1件）
- `--epic` フィルタが preflight（クライアント側、`listIssuesByLabel` の `--limit 10` 取得後）でしか適用されず、オープンなエピックIssueが10件超で指定番号が先頭10件外にある場合に恒久的に取りこぼされる問題を修正。`src/gh.ts` に `listIssuesByNumbers` を新設し、`ownNumberFilters` 経由で該当番号を `gh issue view` で直接取得することでフィルタリングを取得段階（サーバー側）へ移動（対応コミット: 657901e）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `--epic` で指定した番号が、エピックIssueそのものとして正しく判定されるようになりました。
  * `all` / `yolo` 実行時にも `--epic` 指定が反映され、対象外のエピックは処理されなくなりました。

* **Documentation**
  * `--epic` の動作説明を更新し、指定番号の扱いが明確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
