### PR TITLE
fix: publishワークフローのnpmをv11にピン留めしてsigstoreバグを回避

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # npm@latest (12.0.0) is missing bundled sigstore and breaks --provenance publish
+      # (npm/cli#9722). Pin to npm 11 (>= 11.5.1 supports trusted publishing) until fixed.
       - name: Ensure npm supports trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## 概要

`npm publish --provenance` が以下のエラーで失敗する問題の修正です。

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
```

## 原因

- publish.yml の「Ensure npm supports trusted publishing (OIDC)」ステップが `npm install -g npm@latest` を実行している
- `npm@latest` が 12.0.0 に更新されたが、npm 12.0.0 の公開tarballにはルートの `node_modules/sigstore/` が同梱されないパッケージングバグがある ([npm/cli#9722](https://github.com/npm/cli/issues/9722))
- その結果 `libnpmpublish/lib/provenance.js` の `require('sigstore')` が解決できず、`--provenance` 付き publish がクラッシュする

## 対応

- `npm install -g npm@latest` → `npm install -g npm@11` にピン留め
- npm 11 系 (現在 11.18.0) は sigstore が正しく同梱されており、trusted publishing / OIDC に必要な npm >= 11.5.1 も満たす
- npm 側の修正 ([npm/cli#9740](https://github.com/npm/cli/pull/9740)) がリリースされたら `@latest` に戻してよい

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * パッケージ公開時に発生する署名・検証関連のエラーを修正しました。
  * npm の使用バージョンを安定したバージョン系列に固定し、公開処理の再現性と信頼性を向上させました。
  * これにより、リリース時の公開失敗が発生しにくくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->