### PR TITLE
feat: --project ディスパッチ用CLI引数ヘルパーを追加

### DIFF
--- a/src/dispatch-args.ts
+++ b/src/dispatch-args.ts
@@ -1,0 +1,47 @@
+const PROJECT_INCOMPATIBLE_COMMANDS = ["init", "install", "update", "usage", "version"];
+
+function collectFlagValues(argv: string[], flag: string): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] !== flag) continue;
+    const raw = argv[i + 1];
+    if (!raw || raw.startsWith("--")) {
+      console.error(`${flag} requires a value`);
+      process.exit(1);
+    }
+    values.push(raw);
+  }
+  return values;
+}
+
+export function parseProjectFilters(): string[] {
+  return collectFlagValues(process.argv, "--project");
+}
+
+export function hasProjectFilter(): boolean {
+  return process.argv.includes("--project");
+}
+
+export function assertProjectCompatibleCommand(command: string): void {
+  if (PROJECT_INCOMPATIBLE_COMMANDS.includes(command)) {
+    console.error(`--project cannot be used with the "${command}" command`);
+    process.exit(1);
+  }
+}
+
+export function shellQuote(value: string): string {
+  if (value === "") return "''";
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function buildForwardedCommand(argv: string[]): string {
+  const tokens: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--project") {
+      i++;
+      continue;
+    }
+    tokens.push(argv[i]);
+  }
+  return ["claude-task-worker", ...tokens.map(shellQuote)].join(" ");
+}


### PR DESCRIPTION
## 概要

`--project` オプションの値収集・コマンド互換検証・転送コマンド文字列生成を行う純粋ヘルパー群を新規 `src/dispatch-args.ts` に追加する。dispatcher（未実装）が herdr pane へ送信するコマンドを組み立てる際の基盤となる。

## 変更内容

- `src/dispatch-args.ts` を新規追加
  - `parseProjectFilters()`: `--project` の繰り返し指定を収集する
  - `hasProjectFilter()`: `--project` 指定の有無を判定する
  - `assertProjectCompatibleCommand(command)`: `init` / `install` / `update` / `usage` / `version` と `--project` の併用をエラー終了させる
  - `buildForwardedCommand(argv)`: `--project <value>` の2トークン組のみ除去し、各トークンをシェルエスケープして `claude-task-worker <command> <flags>` を再構成する
  - `shellQuote(value)`: POSIXシングルクォート方式のシェルエスケープを自前実装（npm依存追加を回避）

## 関連Issue

Closes #62

## テスト内容

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] 動作確認（該当する場合、確認手順を記述）

## その他の確認事項

- [ ] 破壊的変更がある場合、README.md / CLAUDE.md を更新した