### PR TITLE
ci: publishワークフローをdispatch方式に変更しリリース作成を自動化

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,28 @@
 name: Publish to npm
 
 on:
-  push:
-    tags:
-      - "v*"
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: "Version increment level"
+        type: choice
+        required: true
+        default: minor
+        options:
+          - major
+          - minor
+          - patch
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
+          fetch-depth: 0
 
       - uses: actions/setup-node@v5
         with:
@@ -29,6 +35,31 @@ jobs:
 
       - name: Ensure npm supports trusted publishing (OIDC)
         run: npm install -g npm@latest
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: version
+        run: |
+          new_version=$(npm version "${{ inputs.semver }}" --no-git-tag-version)
+          echo "version=$new_version" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push
+        run: |
+          git commit -am "chore: release ${{ steps.version.outputs.version }}"
+          git push origin "HEAD:${{ github.ref_name }}"
+
+      - name: Create tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --target "${{ github.ref_name }}" \
+            --latest \
+            --generate-notes
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## 概要

npm publish ワークフローを手動 dispatch 方式へ変更し、publish 前にバージョン更新・タグ/リリース作成を自動化しました。

## 変更内容

- **トリガー**: `push tags` / `release published` → `workflow_dispatch` に変更
  - 入力 `semver`: `major` / `minor` / `patch` の選択式（既定 `minor`）
- **Bump version**: `npm version <semver> --no-git-tag-version` で package.json / package-lock.json のバージョンをインクリメント
- **Commit and push**: bump コミットをディスパッチ元ブランチ（ターゲットブランチ）へ push
- **Create tag and release**: `gh release create` で `--target` からタグを自動生成、`--latest` で Latest マーク、`--generate-notes` でノート自動生成
- **Build → Publish**: 従来どおり `npm publish --provenance --access public`
- `permissions` に `contents: write` を追加、checkout は `persist-credentials` 解除 + `fetch-depth: 0`

## 参考

- https://cli.github.com/manual/gh_release_create

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * リリース公開を手動で実行できるようになりました。
  * バージョン種別（major / minor / patch）を指定して、更新を進められるようになりました。

* **Bug Fixes**
  * リリース作成時に必要な履歴情報が取得されるようになり、タグ作成やコミット反映が安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->