### PR TITLE
refactor: extract table display-width helpers into src/table.ts

### DIFF
--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -1,59 +1,13 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { getWorkerConfig } from "./config.js";
+import { getDisplayWidth, truncateToWidth, padToWidth } from "./table.js";
 
 type TaskStatus = "running" | "completed" | "failed";
 
 const childProcesses = new Map<number, ChildProcess>();
 
 const TASK_TIMEOUT_MS = 90 * 60 * 1000;
-
-function getDisplayWidth(str: string): number {
-  let width = 0;
-  for (const char of str) {
-    const code = char.codePointAt(0)!;
-    if (
-      (code >= 0x1100 && code <= 0x115f) ||
-      (code >= 0x2e80 && code <= 0x303e) ||
-      (code >= 0x3040 && code <= 0x33bf) ||
-      (code >= 0x3400 && code <= 0x4dbf) ||
-      (code >= 0x4e00 && code <= 0xa4cf) ||
-      (code >= 0xac00 && code <= 0xd7af) ||
-      (code >= 0xf900 && code <= 0xfaff) ||
-      (code >= 0xfe30 && code <= 0xfe6f) ||
-      (code >= 0xff01 && code <= 0xff60) ||
-      (code >= 0xffe0 && code <= 0xffe6) ||
-      (code >= 0x20000 && code <= 0x2fffd) ||
-      (code >= 0x30000 && code <= 0x3fffd)
-    ) {
-      width += 2;
-    } else {
-      width += 1;
-    }
-  }
-  return width;
-}
-
-function truncateToWidth(str: string, maxWidth: number): string {
-  let width = 0;
-  let i = 0;
-  const chars = [...str];
-  while (i < chars.length) {
-    const charWidth = getDisplayWidth(chars[i]);
-    if (width + charWidth > maxWidth - 3) {
-      return chars.slice(0, i).join("") + "...";
-    }
-    width += charWidth;
-    i++;
-  }
-  return str;
-}
-
-function padToWidth(str: string, targetWidth: number): string {
-  const currentWidth = getDisplayWidth(str);
-  const padding = targetWidth - currentWidth;
-  return padding > 0 ? str + " ".repeat(padding) : str;
-}
 
 interface TaskEntry {
   id: number;

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,0 +1,46 @@
+export function getDisplayWidth(str: string): number {
+  let width = 0;
+  for (const char of str) {
+    const code = char.codePointAt(0)!;
+    if (
+      (code >= 0x1100 && code <= 0x115f) ||
+      (code >= 0x2e80 && code <= 0x303e) ||
+      (code >= 0x3040 && code <= 0x33bf) ||
+      (code >= 0x3400 && code <= 0x4dbf) ||
+      (code >= 0x4e00 && code <= 0xa4cf) ||
+      (code >= 0xac00 && code <= 0xd7af) ||
+      (code >= 0xf900 && code <= 0xfaff) ||
+      (code >= 0xfe30 && code <= 0xfe6f) ||
+      (code >= 0xff01 && code <= 0xff60) ||
+      (code >= 0xffe0 && code <= 0xffe6) ||
+      (code >= 0x20000 && code <= 0x2fffd) ||
+      (code >= 0x30000 && code <= 0x3fffd)
+    ) {
+      width += 2;
+    } else {
+      width += 1;
+    }
+  }
+  return width;
+}
+
+export function truncateToWidth(str: string, maxWidth: number): string {
+  let width = 0;
+  let i = 0;
+  const chars = [...str];
+  while (i < chars.length) {
+    const charWidth = getDisplayWidth(chars[i]);
+    if (width + charWidth > maxWidth - 3) {
+      return chars.slice(0, i).join("") + "...";
+    }
+    width += charWidth;
+    i++;
+  }
+  return str;
+}
+
+export function padToWidth(str: string, targetWidth: number): string {
+  const currentWidth = getDisplayWidth(str);
+  const padding = targetWidth - currentWidth;
+  return padding > 0 ? str + " ".repeat(padding) : str;
+}


### PR DESCRIPTION
Closes #63

## 概要

ステータステーブル描画で使用しているCJK幅対応の表示幅計算ヘルパーを `src/process-manager.ts` から `src/table.ts` に切り出し、共有モジュール化した。

## 変更内容

- `src/table.ts` を新規作成し、表示幅計算関連のヘルパー関数を移動
- `src/process-manager.ts` から該当ロジックを削除し、`src/table.ts` からインポートするよう変更

## 関連Issue

Closes #63

## テスト内容

- [x] `npm run build`
- [ ] `npm run lint`
- [ ] `npm run format:check`
- [ ] 動作確認（該当する場合、確認手順を記述）

## その他の確認事項

- [ ] 破壊的変更がある場合、README.md / CLAUDE.md を更新した