### PR TITLE
feat: エピックPRのリリースゲート(cc-release-ready)追加 + v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ claude-task-worker init --force   # 既存ファイルを強制上書き
 | `cc-need-human-check` | 人間の確認が必要なマーク（付与中はIssueワーカーの処理対象から除外される） |
 | `cc-issue-created` | `/claude-task-worker:create-issue` 由来のIssueマーク（triage-created-issue のトリガー条件） |
 | `cc-pr-created` | PR作成完了マーク |
-| `cc-epic-issue` | エピックIssueマーク（サブIssueが全Closeで `epic-issue` ワーカーが起動） |
+| `cc-epic-issue` | エピックマーク（Issueではサブ全Closeで `epic-issue` ワーカー起動、PRではリリースゲート対象を示すマーク） |
+| `cc-release-ready` | エピックPRがリリース可能（マージ問題なし）と判定されたマーク。実際のマージ（リリース）は人間が実施 |
 
 作成されるファイル:
 
@@ -234,6 +235,8 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 
 - `cc-fix-onetime` が付いているPRは除外
 - `cc-resolve-conflict` が付いているPRは除外
+- `cc-release-ready` が付いているPRは除外（リリースゲート判定済みのため再トリアージしない）
+- マージ可能と判定した際、`cc-epic-issue` が付いたエピックPRはマージせず `cc-release-ready` ラベルを付与する（リリースのためのマージは人間の判断に委ねる）。通常PRは従来どおりマージする
 
 ### resolve-conflict
 
@@ -254,7 +257,8 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 
 - `cc-pr-created` が付いているIssueは除外
 - サブIssueが存在しない、または1つでも未Closeのものがあればスキップ
-- 完了後、`cc-pr-created` ラベルを付与
+- 完了後、親Issueに `cc-pr-created` ラベルを付与
+- 完了後、作成されたエピックPR（`cc-epic-<親Issue番号>` ブランチ）に `cc-epic-issue` と `cc-triage-scope` ラベルを付与し、triage-pr のリリースゲート判定に引き継ぐ
 
 ### all
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-task-worker",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "claude-task-worker と組み合わせて使う getty104's base tool set (skills/agents/hooks)",
   "author": {
     "name": "getty104"

--- a/plugin/skills/triage-pr/SKILL.md
+++ b/plugin/skills/triage-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-pr
-description: Triage a single GitHub PR by PR number. Check out the PR's branch, detect conflicts with the target branch via `gh pr status` (and label the PR with `cc-resolve-conflict` if any are found), generate and evaluate a fix plan via create-review-fix-plan, then take action (add cc-fix-onetime label if fixes are needed, or merge the PR if it's ready).
+description: Triage a single GitHub PR by PR number. Check out the PR's branch, detect conflicts with the target branch via `gh pr status` (and label the PR with `cc-resolve-conflict` if any are found), generate and evaluate a fix plan via create-review-fix-plan, then take action (add cc-fix-onetime label if fixes are needed; if release-ready, add cc-release-ready label for an Epic PR marked `cc-epic-issue` instead of merging, otherwise merge the PR).
 argument-hint: "[pr-number]"
 hooks:
   Stop:
@@ -19,7 +19,7 @@ hooks:
 **やること**:
 - ステップ1のコンフリクト検知（`gh pr status`で確認し、コンフリクトがあれば`cc-resolve-conflict`ラベル付与のみで終了）
 - ステップ2の修正プラン生成と評価（プランの分析・判定のみ）
-- ステップ3のラベル付与（`cc-fix-onetime`）またはマージ
+- ステップ3のアクション: 修正が必要なら`cc-fix-onetime`ラベル付与 / マージ可能な場合は、Epic PR（`cc-epic-issue`付き）なら`cc-release-ready`ラベル付与（マージはしない）、通常PRならマージ
 
 **絶対にやらないこと**:
 - **PRのコード修正・実装**: 修正プランで「対応すべき」と判定された項目があっても、このスキル内では一切コードを変更しない。修正の実行は`cc-fix-onetime`ラベル付与後に別スキル（`fix-review-point`など）の責務
@@ -112,7 +112,21 @@ gh pr edit $ARGUMENTS --add-label "cc-fix-onetime"
 
 #### パターンB: マージ可能な場合
 
-すべての項目が「対応不要」、または修正プランに項目がない場合、以下の手順でマージし、**必要に応じて関連Issueを明示的にクローズする。判定だけで終了しないこと。**
+すべての項目が「対応不要」、または修正プランに項目がない場合、マージ可能（リリース問題なし）と判定する。
+
+**まず対象PRが Epic PR（`cc-epic-issue` ラベル付き）かどうかを確認する。**
+
+```bash
+gh pr view $ARGUMENTS --json labels -q '.labels[].name'
+```
+
+- **Epic PR の場合（出力に `cc-epic-issue` を含む）**: このPRをマージするとデフォルトブランチへの集約反映（＝リリース）になるため、**このスキルではマージせず** `cc-release-ready` ラベルのみを付与して終了する。実際のリリース（マージ）は人間の判断に委ねるゲートとして扱う。以降のマージ手順・関連Issueクローズには進まない。
+
+  ```bash
+  gh pr edit $ARGUMENTS --add-label "cc-release-ready"
+  ```
+
+- **通常のPRの場合（`cc-epic-issue` を含まない）**: 以下の手順でマージし、**必要に応じて関連Issueを明示的にクローズする。判定だけで終了しないこと。**
 
 1. マージ前に、PRのbaseブランチとデフォルトブランチ名を取得する。
 
@@ -191,5 +205,5 @@ gh issue close <issue番号> --reason "not planned"
 
 処理結果として以下を報告する：
 
-- **判定**: コンフリクト検知（`cc-resolve-conflict`ラベル付与） / パターンA（修正が必要・`cc-fix-onetime`ラベル付与） / パターンB（マージ済み。非デフォルトブランチへのマージ時は連動Closeした関連Issue番号も明記） / PRクローズ（関連IssueもClose） / エラー
-- **理由**: 判定の根拠（コンフリクト検知時はターゲットブランチ名、対応すべき項目の要約、マージ可能と判断した理由、非デフォルトブランチへのマージで`--reason completed`により連動Closeした関連Issue番号、またはクローズ理由と連動Closeした関連Issue番号）
+- **判定**: コンフリクト検知（`cc-resolve-conflict`ラベル付与） / パターンA（修正が必要・`cc-fix-onetime`ラベル付与） / パターンB-Epic（Epic PRのリリースゲート・`cc-release-ready`ラベル付与、マージせず終了） / パターンB-通常（マージ済み。非デフォルトブランチへのマージ時は連動Closeした関連Issue番号も明記） / PRクローズ（関連IssueもClose） / エラー
+- **理由**: 判定の根拠（コンフリクト検知時はターゲットブランチ名、対応すべき項目の要約、マージ可能と判断した理由、Epic PRで`cc-release-ready`を付与した旨、非デフォルトブランチへのマージで`--reason completed`により連動Closeした関連Issue番号、またはクローズ理由と連動Closeした関連Issue番号）

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,6 +14,7 @@ const LABELS: { name: string; color: string }[] = [
   { name: "cc-triage-scope", color: "c5def5" },
   { name: "cc-resolve-conflict", color: "fbca04" },
   { name: "cc-epic-issue", color: "8b5cf6" },
+  { name: "cc-release-ready", color: "2da44e" },
 ];
 
 const ISSUE_TEMPLATE = `name: "[claude-task-worker] Issue作成依頼"

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -132,6 +132,23 @@ export async function listIssuesByNumbers(
   return results;
 }
 
+export async function findOpenPrNumberByHeadRef(headRefName: string): Promise<number | null> {
+  const output = await execGh([
+    "pr",
+    "list",
+    "--state",
+    "open",
+    "--head",
+    headRefName,
+    "--json",
+    "number",
+    "--limit",
+    "1",
+  ]);
+  const prs: { number: number }[] = JSON.parse(output);
+  return prs.length > 0 ? prs[0].number : null;
+}
+
 export async function getIssueSubIssuesSummary(issueNumber: number): Promise<SubIssuesSummary> {
   const output = await execGh(["issue", "view", String(issueNumber), "--json", "subIssuesSummary"]);
   const parsed = JSON.parse(output);

--- a/src/workers/epic-issue.ts
+++ b/src/workers/epic-issue.ts
@@ -1,4 +1,4 @@
-import { addLabel, getIssueSubIssuesSummary } from "../gh";
+import { addLabel, findOpenPrNumberByHeadRef, getIssueSubIssuesSummary } from "../gh";
 import { createIssuePollingWorker } from "./issue-worker";
 
 export const epicIssueWorker = (opts: { epicFilters?: number[]; labelFilters?: string[] } = {}) =>
@@ -17,5 +17,15 @@ export const epicIssueWorker = (opts: { epicFilters?: number[]; labelFilters?: s
     },
     onCompleted: async (issueNumber) => {
       await addLabel("issue", issueNumber, "cc-pr-created");
+      // create-epic-pr が作成した Epic PR を epic ブランチ名で特定し、
+      // triage-pr がリリースゲートとして拾えるよう cc-epic-issue（マーカー）と
+      // cc-triage-scope（triage 投入）を付与する。
+      const prNumber = await findOpenPrNumberByHeadRef(`cc-epic-${issueNumber}`);
+      if (prNumber === null) {
+        console.error(`[epic-issue] Epic PR for branch cc-epic-${issueNumber} not found; skip labeling`);
+        return;
+      }
+      await addLabel("pr", prNumber, "cc-epic-issue");
+      await addLabel("pr", prNumber, "cc-triage-scope");
     },
   })();

--- a/src/workers/triage-pr.ts
+++ b/src/workers/triage-pr.ts
@@ -4,5 +4,5 @@ export const triagePrWorker = createPrPollingWorker({
   name: "triage-pr",
   command: "/claude-task-worker:triage-pr",
   triggerLabel: "cc-triage-scope",
-  excludeLabels: ["cc-fix-onetime", "cc-resolve-conflict"],
+  excludeLabels: ["cc-fix-onetime", "cc-resolve-conflict", "cc-release-ready"],
 });


### PR DESCRIPTION
## 概要
エピックPRのリリースゲート機構を追加し、あわせて claude-task-worker プラグインのバージョンを `0.1.1` から `0.2.0` に更新（minor bump）。

## 変更内容
- **epic-issue ワーカー**: 完了時、`create-epic-pr` が作成した Epic PR を `cc-epic-<親Issue番号>` ブランチ名で特定し、`cc-epic-issue`（マーカー）と `cc-triage-scope`（triage 投入）ラベルを付与
- **triage-pr スキル**: マージ可能判定時、`cc-epic-issue` 付きの Epic PR はマージせず `cc-release-ready` ラベルを付与（実際のリリース＝マージは人間の判断に委ねるゲート）。通常 PR は従来どおりマージ
- **triage-pr ワーカー**: 除外ラベルに `cc-release-ready` を追加し、リリースゲート判定済み PR の再トリアージを防止
- **init コマンド**: `cc-release-ready` ラベルを作成対象に追加
- **gh.ts**: `findOpenPrNumberByHeadRef` を追加
- **plugin.json**: `0.1.1` → `0.2.0`
- **README**: ラベル表・triage-pr・epic-issue の各説明を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * リリース可能なPRを示す新しいラベルが追加され、初期化時に自動で用意されるようになりました。
  * Epic関連のPRに対して、通常PRとは異なるリリース準備フローが反映されるようになりました。

* **Bug Fixes**
  * すでにリリース準備完了と判定されたPRが、再トリアージされないようになりました。
  * Epic PRはその場でマージせず、リリース準備完了の状態に切り替わるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->