### PR TITLE
test: add unit tests for table display-width helpers and run them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Format check
         run: npm run format:check
+
+      - name: Test
+        run: npm test

--- a/src/projects-config.test.ts
+++ b/src/projects-config.test.ts
@@ -8,6 +8,10 @@ import type * as ProjectsConfigModule from "./projects-config";
 const configHome = mkdtempSync(join(tmpdir(), "ptw-config-"));
 process.env.XDG_CONFIG_HOME = configHome;
 
+// node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求する一方、
+// tsc --noEmit（npm run build）は allowImportingTsExtensions が無効なため
+// 静的import文中の .ts 拡張子指定子を許容せず失敗する。両立のため、
+// TSの静的解析対象にならない動的文字列結合でパスを構築している。
 const projectsConfigModulePath = ["./projects-config", "ts"].join(".");
 const { loadProjectsConfig, resolveTargetProjects, ProjectsConfigError, PROJECTS_CONFIG_PATH } = (await import(
   projectsConfigModulePath

--- a/src/table.test.ts
+++ b/src/table.test.ts
@@ -1,0 +1,158 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type * as TableModule from "./table";
+
+const tableModulePath = ["./table", "ts"].join(".");
+const { getDisplayWidth, truncateToWidth, padToWidth } = (await import(tableModulePath)) as typeof TableModule;
+
+test("getDisplayWidth returns 0 for empty string", () => {
+  assert.equal(getDisplayWidth(""), 0);
+});
+
+test("getDisplayWidth treats ASCII characters as width 1", () => {
+  assert.equal(getDisplayWidth("abc"), 3);
+});
+
+test("getDisplayWidth: U+10FF (just before U+1100) is width 1", () => {
+  assert.equal(getDisplayWidth("ჿ"), 1);
+});
+
+test("getDisplayWidth: U+1100 (start of range) is width 2", () => {
+  assert.equal(getDisplayWidth("ᄀ"), 2);
+});
+
+test("getDisplayWidth: U+2E80 (start of range) is width 2", () => {
+  assert.equal(getDisplayWidth("⺀"), 2);
+});
+
+test("getDisplayWidth: U+2E7F (just before U+2E80) is width 1", () => {
+  assert.equal(getDisplayWidth("⹿"), 1);
+});
+
+test("getDisplayWidth: U+3040 (start of range) is width 2", () => {
+  assert.equal(getDisplayWidth("぀"), 2);
+});
+
+test("getDisplayWidth: U+303F (just before U+3040, in the gap after the preceding CJK punctuation range) is width 1", () => {
+  assert.equal(getDisplayWidth("〿"), 1);
+});
+
+test("getDisplayWidth: U+4E00 (start of range) is width 2", () => {
+  assert.equal(getDisplayWidth("一"), 2);
+});
+
+test("getDisplayWidth: U+33BF (just before U+3400, inside preceding range) is width 2", () => {
+  assert.equal(getDisplayWidth("㎿"), 2);
+});
+
+test("getDisplayWidth: U+AC00 (start of range) is width 2", () => {
+  assert.equal(getDisplayWidth("가"), 2);
+});
+
+test("getDisplayWidth: U+ABFF (just before U+AC00) is width 1", () => {
+  assert.equal(getDisplayWidth("꯿"), 1);
+});
+
+test("getDisplayWidth: U+F900 (start of range) is width 2", () => {
+  assert.equal(getDisplayWidth("豈"), 2);
+});
+
+test("getDisplayWidth: U+F8FF (just before U+F900) is width 1", () => {
+  assert.equal(getDisplayWidth(""), 1);
+});
+
+test("getDisplayWidth: U+FE30 (start of range) is width 2", () => {
+  assert.equal(getDisplayWidth("︰"), 2);
+});
+
+test("getDisplayWidth: U+FE2F (just before U+FE30) is width 1", () => {
+  assert.equal(getDisplayWidth("︯"), 1);
+});
+
+test("getDisplayWidth: U+FF01 (start of range) is width 2", () => {
+  assert.equal(getDisplayWidth("！"), 2);
+});
+
+test("getDisplayWidth: U+FF00 (just before U+FF01) is width 1", () => {
+  assert.equal(getDisplayWidth("＀"), 1);
+});
+
+test("getDisplayWidth: U+FF60 (end of range) is width 2", () => {
+  assert.equal(getDisplayWidth("｠"), 2);
+});
+
+test("getDisplayWidth: U+FF61 (just after U+FF60) is width 1", () => {
+  assert.equal(getDisplayWidth("｡"), 1);
+});
+
+test("getDisplayWidth: U+FFE0 (start of range) is width 2", () => {
+  assert.equal(getDisplayWidth("￠"), 2);
+});
+
+test("getDisplayWidth: U+FFDF (just before U+FFE0) is width 1", () => {
+  assert.equal(getDisplayWidth("￟"), 1);
+});
+
+test("getDisplayWidth: U+FFE6 (end of range) is width 2", () => {
+  assert.equal(getDisplayWidth("￦"), 2);
+});
+
+test("getDisplayWidth: U+FFE7 (just after U+FFE6) is width 1", () => {
+  assert.equal(getDisplayWidth("￧"), 1);
+});
+
+test("getDisplayWidth: U+20000 (start of range, surrogate pair) is width 2", () => {
+  assert.equal(getDisplayWidth("\u{20000}"), 2);
+});
+
+test("getDisplayWidth: U+1FFFF (just before U+20000, surrogate pair) is width 1", () => {
+  assert.equal(getDisplayWidth("\u{1ffff}"), 1);
+});
+
+test("getDisplayWidth: U+30000 (start of range, surrogate pair) is width 2", () => {
+  assert.equal(getDisplayWidth("\u{30000}"), 2);
+});
+
+test("getDisplayWidth: U+2FFFF (just before U+30000, in the gap after the preceding range ends at U+2FFFD) is width 1", () => {
+  assert.equal(getDisplayWidth("\u{2ffff}"), 1);
+});
+
+test("getDisplayWidth: U+40000 (just after U+3FFFD range end) is width 1", () => {
+  assert.equal(getDisplayWidth("\u{40000}"), 1);
+});
+
+test("truncateToWidth returns the original string unchanged when within maxWidth", () => {
+  assert.equal(truncateToWidth("abc", 10), "abc");
+});
+
+test("truncateToWidth returns the original string unchanged when its width is comfortably under maxWidth", () => {
+  assert.equal(truncateToWidth("abcde", 8), "abcde");
+});
+
+test("truncateToWidth truncates an ASCII string with an ellipsis when exceeding maxWidth", () => {
+  assert.equal(truncateToWidth("abcdefghij", 5), "ab...");
+});
+
+test("truncateToWidth truncates a full-width (CJK) string with an ellipsis based on display width", () => {
+  assert.equal(truncateToWidth("あいうえお", 6), "あ...");
+});
+
+test("truncateToWidth truncates a mixed half-width/full-width string with an ellipsis", () => {
+  assert.equal(truncateToWidth("aあbいc", 6), "aあ...");
+});
+
+test("padToWidth pads an ASCII string with trailing spaces to reach targetWidth", () => {
+  assert.equal(padToWidth("ab", 5), "ab   ");
+});
+
+test("padToWidth pads a full-width (CJK) string based on display width, not character count", () => {
+  assert.equal(padToWidth("あい", 6), "あい  ");
+});
+
+test("padToWidth returns the string unchanged when its display width already equals targetWidth", () => {
+  assert.equal(padToWidth("あい", 4), "あい");
+});
+
+test("padToWidth returns the string unchanged when its display width already exceeds targetWidth", () => {
+  assert.equal(padToWidth("あいう", 4), "あいう");
+});

--- a/src/table.test.ts
+++ b/src/table.test.ts
@@ -2,6 +2,10 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import type * as TableModule from "./table";
 
+// node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求する一方、
+// tsc --noEmit（npm run build）は allowImportingTsExtensions が無効なため
+// 静的import文中の .ts 拡張子指定子を許容せず失敗する。両立のため、
+// TSの静的解析対象にならない動的文字列結合でパスを構築している。
 const tableModulePath = ["./table", "ts"].join(".");
 const { getDisplayWidth, truncateToWidth, padToWidth } = (await import(tableModulePath)) as typeof TableModule;
 


### PR DESCRIPTION
## 概要

Issue #63（PR #74で完了）で src/process-manager.ts から切り出された純粋関数（getDisplayWidth / truncateToWidth / padToWidth）を対象に、src/table.ts のユニットテストを追加し、CI に test 実行ステップを組み込む。

## 変更内容

- `src/table.test.ts` を新規作成し、node:test + node:assert/strict で getDisplayWidth（CJK幅判定の境界値）/ truncateToWidth（全角混在時の切り詰め）/ padToWidth（表示幅ベースのパディング）を網羅的にテスト
- `.github/workflows/ci.yml` の build ジョブに `npm test` 実行ステップを追加（format:check の後段）
- （参考: プロジェクト側で並行して進んでいた変更として `src/dispatch-args.ts` / `src/projects-config.ts` 等も含まれる）

## 関連Issue

Closes #72

## テスト内容

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`（47件全て pass）

## その他の確認事項

- [x] 破壊的変更なし

## 修正履歴

### 2026-07-11: レビュー指摘対応（1件）
- `src/table.test.ts` / `src/projects-config.test.ts` で拡張子を動的に文字列結合してimportしている理由（`node --experimental-strip-types` によるテスト実行と `tsc --noEmit` によるビルドの両立のため）を説明するコメントを追加（対応コミット: d4352ff）