### PR TITLE
feat: herdr CLIラッパー（tab/pane管理、JSON パース・error判定の集約）

### DIFF
--- a/src/herdr.test.ts
+++ b/src/herdr.test.ts
@@ -1,0 +1,67 @@
+import { test, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import type * as ChildProcess from "node:child_process";
+import type * as HerdrModule from "./herdr";
+
+const childProcess = createRequire(import.meta.url)("node:child_process") as typeof ChildProcess;
+
+const herdrModulePath = ["./herdr", "ts"].join(".");
+const { tabCreate, tabList, paneProcessInfo } = (await import(herdrModulePath)) as typeof HerdrModule;
+
+type ExecFileCallback = (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void;
+
+function mockExecFile(t: TestContext, stdout: string, stderr: string): void {
+  t.mock.method(childProcess, "execFile", (_command: string, _args: string[], callback: ExecFileCallback) => {
+    callback(null, stdout, stderr);
+  });
+}
+
+test("execHerdr includes stderr content in the error message when stdout is invalid JSON", async (t) => {
+  mockExecFile(t, "not json", "herdr: connection refused");
+  await assert.rejects(tabList(), (error: Error) => {
+    assert.match(error.message, /invalid JSON output/);
+    assert.match(error.message, /herdr: connection refused/);
+    return true;
+  });
+});
+
+test("tabCreate throws an explicit error when root_pane is missing from the response", async (t) => {
+  mockExecFile(t, JSON.stringify({ result: { tab: { tab_id: "tab-1" } } }), "");
+  await assert.rejects(
+    tabCreate({ label: "test", cwd: "/tmp" }),
+    /Failed to create tab: invalid response structure from herdr/,
+  );
+});
+
+test("tabCreate throws an explicit error when tab is missing from the response", async (t) => {
+  mockExecFile(t, JSON.stringify({ result: { root_pane: { pane_id: "pane-1" } } }), "");
+  await assert.rejects(
+    tabCreate({ label: "test", cwd: "/tmp" }),
+    /Failed to create tab: invalid response structure from herdr/,
+  );
+});
+
+test("tabList returns an empty array when tabs is not an array", async (t) => {
+  mockExecFile(t, JSON.stringify({ result: { tabs: "not-an-array" } }), "");
+  const result = await tabList();
+  assert.deepEqual(result, []);
+});
+
+test("tabList returns an empty array when result is null", async (t) => {
+  mockExecFile(t, JSON.stringify({ result: null }), "");
+  const result = await tabList();
+  assert.deepEqual(result, []);
+});
+
+test("paneProcessInfo returns an empty foregroundProcesses array when process_info is missing", async (t) => {
+  mockExecFile(t, JSON.stringify({ result: {} }), "");
+  const result = await paneProcessInfo("pane-1");
+  assert.deepEqual(result, { foregroundProcesses: [] });
+});
+
+test("paneProcessInfo returns an empty foregroundProcesses array when foreground_processes is missing", async (t) => {
+  mockExecFile(t, JSON.stringify({ result: { process_info: {} } }), "");
+  const result = await paneProcessInfo("pane-1");
+  assert.deepEqual(result, { foregroundProcesses: [] });
+});

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -1,0 +1,157 @@
+import { createRequire } from "node:module";
+import type * as ChildProcess from "node:child_process";
+
+const childProcess = createRequire(import.meta.url)("node:child_process") as typeof ChildProcess;
+
+export interface TabInfo {
+  tabId: string;
+  label: string;
+  workspaceId: string;
+}
+
+export interface PaneProcessInfo {
+  foregroundProcesses: {
+    name: string;
+    argv: string[];
+    cmdline: string;
+    pid: number;
+  }[];
+}
+
+interface HerdrErrorPayload {
+  code: string;
+  message: string;
+}
+
+interface HerdrResponse {
+  result?: unknown;
+  error?: HerdrErrorPayload;
+}
+
+export class HerdrUnavailableError extends Error {
+  readonly reason: "not-installed" | "server-unreachable";
+
+  constructor(message: string, reason: "not-installed" | "server-unreachable") {
+    super(message);
+    this.name = "HerdrUnavailableError";
+    this.reason = reason;
+  }
+}
+
+interface HerdrRawResult {
+  execError: NodeJS.ErrnoException | null;
+  parsed: HerdrResponse | undefined;
+  stderr: string;
+}
+
+// herdr は error 発生時も終了コード0を返すため、execFile の成否ではなく
+// stdout の JSON パース結果（parsed）と error.code の両方を呼び出し側で判定させる。
+function runHerdr(args: string[]): Promise<HerdrRawResult> {
+  return new Promise((resolve) => {
+    childProcess.execFile("herdr", args, (error, stdout, stderr) => {
+      let parsed: HerdrResponse | undefined;
+      try {
+        parsed = JSON.parse(stdout) as HerdrResponse;
+      } catch {
+        parsed = undefined;
+      }
+      resolve({ execError: error as NodeJS.ErrnoException | null, parsed, stderr });
+    });
+  });
+}
+
+async function execHerdr(args: string[]): Promise<unknown> {
+  const { execError, parsed, stderr } = await runHerdr(args);
+  const stderrSuffix = stderr.trim() ? `: ${stderr.trim()}` : "";
+  // stdout に有効な error JSON が乗っているケースは execFile の失敗より優先して扱う。
+  if (parsed?.error) {
+    throw new Error(`herdr ${args.join(" ")} failed: [${parsed.error.code}] ${parsed.error.message}`);
+  }
+  if (execError) {
+    throw new Error(`herdr ${args.join(" ")} failed: ${execError.message}${stderrSuffix}`);
+  }
+  if (!parsed) {
+    throw new Error(`herdr ${args.join(" ")} failed: invalid JSON output${stderrSuffix}`);
+  }
+  return parsed.result;
+}
+
+export async function tabCreate({ label, cwd }: { label: string; cwd: string }): Promise<{
+  paneId: string;
+  tabId: string;
+}> {
+  const result = (await execHerdr(["tab", "create", "--label", label, "--cwd", cwd, "--no-focus"])) as
+    | { root_pane?: { pane_id?: string }; tab?: { tab_id?: string } }
+    | null
+    | undefined;
+  const paneId = result?.root_pane?.pane_id;
+  const tabId = result?.tab?.tab_id;
+  if (!paneId || !tabId) {
+    throw new Error("Failed to create tab: invalid response structure from herdr");
+  }
+  return { paneId, tabId };
+}
+
+export async function tabClose(tabId: string): Promise<void> {
+  await execHerdr(["tab", "close", tabId]);
+}
+
+export async function tabList(): Promise<TabInfo[]> {
+  const result = (await execHerdr(["tab", "list"])) as
+    | { tabs?: { tab_id: string; label: string; workspace_id: string }[] }
+    | null
+    | undefined;
+  if (!result || !Array.isArray(result.tabs)) {
+    return [];
+  }
+  return result.tabs.map((tab) => ({
+    tabId: tab.tab_id,
+    label: tab.label,
+    workspaceId: tab.workspace_id,
+  }));
+}
+
+export async function paneSendText(paneId: string, text: string): Promise<void> {
+  await execHerdr(["pane", "send-text", paneId, text]);
+}
+
+export async function paneSendKeys(paneId: string, ...keys: string[]): Promise<void> {
+  await execHerdr(["pane", "send-keys", paneId, ...keys]);
+}
+
+export async function paneProcessInfo(paneId: string): Promise<PaneProcessInfo> {
+  const result = (await execHerdr(["pane", "process-info", "--pane", paneId])) as
+    | {
+        process_info?: {
+          foreground_processes?: { name: string; argv: string[]; cmdline: string; pid: number }[];
+        };
+      }
+    | null
+    | undefined;
+  const foregroundProcesses = result?.process_info?.foreground_processes ?? [];
+  return {
+    foregroundProcesses: foregroundProcesses.map((process) => ({
+      name: process.name,
+      argv: process.argv,
+      cmdline: process.cmdline,
+      pid: process.pid,
+    })),
+  };
+}
+
+export async function checkHerdrAvailable(): Promise<void> {
+  const { execError, parsed } = await runHerdr(["tab", "list"]);
+  if (execError?.code === "ENOENT") {
+    throw new HerdrUnavailableError(
+      "herdrがインストールされていません。herdr CLIをインストールしてください。",
+      "not-installed",
+    );
+  }
+  if (!parsed) {
+    throw new HerdrUnavailableError(
+      "herdrサーバーに接続できませんでした。`herdr status` 等で起動状態を確認してください。",
+      "server-unreachable",
+    );
+  }
+  // parsed に error キーがあっても herdr 自体は稼働中（疎通OK）とみなし、例外を投げない。
+}


### PR DESCRIPTION
## 概要

herdr CLI（ターミナルワークスペースマネージャー）を execFile 経由で包み、JSON レスポンスのパースと error キー判定を集約するラッパー `src/herdr.ts` を新設する。マルチプロジェクトディスパッチ機能（PRD: docs/prd-multi-project-dispatch.md）で今後実装される `src/dispatcher.ts` から利用される基盤モジュール。

## 変更内容

- `src/herdr.ts` を新設し、以下を実装
  - `execHerdr` 内部関数: herdr は error 時も終了コード0を返すため、stdout の JSON.parse 成否と error キー有無のみで成否判定（execFile の ENOENT はJSON内のerrorキー判定より後に扱う）
  - コマンド関数: `tabCreate({label, cwd})` / `tabClose(tabId)` / `tabList()` / `paneSendText(paneId, text)` / `paneSendKeys(paneId, ...keys)` / `paneProcessInfo(paneId)`
  - `tabCreate` は `result.root_pane.pane_id` / `result.tab.tab_id` を `{paneId, tabId}` として返す
  - `tabList` / `paneProcessInfo` は実機確認済みスキーマを camelCase の明示 interface（`TabInfo`, `PaneProcessInfo`）に変換して返す
  - `checkHerdrAvailable()`: (A) ENOENT＝未インストール、(B) JSON.parse失敗＝サーバー未起動/接続不可、(C) error キーあり＝疎通OK、の3層判定
  - `HerdrUnavailableError extends Error`（`readonly reason: "not-installed" | "server-unreachable"`）を新設

## 関連Issue

Closes #61

## テスト内容

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`（`src/herdr.test.ts` を新設し、`node:child_process` の `execFile` をモックしてエラーハンドリング・防御的レスポンス解析をカバー）
- [ ] 動作確認（herdr 実機でのマニュアル検証が必要。E2Eテスト基盤は本リポジトリに存在しない）

## その他の確認事項

- [ ] 破壊的変更がある場合、README.md / CLAUDE.md を更新した（該当なし）

## 修正履歴

### 2026-07-11: レビュー指摘対応（4件）
- `execFile` のコールバックで `stderr` を破棄しておりエラー原因が追跡できなかった問題を修正。`stderr` を取得し、`execError`/JSON不正時のエラーメッセージに付加（対応コミット: 82f33e5）
- `tabCreate` が `execHerdr` の戻り値を無条件キャストし `root_pane.pane_id` / `tab.tab_id` に無防備アクセスしていた問題を修正。オプショナルチェイニング化し、欠落時は明示的なエラーをthrow（対応コミット: 82f33e5）
- `tabList` が `result.tabs.map(...)` を無防備に呼んでおりレスポンス形状不正時に例外落ちしていた問題を修正。`tabs` が配列でない場合は空配列を返すガードを追加（対応コミット: 82f33e5）
- `paneProcessInfo` が `process_info.foreground_processes` に2階層無防備アクセスしていた問題を修正。オプショナルチェイニング＋デフォルト空配列で安全化（対応コミット: 82f33e5）
