### PR TITLE
chore(plugin): Bump version to 0.2.5

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-task-worker",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "claude-task-worker と組み合わせて使う getty104's base tool set (skills/agents/hooks)",
   "author": {
     "name": "getty104"


### PR DESCRIPTION
claude-task-worker プラグインのバージョンを 0.2.4 から 0.2.5 に更新（patch bump）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * プラグインのバージョンを **0.2.5** に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->