### PR TITLE
fix: PRベースブランチが無関係なcc-epic-*に選ばれる問題を修正

### DIFF
--- a/plugin/skills/create-pr/SKILL.md
+++ b/plugin/skills/create-pr/SKILL.md
@@ -35,10 +35,11 @@ GitHubでPull Request（PR）を作成するスキルです。呼び出された
 
 ## ベースブランチの決定
 
-ベースブランチは以下の優先順で決定する。必ず 1 → 2 の順に試すこと。
+ベースブランチは以下の優先順で決定する。必ず 1 → 2 → 3 の順に試すこと。
 
 1. **Epicブランチの確定的導出**: Issue `$0` が parent（Epic Issue）を持つ場合、`cc-epic-<parent番号>` をベースにする
-2. **分岐元ブランチの推定（fallback）**: parentが無い場合やepicブランチがremoteに存在しない場合、merge-base距離で分岐元を推定する
+2. **upstream（追跡ブランチ）からの確定的導出**: 現在のブランチの upstream が origin の別ブランチを指している場合、それをベースにする（ワーカーが worktree 作成時に `--track` で分岐元を記録している）
+3. **分岐元ブランチの推定（fallback）**: 1・2 のいずれでも決まらない場合のみ、merge-base距離で分岐元を推定する
 
 ### 1. Epicブランチの確定的導出
 
@@ -64,12 +65,32 @@ fi
 
 引数のIssue番号が渡されていない場合（`$0`が空）は本ステップをスキップし、`BASE_BRANCH` を空のままステップ2へ進む。Issue番号が指定されているが `gh issue view` の実行に失敗した場合（ネットワークエラー・権限不足等）はエラーメッセージを出力して処理を中断する。
 
-### 2. 分岐元ブランチの推定（fallback）
+### 2. upstream（追跡ブランチ）からの確定的導出
 
-「現在のブランチの分岐元ブランチ」は、リモートトラッキングブランチ（`refs/remotes/origin/`配下）のうち、現在のブランチ自身を除き、HEADから最も近い merge-base を持つものとして推定する。Epic ブランチや任意の中間ブランチから派生した作業ブランチでも、その派生元へPRを向けられるようにするための仕組み。
+ワーカーは worktree 作成時に `git worktree add --track` で分岐元ブランチを upstream として記録している（例: デフォルトブランチ由来なら `origin/main`、epic 由来なら `origin/cc-epic-<N>`）。手動で `git checkout -b <branch> origin/<base>` した場合も既定で同じ upstream が付く。これは「どのブランチから派生したか」の確定情報なので、merge-base 推定より必ず先に使う。
 
 ```bash
 if [ -z "${BASE_BRANCH}" ]; then
+  CURRENT=$(git rev-parse --abbrev-ref HEAD)
+  UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
+  UPSTREAM=${UPSTREAM#origin/}
+  # upstream が未設定・自分自身（push -u した作業ブランチ）・origin に実在しない場合は採用しない
+  if [ -n "${UPSTREAM}" ] && [ "${UPSTREAM}" != "${CURRENT}" ] \
+    && git rev-parse --verify --quiet "refs/remotes/origin/${UPSTREAM}" >/dev/null; then
+    BASE_BRANCH="${UPSTREAM}"
+  fi
+fi
+```
+
+### 3. 分岐元ブランチの推定（fallback）
+
+「現在のブランチの分岐元ブランチ」は、リモートトラッキングブランチ（`refs/remotes/origin/`配下）のうち、現在のブランチ自身を除き、HEADから最も近い merge-base を持つものとして推定する。Epic ブランチや任意の中間ブランチから派生した作業ブランチでも、その派生元へPRを向けられるようにするための仕組み。
+
+**距離が同点の場合はデフォルトブランチを最優先する**こと。デフォルトブランチと同一コミットを指すブランチ（作成直後の epic ブランチや並行タスクのPRブランチ）が存在すると距離が同点になり、単純なアルファベット順タイブレークでは `origin/cc-epic-*` が `origin/main` より先に来て**無関係な epic ブランチがベースに選ばれる**ため。
+
+```bash
+if [ -z "${BASE_BRANCH}" ]; then
+  DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
   CURRENT=$(git rev-parse --abbrev-ref HEAD)
 
   BASE_BRANCH=$(
@@ -80,18 +101,19 @@ if [ -z "${BASE_BRANCH}" ]; then
         mb=$(git merge-base "$b" HEAD 2>/dev/null) || continue
         [ -n "$mb" ] || continue
         dist=$(git rev-list --count "${mb}..HEAD" 2>/dev/null) || continue
-        echo "$dist $b"
-      done | sort -n | head -1 | awk '{print $2}' | sed 's|^origin/||'
+        if [ "$b" = "origin/${DEFAULT_BRANCH}" ]; then pref=0; else pref=1; fi
+        echo "$dist $pref $b"
+      done | sort -k1,1n -k2,2n -k3,3 | head -1 | awk '{print $3}' | sed 's|^origin/||'
   )
-fi
 
-# 候補が見つからない場合（孤立ブランチ等）はデフォルトブランチに fallback する
-if [ -z "${BASE_BRANCH}" ]; then
-  BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+  # 候補が見つからない場合（孤立ブランチ等）はデフォルトブランチに fallback する
+  if [ -z "${BASE_BRANCH}" ]; then
+    BASE_BRANCH="${DEFAULT_BRANCH}"
+  fi
 fi
 ```
 
-距離が同点の場合は `git for-each-ref` の列挙順（refname のアルファベット順）で先に出てきたものを採用する。期待しないブランチがベースに選ばれた場合は `--base` を明示的に指定して上書きする。
+距離が同点の場合はデフォルトブランチ → refname のアルファベット順の優先度で採用する。期待しないブランチがベースに選ばれた場合は `--base` を明示的に指定して上書きする。
 
 ## Command Examples
 

--- a/plugin/skills/exec-issue/SKILL.md
+++ b/plugin/skills/exec-issue/SKILL.md
@@ -197,13 +197,28 @@ E2Eテストが存在しない場合は、Issueが明示的に要求しない限
 まず差分の基準ブランチ（`BASE_BRANCH`）を決定する。Issue `$0` が parent（Epic Issue）を持つ場合、worktree は `cc-epic-<parent番号>` ブランチから派生しているため、epic ブランチを基準にする。デフォルトブランチを基準にすると、epic ブランチへマージ済みの**他サブIssueの差分が混ざり**、「本Issueでのコード変更の有無」を誤判定する（create-pr スキルのベースブランチ決定と同じ確定的導出を用いる）。
 
 ```bash
-BASE_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')
+BASE_BRANCH=""
 if ! PARENT=$(gh issue view "$0" --json parent --jq '.parent.number // empty'); then
   echo "failed to resolve issue parent" >&2
   exit 1
 fi
 if [ -n "${PARENT}" ] && git rev-parse --verify --quiet "refs/remotes/origin/cc-epic-${PARENT}" >/dev/null; then
   BASE_BRANCH="cc-epic-${PARENT}"
+fi
+
+# parent が無い場合は upstream（ワーカーが worktree 作成時に --track で記録した分岐元）を使う
+if [ -z "${BASE_BRANCH}" ]; then
+  CURRENT=$(git rev-parse --abbrev-ref HEAD)
+  UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
+  UPSTREAM=${UPSTREAM#origin/}
+  if [ -n "${UPSTREAM}" ] && [ "${UPSTREAM}" != "${CURRENT}" ] \
+    && git rev-parse --verify --quiet "refs/remotes/origin/${UPSTREAM}" >/dev/null; then
+    BASE_BRANCH="${UPSTREAM}"
+  fi
+fi
+
+if [ -z "${BASE_BRANCH}" ]; then
+  BASE_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')
 fi
 
 git status --short

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -117,7 +117,10 @@ export async function createWorktreeFromBranch(worktreeId: string, baseBranch: s
   // detached HEAD だと後段の commit-push スキルの `git push origin HEAD` が
   // refspec を解決できず失敗するため、worktreeId と同名のブランチを切って checkout する。
   // -B を使うことで孤児ブランチが残っていても origin/${baseBranch} から強制再作成して安全に回復できる。
-  await execFileAsync("git", ["worktree", "add", "-B", worktreeId, worktreePath, `origin/${baseBranch}`]);
+  // --track で upstream に origin/${baseBranch} を明示記録する（branch.autoSetupMerge=false 環境でも保証）。
+  // create-pr スキルはこの upstream をPRベースブランチの確定的導出に使うため、省略すると
+  // merge-base 距離推定に落ちて無関係な cc-epic-* ブランチをベースに選ぶことがある。
+  await execFileAsync("git", ["worktree", "add", "--track", "-B", worktreeId, worktreePath, `origin/${baseBranch}`]);
 }
 
 export async function removeWorktree(worktreeId: string): Promise<void> {


### PR DESCRIPTION
## 概要

exec-issue実行時、parentを持たない通常Issueから作成されたPRのベースブランチが、無関係なEpic Issueのブランチ（`cc-epic-*`）に向いてしまうバグを修正します。

### 根本原因

create-prスキルの「分岐元ブランチの推定（merge-base距離）」fallbackにおいて、作業ブランチの分岐点と同一コミットを指すリモートブランチ（作成直後のepicブランチ・並行タスクのPRブランチ等）が存在すると、`origin/main` と距離が**同点**になる。同点時のタイブレークが単純なアルファベット順（`sort -n | head -1`）のため、`origin/cc-epic-*`（c）が `origin/main`（m）より必ず先に採用されていた。

epicブランチは `ensureEpicBranch` がその時点の `origin/main` から派生作成し、epic完了まで長期間残るため、「epicが進行中の間に起動された通常Issueのタスク」は高確率でこの条件を踏む。scratchリポジトリでの再現確認済み：

```
--- fallback simulation（epicブランチがmainと同一コミットの状態）---
1 origin/cc-epic-7   ← sort -n | head -1 でこちらが選ばれる
1 origin/main
```

### 修正内容

推定に頼らず、ワーカーが知っている「実際の分岐元」を確定情報としてスキルに引き継ぐ構成に変更：

1. **`src/worktree.ts`**: `git worktree add` に `--track` を追加し、upstreamに分岐元（`origin/main` / `origin/cc-epic-<N>`）を確実に記録する（`branch.autoSetupMerge=false` 環境でも保証される）
2. **`plugin/skills/create-pr/SKILL.md`**: ベースブランチ決定を「①parentからのepic導出 → ②upstreamからの確定的導出（新設） → ③merge-base推定」の3段階に変更。③のタイブレークもデフォルトブランチ優先に修正
3. **`plugin/skills/exec-issue/SKILL.md`**: フェーズ6の差分基準ブランチ決定も同じ導出ロジックに統一

## 変更内容

- `createWorktreeFromBranch` の `git worktree add` に `--track` を追加
- create-prスキルにupstreamベースの確定的導出ステップを追加
- merge-base推定のタイブレークをデフォルトブランチ優先に変更
- exec-issueフェーズ6の `BASE_BRANCH` 導出をcreate-prと同一ロジックに統一

## 関連Issue

なし（ユーザー報告による修正）

## テスト内容

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`（既存の未整形ファイル `claude-task-worker.json` の警告のみ。今回の変更ファイルは問題なし）
- [x] 動作確認: scratchリポジトリで以下を検証
  - 修正前のfallbackがタイブレークで `cc-epic-7` を選ぶことを再現
  - `--track` 付き `git worktree add` がupstreamを記録すること（`branch.autoSetupMerge=false` でも有効）
  - upstream導出が `main` / `cc-epic-7` をそれぞれ正しく返すこと
  - 修正後のfallbackが同点時に `main` を優先すること

## その他の確認事項

- [x] 破壊的変更なし（README.md / CLAUDE.md の更新不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - PR作成時のベースブランチ判定を改善し、関連する追跡ブランチを優先して選択するようになりました。
  - 適切な追跡ブランチを確認できない場合は、デフォルトブランチへ自動的にフォールバックします。
  - 複数候補の優先順位を見直し、同条件ではデフォルトブランチが選ばれやすくなりました。
  - Worktree作成時に元ブランチを追跡する設定が追加され、後続処理でのブランチ判定がより安定します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->