### PR TITLE
feat: projects.json のロード・検証・対象プロジェクト解決

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "tsc --noEmit --watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "node --experimental-strip-types --test src/**/*.test.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepublishOnly": "npm run build"

--- a/src/projects-config.test.ts
+++ b/src/projects-config.test.ts
@@ -1,0 +1,95 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type * as ProjectsConfigModule from "./projects-config";
+
+const configHome = mkdtempSync(join(tmpdir(), "ptw-config-"));
+process.env.XDG_CONFIG_HOME = configHome;
+
+const projectsConfigModulePath = ["./projects-config", "ts"].join(".");
+const { loadProjectsConfig, resolveTargetProjects, ProjectsConfigError, PROJECTS_CONFIG_PATH } = (await import(
+  projectsConfigModulePath
+)) as typeof ProjectsConfigModule;
+
+const configDir = join(configHome, "claude-task-worker");
+
+function writeConfigFile(content: string): void {
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(PROJECTS_CONFIG_PATH, content, "utf-8");
+}
+
+test("loadProjectsConfig throws ProjectsConfigError when raw JSON is null", () => {
+  writeConfigFile("null");
+  assert.throws(() => loadProjectsConfig(), ProjectsConfigError);
+});
+
+test("loadProjectsConfig throws ProjectsConfigError when raw JSON is an array", () => {
+  writeConfigFile("[]");
+  assert.throws(() => loadProjectsConfig(), ProjectsConfigError);
+});
+
+test("loadProjectsConfig throws ProjectsConfigError when raw JSON is a string primitive", () => {
+  writeConfigFile('"hello"');
+  assert.throws(() => loadProjectsConfig(), ProjectsConfigError);
+});
+
+test("loadProjectsConfig throws ProjectsConfigError when raw JSON is a number primitive", () => {
+  writeConfigFile("42");
+  assert.throws(() => loadProjectsConfig(), ProjectsConfigError);
+});
+
+test("loadProjectsConfig does not treat Object.prototype members as valid projectGroups members", () => {
+  writeConfigFile(
+    JSON.stringify({
+      projects: {
+        alpha: process.cwd(),
+      },
+      projectGroups: {
+        mygroup: ["alpha", "toString", "constructor", "hasOwnProperty"],
+      },
+    }),
+  );
+  const config = loadProjectsConfig();
+  assert.deepEqual(config.projectGroups["mygroup"], ["alpha"]);
+});
+
+test("loadProjectsConfig loads a valid projects.json normally", () => {
+  writeConfigFile(
+    JSON.stringify({
+      projects: {
+        alpha: process.cwd(),
+      },
+      projectGroups: {
+        mygroup: ["alpha"],
+      },
+    }),
+  );
+  const config = loadProjectsConfig();
+  assert.deepEqual(config.projects, { alpha: process.cwd() });
+  assert.deepEqual(config.projectGroups, { mygroup: ["alpha"] });
+});
+
+test("resolveTargetProjects throws ProjectsConfigError for constructor/toString requests", () => {
+  const config = {
+    projects: { alpha: "/tmp/alpha" },
+    projectGroups: { mygroup: ["alpha"] },
+  };
+  assert.throws(() => resolveTargetProjects(["constructor"], config), ProjectsConfigError);
+  assert.throws(() => resolveTargetProjects(["toString"], config), ProjectsConfigError);
+  assert.throws(() => resolveTargetProjects(["hasOwnProperty"], config), ProjectsConfigError);
+});
+
+test("resolveTargetProjects resolves known projects and groups normally", () => {
+  const config = {
+    projects: { alpha: "/tmp/alpha", beta: "/tmp/beta" },
+    projectGroups: { mygroup: ["alpha", "beta"] },
+  };
+  const resolved = resolveTargetProjects(["mygroup"], config);
+  assert.deepEqual(resolved.map((r) => r.name).sort(), ["alpha", "beta"]);
+});
+
+test("cleanup temp config dir", () => {
+  rmSync(configHome, { recursive: true, force: true });
+});

--- a/src/projects-config.ts
+++ b/src/projects-config.ts
@@ -1,0 +1,154 @@
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+const RESERVED_ALL = "all";
+
+export interface ProjectsConfig {
+  projects: Record<string, string>;
+  projectGroups: Record<string, string[]>;
+}
+
+export interface ResolvedProject {
+  name: string;
+  path: string;
+}
+
+export class ProjectsConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProjectsConfigError";
+  }
+}
+
+function getProjectsConfigPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const configHome = xdg && xdg.length > 0 ? xdg : join(homedir(), ".config");
+  return join(configHome, "claude-task-worker", "projects.json");
+}
+
+export const PROJECTS_CONFIG_PATH = getProjectsConfigPath();
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function loadProjectsConfig(): ProjectsConfig {
+  const configPath = PROJECTS_CONFIG_PATH;
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new ProjectsConfigError(`projects.json not found: ${configPath}`);
+    }
+    if (err instanceof SyntaxError) {
+      throw new ProjectsConfigError(`projects.json contains invalid JSON: ${configPath}: ${err.message}`);
+    }
+    throw err;
+  }
+
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new ProjectsConfigError(`projects.json must contain a JSON object: ${configPath}`);
+  }
+
+  if (!("projects" in raw) || typeof raw["projects"] !== "object" || raw["projects"] === null) {
+    throw new ProjectsConfigError(`projects.json must contain a "projects" section: ${configPath}`);
+  }
+
+  const rawProjects = raw["projects"] as Record<string, unknown>;
+  const rawProjectGroups =
+    "projectGroups" in raw && typeof raw["projectGroups"] === "object" && raw["projectGroups"] !== null
+      ? (raw["projectGroups"] as Record<string, unknown>)
+      : {};
+
+  const projectKeys = Object.keys(rawProjects);
+  const groupKeys = Object.keys(rawProjectGroups);
+
+  if (projectKeys.includes(RESERVED_ALL) || groupKeys.includes(RESERVED_ALL)) {
+    throw new ProjectsConfigError(
+      `"${RESERVED_ALL}" is a reserved word and cannot be used as a key in "projects" or "projectGroups"`,
+    );
+  }
+
+  const groupKeySet = new Set(groupKeys);
+  const duplicateKeys = projectKeys.filter((key) => groupKeySet.has(key));
+  if (duplicateKeys.length > 0) {
+    throw new ProjectsConfigError(
+      `"projects" and "projectGroups" share the same key namespace; duplicate keys are not allowed: ${duplicateKeys.join(", ")}`,
+    );
+  }
+
+  const projects: Record<string, string> = {};
+  for (const [name, value] of Object.entries(rawProjects)) {
+    if (typeof value !== "string" || !isAbsolute(value)) {
+      console.warn(`[projects-config] invalid projects.${name}: expected an absolute path, skipping`);
+      continue;
+    }
+    if (!isDirectory(value)) {
+      console.warn(`[projects-config] projects.${name} does not exist as a directory: ${value}, skipping`);
+      continue;
+    }
+    projects[name] = value;
+  }
+
+  const projectGroups: Record<string, string[]> = {};
+  for (const [groupName, value] of Object.entries(rawProjectGroups)) {
+    if (!Array.isArray(value)) {
+      console.warn(`[projects-config] invalid projectGroups.${groupName}: expected an array, skipping`);
+      continue;
+    }
+    const members: string[] = [];
+    for (const member of value) {
+      if (typeof member !== "string" || !Object.prototype.hasOwnProperty.call(projects, member)) {
+        console.warn(
+          `[projects-config] projectGroups.${groupName} references unknown project "${String(member)}", skipping`,
+        );
+        continue;
+      }
+      members.push(member);
+    }
+    projectGroups[groupName] = members;
+  }
+
+  return { projects, projectGroups };
+}
+
+export function resolveTargetProjects(requested: string[], config: ProjectsConfig): ResolvedProject[] {
+  const resolved = new Map<string, ResolvedProject>();
+
+  for (const name of requested) {
+    if (name === RESERVED_ALL) {
+      for (const [projectName, projectPath] of Object.entries(config.projects)) {
+        resolved.set(projectName, { name: projectName, path: projectPath });
+      }
+      continue;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(config.projects, name)) {
+      resolved.set(name, { name, path: config.projects[name] });
+      continue;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(config.projectGroups, name)) {
+      for (const projectName of config.projectGroups[name]) {
+        const projectPath = config.projects[projectName];
+        if (projectPath === undefined) continue;
+        resolved.set(projectName, { name: projectName, path: projectPath });
+      }
+      continue;
+    }
+
+    const availableProjects = Object.keys(config.projects).join(", ") || "(none)";
+    const availableGroups = Object.keys(config.projectGroups).join(", ") || "(none)";
+    throw new ProjectsConfigError(
+      `Unknown project or group: "${name}". Available projects: ${availableProjects}. Available groups: ${availableGroups}.`,
+    );
+  }
+
+  return Array.from(resolved.values());
+}


### PR DESCRIPTION
## 概要

`projects.json` 設定ファイルを読み込み・検証し、`--project` 指定から対象プロジェクトを解決する `projects-config.ts` を追加する。

## 変更内容

- `src/projects-config.ts` を新規追加
  - `loadProjectsConfig()`: `$XDG_CONFIG_HOME/claude-task-worker/projects.json`（未設定時は `~/.config/claude-task-worker/projects.json`）を読み込み、`projects` / `projectGroups` のネスト構造を検証
    - ファイル不在・JSON構文エラーは `ProjectsConfigError` として送出
    - JSONのトップレベルが非オブジェクト（`null` / 配列 / プリミティブ）の場合も `ProjectsConfigError` として送出
    - 予約語 `all` の使用、`projects` と `projectGroups` のキー名前空間重複はエラー
    - 各プロジェクトパスは絶対パスかつ実在ディレクトリであることを検証し、不正なエントリは警告ログを出して除外
    - `projectGroups` の各メンバーは `projects` に存在する自プロパティ（`Object.prototype` 由来のプロパティを除く）のみ採用し、それ以外は警告ログを出して除外
  - `resolveTargetProjects(requested, config)`: `--project` の指定値（プロジェクト名 / グループ名 / 予約語 `all`）を実際のプロジェクト一覧（名前・パス）に解決
    - 未知の名前・グループはエラーメッセージに利用可能な候補一覧を含めて送出
    - `Object.prototype` 由来のプロパティ名（`constructor` / `toString` 等）を指定しても存在するプロジェクト/グループとして誤判定しない
- `src/projects-config.test.ts` を新規追加（`node:test` によるユニットテスト9件）
- `package.json` に `scripts.test`（`node --experimental-strip-types --test src/**/*.test.ts`）を追加

## 関連Issue

Closes #60

## テスト内容

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test`（`src/projects-config.test.ts` 9件すべてpass）

## その他の確認事項

- [ ] 破壊的変更がある場合、README.md / CLAUDE.md を更新した

## 修正履歴

### 2026-07-11: レビュー指摘対応（1件）
- CI の `build / Format check` が `src/projects-config.test.ts` のPrettier整形不整合で失敗していた問題を修正。`npx prettier --write src/projects-config.test.ts` で整形のみ実施し、ロジック変更はなし（対応コミット: f4a7057）

### 2026-07-11: レビュー指摘対応（3件）
- `JSON.parse` 結果が非オブジェクト（`null`・配列・プリミティブ）の場合に `"projects" in raw` が `TypeError` を送出しクラッシュしうる問題を修正。`JSON.parse` 直後に型ガードを追加し `ProjectsConfigError` として統一的にハンドリングするようにした（対応コミット: e125f4d）
- `projectGroups` メンバー検証で `member in projects` を使用しており `Object.prototype` 由来のプロパティ（`toString` 等）を誤って有効なメンバーとして採用してしまう問題を修正。`Object.prototype.hasOwnProperty.call` による自プロパティ判定に置き換えた（対応コミット: e125f4d）
- `resolveTargetProjects` 内の `name in config.projects` / `name in config.projectGroups` も同様のプロトタイプ汚染により `--project constructor` 等の入力を誤って解決してしまう問題を修正。両箇所とも `Object.prototype.hasOwnProperty.call` に置き換えた（対応コミット: e125f4d）
- あわせて `node:test` によるユニットテストを新規追加し、上記3ケースを含む回帰防止を行った（対応コミット: e125f4d）
