### PR TITLE
feat: version コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,18 @@ claude-task-worker update
 
 いずれかのステップが失敗しても処理は継続し、`[update]` プレフィックス付きでエラー内容がログ出力される。
 
+### version
+
+インストールされている `claude-task-worker` CLI のバージョンを表示する。
+
+```bash
+claude-task-worker version
+claude-task-worker --version
+claude-task-worker -v
+```
+
+`package.json` の `version` を出力する（例: `0.2.0`）。
+
 ## 設定ファイル
 
 コマンドを実行したディレクトリ直下の `claude-task-worker.json` を読み込む。

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function version(): void {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const pkgPath = join(here, "..", "package.json");
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };
+    console.log(pkg.version ?? "unknown");
+  } catch (err) {
+    console.error(`[version] Failed to read version: ${(err as Error).message}`);
+    process.exitCode = 1;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { shutdown, waitForAllProcesses, setShuttingDown, isShuttingDown } from "
 import { init } from "./commands/init";
 import { install } from "./commands/install";
 import { update } from "./commands/update";
+import { version } from "./commands/version";
 import { buildTokenLimitText, send } from "./slack";
 
 const WORKERS: Record<string, (opts?: { epicFilters?: number[]; labelFilters?: string[] }) => Promise<void>> = {
@@ -37,6 +38,7 @@ Commands:
   install           Add the claude-task-worker marketplace, install the plugin, and install/update the CLI
   update            Update the claude-task-worker plugin/marketplace and the CLI itself
   usage             Notify current usage to Slack
+  version           Print the installed claude-task-worker CLI version (aliases: --version, -v)
 
 Workers:
   exec-issue        Poll issues and run /exec-issue
@@ -67,6 +69,11 @@ Example:
 }
 
 const workerType = process.argv[2];
+
+if (workerType === "version" || workerType === "--version" || workerType === "-v") {
+  version();
+  process.exit(process.exitCode ?? 0);
+}
 
 if (!workerType) {
   printUsage();


### PR DESCRIPTION
## 概要

現在インストールされている `claude-task-worker` CLI のバージョンを把握できるよう、`version` コマンドを追加しました。

## 変更内容

- **`src/commands/version.ts`（新規）**: 実行時に `package.json` の `version` を読み込んで出力する。esbuild バンドル後の `dist/index.js` から `import.meta.url` 基準で `../package.json` を解決するため、`npm install -g` 環境でも正しく動作する（npm は `files` 指定に関わらず `package.json` を同梱するため）。読み込み失敗時は `[version]` プレフィックス付きでエラー出力し終了コード 1。
- **`src/index.ts`**: `version` / `--version` / `-v` の 3 通りで呼び出せるよう early return で分岐。usage テキストにも追記。
- **`README.md`**: コマンド一覧に `version` セクションを追加。

## 動作確認

- `npm run build`（tsc 型チェック + esbuild）成功
- `node dist/index.js version` / `--version` / `-v` すべて `0.2.0` を出力
- `npm run lint` / `npm run format:check` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `version` コマンド（`--version`、`-v`）を追加し、インストール済み CLI のバージョンを表示できるようになりました。
  * 起動時のコマンド一覧にバージョン表示の案内を追加しました。
* **ドキュメント**
  * README に `version` コマンドの使い方と表示内容の説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->