### PR TITLE
fix: fetch.prune=true 環境で ensureEpicBranch の fetch が remote-tracking ref を prune 削除する問題を修正

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -41,24 +41,21 @@ export async function ensureEpicBranch(epicBranch: string, defaultBranch: string
   // FETCH_HEAD のような共有スロットを避けることで、並行実行時に別 fetch が
   // source を上書きして誤コミットを push してしまう競合を防ぐ。
   await fetchRemoteTracking(defaultBranch);
-  await execFileAsync("git", [
-    "push",
-    "origin",
-    `refs/remotes/origin/${defaultBranch}:refs/heads/${epicBranch}`,
-  ]);
+  await execFileAsync("git", ["push", "origin", `refs/remotes/origin/${defaultBranch}:refs/heads/${epicBranch}`]);
   await fetchRemoteTracking(epicBranch);
 
   // ここまで来ても remote-tracking ref が無ければ worktree add に進ませない。
   await assertRemoteTrackingExists(epicBranch);
 }
 
-/** origin/<branch> を refs/remotes/origin/<branch> に force で取り込む（標準の remote-tracking と同じ挙動）。 */
+/**
+ * origin/<branch> を refs/remotes/origin/<branch> に force で取り込む（標準の remote-tracking と同じ挙動）。
+ * fetch.prune=true 環境で短縮形 src はリモート広告 ref（完全名）とリテラル比較され
+ * 「消えたブランチ」と誤判定されて dst が prune 削除されるため、
+ * src は refs/heads/ で完全修飾し、さらに --no-prune で prune 自体を無効化する。
+ */
 async function fetchRemoteTracking(branch: string): Promise<void> {
-  await execFileAsync("git", [
-    "fetch",
-    "origin",
-    `+${branch}:refs/remotes/origin/${branch}`,
-  ]);
+  await execFileAsync("git", ["fetch", "--no-prune", "origin", `+refs/heads/${branch}:refs/remotes/origin/${branch}`]);
 }
 
 /** fetch エラーが「remote に該当 ref が無い」ことによるものかを判定する。 */
@@ -69,10 +66,5 @@ function isMissingRemoteRefError(error: unknown): boolean {
 
 /** refs/remotes/origin/<epicBranch> がローカルに存在することを保証する（無ければ throw）。 */
 async function assertRemoteTrackingExists(epicBranch: string): Promise<void> {
-  await execFileAsync("git", [
-    "rev-parse",
-    "--verify",
-    "--quiet",
-    `refs/remotes/origin/${epicBranch}`,
-  ]);
+  await execFileAsync("git", ["rev-parse", "--verify", "--quiet", `refs/remotes/origin/${epicBranch}`]);
 }


### PR DESCRIPTION
## 概要

`[create-issue] dementia_app | Error: Command failed: git rev-parse --verify --quiet refs/remotes/origin/cc-epic-4773` の根本原因を修正します。

## 原因

`fetchRemoteTracking()` は `git fetch origin +cc-epic-N:refs/remotes/origin/cc-epic-N` と **短縮形 src** の refspec を使っていた。`fetch.prune = true`（グローバル gitconfig）環境では、prune が明示 refspec の src をリモート広告 ref の**完全名**（`refs/heads/cc-epic-N`）とリテラル比較するため、リモートにブランチが実在していても「消えたブランチ」と誤判定される。

- dst ref がローカルに無い → `* [new branch]` で作成され成功
- dst ref が既に最新 → 更新不要と判断され、**prune が ref を削除して fetch は exit 0**（`[deleted] (none) -> origin/cc-epic-N`）

後者のケースで直後の `assertRemoteTrackingExists`（`rev-parse --verify --quiet` は stderr を出さない）が throw し、setup error になる。エピックの2つ目以降のサブイシュー処理時（= tracking ref が既に最新）に決定的に発生し、失敗すると ref が消えるため次の tick では成功する、という交互挙動だった（git 2.54.0 で再現確認）。

## 修正内容

- refspec の src を `refs/heads/` で完全修飾
- `--no-prune` を付与して prune 自体も無効化（二重の防御）

`couldn't find remote ref` による remote ブランチ不在判定（`isMissingRemoteRefError`）は、完全修飾 src でも stderr メッセージにマッチすることを確認済み。

## 検証

esbuild でバンドルした実際の `ensureEpicBranch` を、`fetch.prune=true` を設定した clone + bare remote で E2E 実行:

1. リモートにブランチ無し（push 派生作成パス）→ 成功、ref 作成
2. ref がローカルに最新状態で存在（**旧コードで失敗していたケース**）→ 成功、ref 維持
3. 3回連続実行 → すべて成功
4. 別 epic の新規ブランチ作成（`couldn't find remote ref` → push 派生パス）→ 正常動作

また `syncDefaultBranch` の `git fetch origin <branch>`（dst なし refspec）は prune の影響を受けないことも確認済み（修正不要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * リモート追跡ブランチの取得方法を見直し、更新がより確実に反映されるようになりました。
  * ブランチ存在確認の処理が安定し、関連操作の失敗を減らしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->