### PR TITLE
feat: dispatcherにセッション監視ループと稼働ワーカー一覧表示を追加

### DIFF
--- a/src/dispatcher.test.ts
+++ b/src/dispatcher.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import type * as ChildProcess from "node:child_process";
 import type * as DispatcherModule from "./dispatcher";
+import type * as HerdrModule from "./herdr";
 import type { ResolvedProject } from "./projects-config";
 
 const childProcess = createRequire(import.meta.url)("node:child_process") as typeof ChildProcess;
@@ -12,7 +13,9 @@ const childProcess = createRequire(import.meta.url)("node:child_process") as typ
 // 静的import文中の .ts 拡張子指定子を許容せず失敗する。両立のため、
 // TSの静的解析対象にならない動的文字列結合でパスを構築している。
 const dispatcherModulePath = ["./dispatcher", "ts"].join(".");
-const { runDispatcher } = (await import(dispatcherModulePath)) as typeof DispatcherModule;
+const { runDispatcher, pollOnce, monitorSessions } = (await import(dispatcherModulePath)) as typeof DispatcherModule;
+const herdrModulePath = ["./herdr", "ts"].join(".");
+const { HerdrError } = (await import(herdrModulePath)) as typeof HerdrModule;
 
 type ExecFileCallback = (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void;
 
@@ -171,4 +174,136 @@ test("closes the dangling tab when sending the command to a created tab fails", 
   assert.ok(!sessions.has("broken-app"));
   assert.deepEqual(closedTabIds, ["tab-broken-app"]);
   assert.ok(errorLogs.some((line) => line.startsWith('[dispatcher] failed to dispatch project "broken-app"')));
+});
+
+function mockTabClose(t: TestContext, closedTabIds: string[]): void {
+  t.mock.method(childProcess, "execFile", (_command: string, args: string[], callback: ExecFileCallback) => {
+    if (args[0] === "tab" && args[1] === "close") {
+      closedTabIds.push(args[2]);
+      callback(null, JSON.stringify({ result: null }), "");
+      return;
+    }
+    callback(new Error(`unexpected herdr args: ${args.join(" ")}`), "", "");
+  });
+}
+
+function makeSession(overrides: Partial<DispatcherModule.WorkerSession> = {}): DispatcherModule.WorkerSession {
+  return {
+    name: "my-app",
+    tabId: "tab-my-app",
+    paneId: "pane-my-app",
+    startedAt: new Date(),
+    status: "running",
+    ...overrides,
+  };
+}
+
+test("pollOnce keeps a session that still has a claude-task-worker foreground process", async () => {
+  const session = makeSession();
+  const sessions: DispatcherModule.SessionRegistry = new Map([[session.name, session]]);
+  const fakeHerdr = {
+    HerdrError,
+    paneProcessInfo: async () => ({
+      foregroundProcesses: [{ name: "node", argv: [], cmdline: "claude-task-worker exec-issue", pid: 123 }],
+    }),
+  } as unknown as typeof HerdrModule;
+
+  await pollOnce(sessions, fakeHerdr);
+
+  assert.equal(sessions.size, 1);
+  assert.ok(sessions.has("my-app"));
+});
+
+test("pollOnce removes a session and closes the tab when the pane returned to the shell", async (t) => {
+  const closedTabIds: string[] = [];
+  mockTabClose(t, closedTabIds);
+  const session = makeSession();
+  const sessions: DispatcherModule.SessionRegistry = new Map([[session.name, session]]);
+  const fakeHerdr = {
+    HerdrError,
+    paneProcessInfo: async () => ({
+      foregroundProcesses: [{ name: "zsh", argv: [], cmdline: "zsh", pid: 123 }],
+    }),
+  } as unknown as typeof HerdrModule;
+
+  await pollOnce(sessions, fakeHerdr);
+
+  assert.equal(sessions.size, 0);
+  assert.deepEqual(closedTabIds, ["tab-my-app"]);
+});
+
+test("pollOnce removes a session without closing the tab when the pane is gone", async (t) => {
+  const closedTabIds: string[] = [];
+  mockTabClose(t, closedTabIds);
+  const session = makeSession();
+  const sessions: DispatcherModule.SessionRegistry = new Map([[session.name, session]]);
+  const fakeHerdr = {
+    HerdrError,
+    paneProcessInfo: async () => {
+      throw new HerdrError("herdr pane process-info failed: [pane_not_found] no such pane", "pane_not_found");
+    },
+  } as unknown as typeof HerdrModule;
+
+  await pollOnce(sessions, fakeHerdr);
+
+  assert.equal(sessions.size, 0);
+  assert.deepEqual(closedTabIds, []);
+});
+
+test("pollOnce keeps a session and logs on a transient error other than pane_not_found", async (t) => {
+  const session = makeSession();
+  const sessions: DispatcherModule.SessionRegistry = new Map([[session.name, session]]);
+  const errorLogs: string[] = [];
+  t.mock.method(console, "error", (message: string) => {
+    errorLogs.push(message);
+  });
+  const fakeHerdr = {
+    HerdrError,
+    paneProcessInfo: async () => {
+      throw new HerdrError("herdr pane process-info failed: [internal] boom", "internal");
+    },
+  } as unknown as typeof HerdrModule;
+
+  await pollOnce(sessions, fakeHerdr);
+
+  assert.equal(sessions.size, 1);
+  assert.ok(sessions.has("my-app"));
+  assert.ok(errorLogs.some((line) => line.startsWith('[dispatcher] failed to poll session "my-app"')));
+});
+
+test("monitorSessions resolves done once all sessions disappear", async (t) => {
+  const closedTabIds: string[] = [];
+  mockTabClose(t, closedTabIds);
+  const session = makeSession();
+  const sessions: DispatcherModule.SessionRegistry = new Map([[session.name, session]]);
+  const fakeHerdr = {
+    HerdrError,
+    paneProcessInfo: async () => ({
+      foregroundProcesses: [{ name: "zsh", argv: [], cmdline: "zsh", pid: 123 }],
+    }),
+  } as unknown as typeof HerdrModule;
+
+  const handle = monitorSessions(sessions, fakeHerdr, { pollIntervalMs: 5, renderIntervalMs: 1000 });
+
+  await handle.done;
+
+  assert.equal(sessions.size, 0);
+});
+
+test("monitorSessions stop() clears intervals and resolves done", async () => {
+  const session = makeSession();
+  const sessions: DispatcherModule.SessionRegistry = new Map([[session.name, session]]);
+  const fakeHerdr = {
+    HerdrError,
+    paneProcessInfo: async () => ({
+      foregroundProcesses: [{ name: "node", argv: [], cmdline: "claude-task-worker exec-issue", pid: 123 }],
+    }),
+  } as unknown as typeof HerdrModule;
+
+  const handle = monitorSessions(sessions, fakeHerdr, { pollIntervalMs: 1000, renderIntervalMs: 1000 });
+  handle.stop();
+
+  await handle.done;
+
+  assert.equal(sessions.size, 1);
 });

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -1,4 +1,5 @@
 import type * as HerdrModule from "./herdr";
+import type * as TableModule from "./table";
 import type { ResolvedProject } from "./projects-config";
 
 // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求する一方、
@@ -9,6 +10,13 @@ async function loadHerdr(): Promise<typeof HerdrModule> {
   const herdrModulePath = ["./herdr", "ts"].join(".");
   return (await import(herdrModulePath)) as typeof HerdrModule;
 }
+
+async function loadTable(): Promise<typeof TableModule> {
+  const tableModulePath = ["./table", "ts"].join(".");
+  return (await import(tableModulePath)) as typeof TableModule;
+}
+
+const { getDisplayWidth, truncateToWidth, padToWidth } = await loadTable();
 
 export const POLL_INTERVAL_MS = 7 * 1000;
 export const SHUTDOWN_TIMEOUT_MS = 10 * 60 * 1000;
@@ -73,4 +81,133 @@ export async function runDispatcher(projects: ResolvedProject[], forwardedComman
   }
 
   return sessions;
+}
+
+export interface MonitorHandle {
+  stop(): void;
+  done: Promise<void>;
+}
+
+export async function removeSession(
+  sessions: SessionRegistry,
+  name: string,
+  { closeTab }: { closeTab: boolean },
+): Promise<void> {
+  const session = sessions.get(name);
+  if (!session) return;
+  sessions.delete(name);
+  if (closeTab) {
+    const { tabClose } = await loadHerdr();
+    await tabClose(session.tabId);
+  }
+}
+
+export async function pollOnce(sessions: SessionRegistry, herdr: typeof HerdrModule): Promise<void> {
+  for (const [name, session] of [...sessions.entries()]) {
+    try {
+      const { foregroundProcesses } = await herdr.paneProcessInfo(session.paneId);
+      const isAlive = foregroundProcesses.some((process) => process.cmdline.includes("claude-task-worker"));
+      if (!isAlive) {
+        await removeSession(sessions, name, { closeTab: true });
+      }
+    } catch (error) {
+      if (error instanceof herdr.HerdrError && error.code === "pane_not_found") {
+        await removeSession(sessions, name, { closeTab: false });
+        continue;
+      }
+      console.error(`[dispatcher] failed to poll session "${name}": ${error}`);
+    }
+  }
+}
+
+export function formatUptime(start: Date, now: Date): string {
+  const totalSeconds = Math.max(0, Math.floor((now.getTime() - start.getTime()) / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function renderSessionTable(sessions: SessionRegistry): void {
+  const entries = [...sessions.values()];
+  if (entries.length === 0) return;
+
+  const maxProjectWidth = 20;
+
+  const rows = entries.map((session) => ({
+    project:
+      getDisplayWidth(session.name) > maxProjectWidth ? truncateToWidth(session.name, maxProjectWidth) : session.name,
+    tab: session.tabId,
+    pane: session.paneId,
+    status: session.status,
+    uptime: formatUptime(session.startedAt, new Date()),
+  }));
+
+  const colWidths = {
+    project: Math.max(7, ...rows.map((r) => getDisplayWidth(r.project))),
+    tab: Math.max(3, ...rows.map((r) => r.tab.length)),
+    pane: Math.max(4, ...rows.map((r) => r.pane.length)),
+    status: Math.max(6, ...rows.map((r) => r.status.length)),
+    uptime: Math.max(6, ...rows.map((r) => r.uptime.length)),
+  };
+
+  const cols = [colWidths.project, colWidths.tab, colWidths.pane, colWidths.status, colWidths.uptime];
+  const line = (l: string, m: string, r: string, f: string) => `${l}${cols.map((w) => f.repeat(w + 2)).join(m)}${r}`;
+
+  const row = (project: string, tab: string, pane: string, status: string, uptime: string) =>
+    `│ ${padToWidth(project, colWidths.project)} │ ${tab.padEnd(colWidths.tab)} │ ${pane.padEnd(colWidths.pane)} │ ${status.padEnd(colWidths.status)} │ ${uptime.padEnd(colWidths.uptime)} │`;
+
+  const lines: string[] = [];
+  lines.push(line("┌", "┬", "┐", "─"));
+  lines.push(row("Project", "Tab", "Pane", "Status", "Uptime"));
+  lines.push(line("├", "┼", "┤", "─"));
+  for (const r of rows) {
+    lines.push(row(r.project, r.tab, r.pane, r.status, r.uptime));
+  }
+  lines.push(line("└", "┴", "┘", "─"));
+
+  console.clear();
+  console.log(lines.join("\n"));
+}
+
+export function monitorSessions(
+  sessions: SessionRegistry,
+  herdr: typeof HerdrModule,
+  options?: { pollIntervalMs?: number; renderIntervalMs?: number },
+): MonitorHandle {
+  const pollIntervalMs = options?.pollIntervalMs ?? POLL_INTERVAL_MS;
+  const renderIntervalMs = options?.renderIntervalMs ?? 1000;
+
+  let resolveDone: () => void;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+  let settled = false;
+
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    clearInterval(pollInterval);
+    clearInterval(renderInterval);
+    resolveDone();
+  };
+
+  const pollInterval = setInterval(() => {
+    void pollOnce(sessions, herdr).then(() => {
+      if (sessions.size === 0) {
+        finish();
+      }
+    });
+  }, pollIntervalMs);
+  pollInterval.unref();
+
+  const renderInterval = setInterval(() => {
+    renderSessionTable(sessions);
+  }, renderIntervalMs);
+  renderInterval.unref();
+
+  return {
+    stop: finish,
+    done,
+  };
 }

--- a/src/herdr.test.ts
+++ b/src/herdr.test.ts
@@ -7,7 +7,7 @@ import type * as HerdrModule from "./herdr";
 const childProcess = createRequire(import.meta.url)("node:child_process") as typeof ChildProcess;
 
 const herdrModulePath = ["./herdr", "ts"].join(".");
-const { tabCreate, tabList, paneProcessInfo } = (await import(herdrModulePath)) as typeof HerdrModule;
+const { tabCreate, tabList, paneProcessInfo, HerdrError } = (await import(herdrModulePath)) as typeof HerdrModule;
 
 type ExecFileCallback = (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void;
 
@@ -64,4 +64,14 @@ test("paneProcessInfo returns an empty foregroundProcesses array when foreground
   mockExecFile(t, JSON.stringify({ result: { process_info: {} } }), "");
   const result = await paneProcessInfo("pane-1");
   assert.deepEqual(result, { foregroundProcesses: [] });
+});
+
+test("throws a HerdrError carrying the error code when herdr responds with an error payload", async (t) => {
+  mockExecFile(t, JSON.stringify({ error: { code: "pane_not_found", message: "no such pane" } }), "");
+  await assert.rejects(paneProcessInfo("pane-1"), (error: unknown) => {
+    assert.ok(error instanceof HerdrError);
+    assert.equal(error.code, "pane_not_found");
+    assert.match(error.message, /^herdr pane process-info --pane pane-1 failed: \[pane_not_found\] no such pane$/);
+    return true;
+  });
 });

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -38,6 +38,16 @@ export class HerdrUnavailableError extends Error {
   }
 }
 
+export class HerdrError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = "HerdrError";
+    this.code = code;
+  }
+}
+
 interface HerdrRawResult {
   execError: NodeJS.ErrnoException | null;
   parsed: HerdrResponse | undefined;
@@ -65,7 +75,10 @@ async function execHerdr(args: string[]): Promise<unknown> {
   const stderrSuffix = stderr.trim() ? `: ${stderr.trim()}` : "";
   // stdout に有効な error JSON が乗っているケースは execFile の失敗より優先して扱う。
   if (parsed?.error) {
-    throw new Error(`herdr ${args.join(" ")} failed: [${parsed.error.code}] ${parsed.error.message}`);
+    throw new HerdrError(
+      `herdr ${args.join(" ")} failed: [${parsed.error.code}] ${parsed.error.message}`,
+      parsed.error.code,
+    );
   }
   if (execError) {
     throw new Error(`herdr ${args.join(" ")} failed: ${execError.message}${stderrSuffix}`);


### PR DESCRIPTION
## 概要

セッション登録簿を一定間隔で pane process-info ポーリングして稼働判定し、リアルタイム一覧表（Project / Tab / Pane / Status / Uptime）を描画する。終了・消滅したセッションを一覧から削除しタブを close、全滅でディスパッチャーを正常終了できるようにする。

## 変更内容

- `herdr.ts` に `code` を保持する構造化エラークラス `HerdrError` を新設し、`execHerdr` の `parsed?.error` 分岐で throw するよう変更
- `dispatcher.ts` に `removeSession(sessions, name, { closeTab })` ヘルパーと、1回分のポーリングを行う `pollOnce(sessions, herdr)` を追加。`foregroundProcesses` の `cmdline` に `claude-task-worker` を含むかで稼働判定し、自然終了時は `tabClose` 付きで削除、`HerdrError.code === "pane_not_found"` の場合は `tabClose` なしで削除、それ以外の一過性エラーはログのみで継続
- `formatUptime(start, now)` を HH:MM:SS 形式で新設
- `monitorSessions(sessions, herdr, options?: { pollIntervalMs?; renderIntervalMs?; })` を新設。`pollOnce` を `pollIntervalMs`（既定7000ms）、一覧表描画を `renderIntervalMs`（既定1000ms）間隔で `setInterval(...).unref()` し、`MonitorHandle { stop(): void; done: Promise<void> }` を返す。全セッション消滅で `done` を resolve
- `dispatcher.test.ts` / `herdr.test.ts` にテストを追加

## 関連Issue

Closes #65

## テスト内容

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] 動作確認（該当する場合、確認手順を記述）

## その他の確認事項

- [ ] 破壊的変更がある場合、README.md / CLAUDE.md を更新した