### PR TITLE
fix(worker): worktree生成を自前管理に統一し削除処理の不具合を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,10 @@ claude-task-worker all             # Run all workers concurrently
 3. ラベル・アサイン条件でフィルタリング
 4. `isRunning()` で重複実行防止
 5. トリガーラベル除去 → `cc-in-progress` ラベル付与
-6. Claude CLIプロセスを非同期spawn
-7. 完了時コールバックでラベルクリーンアップ
+6. `.claude/worktrees/<worktreeId>` にワーカー自身がworktreeを生成し（`claude --worktree` は locked worktree の残骸問題があるため不使用）、Claude CLIプロセスをcwd指定で非同期spawn
+7. 完了時コールバックでラベル・worktree・ローカルブランチをクリーンアップ
+
+ワーカー起動時には `removeStaleWorktrees()` が前回の異常終了で残ったworktree（`adj-noun-4桁` の生成名パターンのみ対象）を回収する。実行中タスクのworktree・lockedな対話セッションのworktreeは削除対象から保護される。
 
 ### ラベルフロー
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { resolveConflictWorker } from "./workers/resolve-conflict";
 import { checkDependabotWorker } from "./workers/check-dependabot";
 import { epicIssueWorker } from "./workers/epic-issue";
 import { shutdown, waitForAllProcesses, setShuttingDown, isShuttingDown } from "./process-manager";
+import { removeStaleWorktrees } from "./worktree";
 import { init } from "./commands/init";
 import { install } from "./commands/install";
 import { update } from "./commands/update";
@@ -182,19 +183,24 @@ if (workerType === "init") {
 } else if (workerType === "all") {
   const epicFilters = parseEpicFilters();
   const labelFilters = parseLabelFilters();
-  Promise.all([
-    execIssueWorker({ epicFilters, labelFilters }),
-    fixReviewPointWorker(),
-    createIssueWorker({ epicFilters, labelFilters }),
-    updateIssueWorker({ epicFilters, labelFilters }),
-    answerIssueQuestionsWorker({ epicFilters, labelFilters }),
-    resolveConflictWorker(),
-    epicIssueWorker({ epicFilters, labelFilters }),
-  ]);
+  (async () => {
+    // 前回の異常終了で残った worktree・ブランチをワーカー起動前に回収する
+    await removeStaleWorktrees();
+    await Promise.all([
+      execIssueWorker({ epicFilters, labelFilters }),
+      fixReviewPointWorker(),
+      createIssueWorker({ epicFilters, labelFilters }),
+      updateIssueWorker({ epicFilters, labelFilters }),
+      answerIssueQuestionsWorker({ epicFilters, labelFilters }),
+      resolveConflictWorker(),
+      epicIssueWorker({ epicFilters, labelFilters }),
+    ]);
+  })();
 } else if (workerType === "yolo") {
   const epicFilters = parseEpicFilters();
   const labelFilters = parseLabelFilters();
   (async () => {
+    await removeStaleWorktrees();
     await Promise.all([
       execIssueWorker({ epicFilters, labelFilters }),
       fixReviewPointWorker(),
@@ -211,5 +217,8 @@ if (workerType === "init") {
 } else {
   const epicFilters = parseEpicFilters();
   const labelFilters = parseLabelFilters();
-  WORKERS[workerType]({ epicFilters, labelFilters });
+  (async () => {
+    await removeStaleWorktrees();
+    await WORKERS[workerType]({ epicFilters, labelFilters });
+  })();
 }

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -82,6 +82,15 @@ export function isRunning(id: number): boolean {
   return task?.status === "running";
 }
 
+export function isWorktreeInUse(worktreeId: string): boolean {
+  for (const task of tasks.values()) {
+    if (task.status === "running" && task.path === worktreeId) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function isWorkerAtCapacity(workerName: string): boolean {
   let count = 0;
   for (const task of tasks.values()) {

--- a/src/random-name.ts
+++ b/src/random-name.ts
@@ -244,3 +244,9 @@ export function generateWorktreeName(): string {
   const suffix = String(randomInt(10000)).padStart(4, "0");
   return `${pick(ADJECTIVES)}-${pick(NOUNS)}-${suffix}`;
 }
+
+// generateWorktreeName() が生成する adj-noun-4桁 形式のみに一致させる。
+// claude CLI の対話セッションが作る worktree（3単語形式など）を巻き込まないためのガード。
+export function isGeneratedWorktreeName(name: string): boolean {
+  return /^[a-z]+-[a-z]+-\d{4}$/.test(name);
+}

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -80,7 +80,6 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
             const command = skill || config.command;
 
             const parentNumber = issue.parent?.number;
-            let cwd: string | undefined;
             const claudeArgs: string[] = [
               "-p",
               `${command} ${issue.number}`,
@@ -91,17 +90,17 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
               effort,
             ];
 
+            // claude CLI の --worktree は locked な worktree を作り、異常終了時に
+            // 削除不能な残骸（幽霊エントリ・checkout済み扱いのブランチ）を残すため使わない。
+            // epic の有無に関わらずワーカー自身が worktree を生成して cwd として渡す。
+            let baseBranch = defaultBranch;
             if (parentNumber !== undefined) {
-              const epicBranch = `cc-epic-${parentNumber}`;
-              await ensureEpicBranch(epicBranch, defaultBranch);
-              await createWorktreeFromBranch(worktreeId, epicBranch);
-              cwd = getWorktreePath(worktreeId);
-              console.log(
-                `[${config.name}] #${issue.number}: created worktree ${worktreeId} from ${epicBranch} (parent #${parentNumber})`,
-              );
-            } else {
-              claudeArgs.push("--worktree", worktreeId);
+              baseBranch = `cc-epic-${parentNumber}`;
+              await ensureEpicBranch(baseBranch, defaultBranch);
             }
+            await createWorktreeFromBranch(worktreeId, baseBranch);
+            const cwd = getWorktreePath(worktreeId);
+            console.log(`[${config.name}] #${issue.number}: created worktree ${worktreeId} from ${baseBranch}`);
 
             run(
               "claude",

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -11,7 +11,13 @@ import { syncDefaultBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isShuttingDown, run } from "../process-manager";
 import { generateWorktreeName } from "../random-name";
 import { notifyTaskCompleted, notifyTaskFailed, notifyError } from "../slack";
-import { removeWorktree, removeWorktreeByBranch } from "../worktree";
+import {
+  createWorktreeFromBranch,
+  deleteLocalBranch,
+  getWorktreePath,
+  removeWorktree,
+  removeWorktreeByBranch,
+} from "../worktree";
 
 const LABEL_IN_PROGRESS = "cc-in-progress";
 const LABEL_TRIAGE_SCOPE = "cc-triage-scope";
@@ -53,25 +59,23 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
           const hadTriageScope = pr.labels.some((l) => l.name === LABEL_TRIAGE_SCOPE);
 
           await addLabel("pr", pr.number, LABEL_IN_PROGRESS);
+          const worktreeId = generateWorktreeName();
           try {
+            // PRブランチを掴んでいる過去の worktree と、残留しているローカルブランチを掃除する。
+            // ローカルブランチが古いまま残っているとスキル内の `gh pr checkout` が
+            // fast-forward できずに失敗するため、リモートを正として作り直させる。
             await removeWorktreeByBranch(pr.headRefName);
-            const worktreeId = generateWorktreeName();
+            await deleteLocalBranch(pr.headRefName);
             syncDefaultBranch(defaultBranch);
+            // claude CLI の --worktree は locked な worktree を作り、異常終了時に
+            // 削除不能な残骸を残すため使わない。ワーカー自身が worktree を生成して cwd として渡す。
+            await createWorktreeFromBranch(worktreeId, defaultBranch);
+            const cwd = getWorktreePath(worktreeId);
             const { model, effort, skill } = getWorkerConfig(config.name);
             const command = skill || config.command;
             run(
               "claude",
-              [
-                "-p",
-                `${command} ${pr.number}`,
-                "--dangerously-skip-permissions",
-                "--model",
-                model,
-                "--effort",
-                effort,
-                "--worktree",
-                worktreeId,
-              ],
+              ["-p", `${command} ${pr.number}`, "--dangerously-skip-permissions", "--model", model, "--effort", effort],
               pr.number,
               `PR #${pr.number} (${pr.headRefName})`,
               config.name,
@@ -115,10 +119,12 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
                   );
                 }
               },
+              cwd,
             );
           } catch (err) {
             console.error(`[${config.name}] setup error for PR #${pr.number}: ${err}`);
             await removeLabel("pr", pr.number, LABEL_IN_PROGRESS).catch(() => {});
+            await removeWorktree(worktreeId).catch(() => {});
             await notifyError(config.name, name, err);
           }
         }

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -34,13 +34,18 @@ async function forceRemoveIfExists(path: string): Promise<void> {
     return;
   }
   if (!(await pathExists(path))) return;
-  await rm(path, { recursive: true, force: true });
-  console.log(`[worktree] Force removed remaining directory: ${path}`);
+  try {
+    await rm(path, { recursive: true, force: true });
+    console.log(`[worktree] Force removed remaining directory: ${path}`);
+  } catch (error) {
+    console.error(`[worktree] Failed to remove directory ${path}:`, error);
+  }
 }
 
 async function listWorktreeEntries(): Promise<WorktreeEntry[]> {
   const { stdout } = await execFileAsync("git", ["worktree", "list", "--porcelain"]);
   return stdout
+    .replace(/\r\n/g, "\n")
     .trim()
     .split("\n\n")
     .filter(Boolean)
@@ -71,11 +76,28 @@ async function removeRegisteredWorktree(worktreePath: string): Promise<void> {
   await forceRemoveIfExists(worktreePath);
 }
 
+const PROTECTED_BRANCHES = new Set(["main", "master", "develop"]);
+
+/** origin/HEAD からデフォルトブランチ名を取得する（未設定などで取得できない場合は undefined）。 */
+async function getDefaultBranchName(): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("git", ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+    return stdout.trim().replace(/^origin\//, "");
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * ローカルブランチを削除する。worktree 削除後のブランチ残留（リーク）防止用。
  * 存在しないブランチは黙って無視し、他の worktree で checkout 中などの失敗のみログする。
  */
 export async function deleteLocalBranch(branchName: string): Promise<void> {
+  const defaultBranch = await getDefaultBranchName();
+  if (PROTECTED_BRANCHES.has(branchName) || branchName === defaultBranch) {
+    console.log(`[worktree] Skipping deletion of protected branch: ${branchName}`);
+    return;
+  }
   try {
     await execFileAsync("git", ["branch", "-D", branchName]);
     console.log(`[worktree] Deleted local branch: ${branchName}`);

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,14 +1,31 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { readdir, rm, stat } from "node:fs/promises";
-import { resolve, sep } from "node:path";
+import { basename, resolve, sep } from "node:path";
+import { isWorktreeInUse } from "./process-manager";
+import { isGeneratedWorktreeName } from "./random-name";
 
 const execFileAsync = promisify(execFile);
 
 const WORKTREES_DIR = ".claude/worktrees";
 
+interface WorktreeEntry {
+  path: string;
+  branch?: string;
+  locked: boolean;
+}
+
 function isManagedWorktreePath(path: string): boolean {
   return resolve(path).startsWith(resolve(WORKTREES_DIR) + sep);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function forceRemoveIfExists(path: string): Promise<void> {
@@ -16,13 +33,57 @@ async function forceRemoveIfExists(path: string): Promise<void> {
     console.error(`[worktree] Refusing to remove path outside ${WORKTREES_DIR}: ${path}`);
     return;
   }
-  try {
-    await stat(path);
-  } catch {
-    return;
-  }
+  if (!(await pathExists(path))) return;
   await rm(path, { recursive: true, force: true });
   console.log(`[worktree] Force removed remaining directory: ${path}`);
+}
+
+async function listWorktreeEntries(): Promise<WorktreeEntry[]> {
+  const { stdout } = await execFileAsync("git", ["worktree", "list", "--porcelain"]);
+  return stdout
+    .trim()
+    .split("\n\n")
+    .filter(Boolean)
+    .map((entry) => {
+      const lines = entry.split("\n");
+      const worktreeLine = lines.find((l) => l.startsWith("worktree "));
+      const branchLine = lines.find((l) => l.startsWith("branch refs/heads/"));
+      return {
+        path: worktreeLine ? worktreeLine.slice("worktree ".length) : "",
+        branch: branchLine?.slice("branch refs/heads/".length),
+        locked: lines.some((l) => l === "locked" || l.startsWith("locked ")),
+      };
+    })
+    .filter((e) => e.path !== "");
+}
+
+/**
+ * worktree を登録から外して実体ディレクトリも削除する。
+ * claude CLI が残した locked worktree や、ディレクトリだけ消えた幽霊エントリも
+ * `--force --force` で管理メタデータごと除去できる（locked は force 1回では削除できない）。
+ */
+async function removeRegisteredWorktree(worktreePath: string): Promise<void> {
+  try {
+    await execFileAsync("git", ["worktree", "remove", "--force", "--force", worktreePath]);
+  } catch (error) {
+    console.error(`[worktree] Failed to remove worktree ${worktreePath}:`, error);
+  }
+  await forceRemoveIfExists(worktreePath);
+}
+
+/**
+ * ローカルブランチを削除する。worktree 削除後のブランチ残留（リーク）防止用。
+ * 存在しないブランチは黙って無視し、他の worktree で checkout 中などの失敗のみログする。
+ */
+export async function deleteLocalBranch(branchName: string): Promise<void> {
+  try {
+    await execFileAsync("git", ["branch", "-D", branchName]);
+    console.log(`[worktree] Deleted local branch: ${branchName}`);
+  } catch (error) {
+    const stderr = String((error as { stderr?: unknown } | null | undefined)?.stderr ?? "");
+    if (/not found/i.test(stderr)) return;
+    console.error(`[worktree] Failed to delete local branch ${branchName}: ${stderr.trim()}`);
+  }
 }
 
 export function getWorktreePath(worktreeId: string): string {
@@ -30,7 +91,7 @@ export function getWorktreePath(worktreeId: string): string {
 }
 
 export async function createWorktreeFromBranch(worktreeId: string, baseBranch: string): Promise<void> {
-  const worktreePath = `${WORKTREES_DIR}/${worktreeId}`;
+  const worktreePath = getWorktreePath(worktreeId);
   // detached HEAD だと後段の commit-push スキルの `git push origin HEAD` が
   // refspec を解決できず失敗するため、worktreeId と同名のブランチを切って checkout する。
   // -B を使うことで孤児ブランチが残っていても origin/${baseBranch} から強制再作成して安全に回復できる。
@@ -38,58 +99,89 @@ export async function createWorktreeFromBranch(worktreeId: string, baseBranch: s
 }
 
 export async function removeWorktree(worktreeId: string): Promise<void> {
-  const worktreePath = `${WORKTREES_DIR}/${worktreeId}`;
+  const worktreePath = getWorktreePath(worktreeId);
+
+  let entry: WorktreeEntry | undefined;
   try {
-    await execFileAsync("git", ["worktree", "remove", "--force", worktreePath]);
+    entry = (await listWorktreeEntries()).find((e) => resolve(e.path) === resolve(worktreePath));
   } catch (error) {
-    console.error(`[worktree] Failed to remove worktree ${worktreeId}:`, error);
+    console.error(`[worktree] Failed to list worktrees:`, error);
   }
-  await forceRemoveIfExists(worktreePath);
+
+  if (entry) {
+    await removeRegisteredWorktree(worktreePath);
+  } else {
+    // 登録が無くてもディレクトリだけ残っているケース（作成途中の失敗など）を回収する
+    await forceRemoveIfExists(worktreePath);
+  }
+
+  // worktree 削除ではブランチは消えないため、checkout されていたブランチと
+  // worktreeId と同名のブランチ（createWorktreeFromBranch が作成）を明示的に削除する
+  const branches = new Set([entry?.branch, worktreeId]);
+  for (const branch of branches) {
+    if (!branch) continue;
+    await deleteLocalBranch(branch);
+  }
 }
 
 export async function removeWorktreeByBranch(branchName: string): Promise<void> {
   try {
-    const { stdout } = await execFileAsync("git", ["worktree", "list", "--porcelain"]);
-    const entries = stdout.trim().split("\n\n").filter(Boolean);
+    const entries = await listWorktreeEntries();
     for (const entry of entries) {
-      const branchLine = entry.split("\n").find((l) => l.startsWith("branch "));
-      if (!branchLine) continue;
-      const branch = branchLine.replace("branch refs/heads/", "");
-      if (branch !== branchName) continue;
-      const worktreeLine = entry.split("\n").find((l) => l.startsWith("worktree "));
-      if (!worktreeLine) continue;
-      const worktreePath = worktreeLine.replace("worktree ", "");
-      if (!isManagedWorktreePath(worktreePath)) {
-        console.log(`[worktree] Skipping unmanaged worktree for branch ${branchName}: ${worktreePath}`);
+      if (entry.branch !== branchName) continue;
+      if (!isManagedWorktreePath(entry.path)) {
+        console.log(`[worktree] Skipping unmanaged worktree for branch ${branchName}: ${entry.path}`);
         continue;
       }
-      try {
-        await execFileAsync("git", ["worktree", "remove", "--force", worktreePath]);
-        console.log(`[worktree] Removed worktree for branch ${branchName}: ${worktreePath}`);
-      } catch (error) {
-        console.error(`[worktree] Failed to remove worktree for branch ${branchName}:`, error);
+      // 実行中タスクが使用している worktree を破壊しない（PR 作成元タスクがまだ動いているケース）
+      const worktreeId = basename(entry.path);
+      if (isWorktreeInUse(worktreeId)) {
+        console.log(`[worktree] Skipping worktree in use by a running task for branch ${branchName}: ${entry.path}`);
+        continue;
       }
-      await forceRemoveIfExists(worktreePath);
+      // locked かつ実体が残っている worktree はアクティブな claude セッションの可能性があるため触らない
+      // （ディレクトリが消えている locked エントリは幽霊なので回収する）
+      if (entry.locked && (await pathExists(entry.path))) {
+        console.log(`[worktree] Skipping locked worktree for branch ${branchName}: ${entry.path}`);
+        continue;
+      }
+      await removeRegisteredWorktree(entry.path);
+      console.log(`[worktree] Removed worktree for branch ${branchName}: ${entry.path}`);
     }
   } catch (error) {
     console.error(`[worktree] Failed to remove worktree for branch ${branchName}:`, error);
   }
 }
 
-export async function removeAllAgentWorktrees(): Promise<void> {
-  let entries: string[];
+/**
+ * 前回のクラッシュ・強制終了などで残った worktree を起動時に一括回収する。
+ * generateWorktreeName() 形式（adj-noun-4桁）の名前だけを対象にすることで、
+ * ユーザーが対話セッションで使用中の claude worktree を誤って削除しない。
+ */
+export async function removeStaleWorktrees(): Promise<void> {
+  const worktreeIds = new Set<string>();
+
   try {
-    entries = await readdir(WORKTREES_DIR);
-  } catch {
-    return;
-  }
-  const agentDirs = entries.filter((e) => e.startsWith("agent-"));
-  for (const dir of agentDirs) {
-    try {
-      await execFileAsync("git", ["worktree", "remove", "--force", `${WORKTREES_DIR}/${dir}`]);
-      console.log(`[worktree] Removed agent worktree: ${dir}`);
-    } catch (error) {
-      console.error(`[worktree] Failed to remove agent worktree ${dir}:`, error);
+    for (const name of await readdir(WORKTREES_DIR)) {
+      if (isGeneratedWorktreeName(name)) worktreeIds.add(name);
     }
+  } catch {
+    // ディレクトリが無ければディスク上の残骸は無い
+  }
+
+  try {
+    for (const entry of await listWorktreeEntries()) {
+      if (!isManagedWorktreePath(entry.path)) continue;
+      const worktreeId = basename(entry.path);
+      if (isGeneratedWorktreeName(worktreeId)) worktreeIds.add(worktreeId);
+    }
+  } catch (error) {
+    console.error(`[worktree] Failed to list worktrees:`, error);
+  }
+
+  for (const worktreeId of worktreeIds) {
+    if (isWorktreeInUse(worktreeId)) continue;
+    console.log(`[worktree] Removing stale worktree: ${worktreeId}`);
+    await removeWorktree(worktreeId);
   }
 }


### PR DESCRIPTION
## 概要

worktree の生成・削除処理の調査で見つかった不具合を修正します。

### 1. `claude --worktree` の廃止（worktree 生成の自前管理化）

claude CLI の `--worktree` が作る worktree は locked 状態で、異常終了時（90分タイムアウトの SIGTERM・強制終了・クラッシュ）に削除不能な残骸を残します：

- `git worktree remove --force`（1回）は locked worktree に対して fatal で失敗する（`-f -f` が必要）
- `rm -rf` fallback 後も `git worktree prune` は locked エントリを回収しない → `.git/worktrees/` に幽霊エントリが恒久残留
- 幽霊エントリのブランチは「checkout 済み」扱いのまま削除・再 checkout 不能になり、以後の fix-review-point 等が失敗し続ける

epic パスで実績のある自前生成（`createWorktreeFromBranch`）に全ワーカーを統一し、cwd 指定で claude を spawn するように変更しました。スキル側の前提（cwd が `.claude/worktrees/` 配下・現在ブランチ ≠ デフォルトブランチ・`gh pr checkout` による PR ブランチ切り替え）はそのまま維持されます。

### 2. 実行中タスクの worktree 破壊競合の修正

`removeWorktreeByBranch` のガードが `isRunning(pr.number)` のみで、PR 作成元の exec-issue タスク（issue 番号キー）が実行中でも worktree を `--force` 削除できてしまう競合がありました。`process-manager` に `isWorktreeInUse()` を追加して実行中タスクの worktree を skip し、locked かつ実体のある worktree（対話 claude セッションの可能性）も保護します。実体が消えた locked 幽霊エントリのみ `--force --force` で回収します。

### 3. 起動時クリーンアップの実装

`removeAllAgentWorktrees` はどこからも呼ばれておらず、`agent-` プレフィックスのフィルタも実際の生成名（`adj-noun-4桁`）と一致しないデッドコードでした。`removeStaleWorktrees()` に置き換え、全ワーカー起動前に前回の異常終了の残骸（ディスク上の残骸と git 登録上の幽霊の両方）を回収します。生成名パターンに一致するもののみ対象とするため、対話セッションの worktree は誤削除されません。

### 4. ローカルブランチのリーク修正

worktree 削除ではブランチが消えないため、`worktreeId` 同名ブランチや `gh pr checkout` で作られた PR ブランチが際限なく蓄積していました。`removeWorktree` が削除前に checkout 中のブランチを特定し、worktree 削除後に `git branch -D` するようにしました。pr-worker は起動前にも stale なローカル PR ブランチを掃除し、diverged ブランチによる `gh pr checkout` 失敗ループを防ぎます。

## テスト

- `npm run build` / `npm run lint` / `npm run format:check` すべてパス
- git 実挙動（locked worktree への `remove --force` 失敗・`-f -f` での回収・prune が locked を skip する挙動）をスクラッチリポジトリで検証
- bare origin + clone のスクラッチ環境で worktree モジュールの E2E を実施し、生成→削除→ブランチ掃除・locked skip・幽霊回収・生成名以外の保護・存在しない worktree への安全な no-op まで全16項目 PASS
- レビュー対応後、保護ブランチガードの検証2項目（`main` / `develop` が `deleteLocalBranch` で削除されないこと）を追加した全19項目で再実行し PASS

## 留意点

- 失敗タスクの未 push コミットはブランチ削除で失われます（リモートを正とする自動化フローのため、stale ブランチ残留の害の方が大きいと判断）
- 起動時クリーンアップは単一インスタンス前提です（従来からの設計前提どおり）

## 修正履歴

### 2026-07-08: レビュー指摘対応（3件）

- `listWorktreeEntries` が `git worktree list --porcelain` の出力を `\n` のみで分割しており、Windows の CRLF 改行ではパス比較・ブランチ比較・locked 判定がすべて壊れるとの指摘に対し、パース前に `\r\n` → `\n` の正規化を追加（対応コミット: c94fbf0）
- `deleteLocalBranch` が GitHub API 由来の `pr.headRefName` を無条件に `git branch -D` しており、PR が `main` 等から作られていた場合にローカルのデフォルトブランチを削除し得るとの指摘に対し、保護ブランチリスト（main / master / develop）と `origin/HEAD` 由来のデフォルトブランチをスキップするガードを追加（対応コミット: c94fbf0）
- `forceRemoveIfExists` の `rm()` に try-catch がなく、権限エラー等の例外で起動時クリーンアップループが打ち切られるとの指摘に対し、失敗をログ出力に留めて処理を継続するよう修正（対応コミット: c94fbf0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * ワーカーの「共通ライフサイクル」の手順を更新し、残骸回収や起動〜完了時クリーンアップの流れを明確化しました。
* **新機能**
  * ワーカー起動前に、前回失敗時などの残存 worktree やローカルブランチを自動回収するようになりました。
* **バグ修正**
  * 使用中・保護対象・ロック/幽霊状態の worktree を誤って削除しないよう改善しました。
  * PR/Issue の失敗時後始末で、クリーンアップをより確実に実施します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
