### PR TITLE
feat: --project分岐でディスパッチャー起動＋ヘルプ更新

### DIFF
--- a/src/dispatch-args.test.ts
+++ b/src/dispatch-args.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type * as DispatchArgsModule from "./dispatch-args";
+
+// node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求する一方、
+// tsc --noEmit（npm run build）は allowImportingTsExtensions が無効なため
+// 静的import文中の .ts 拡張子指定子を許容せず失敗する。両立のため、
+// TSの静的解析対象にならない動的文字列結合でパスを構築している。
+const dispatchArgsModulePath = ["./dispatch-args", "ts"].join(".");
+const { buildForwardedCommand, shellQuote } = (await import(dispatchArgsModulePath)) as typeof DispatchArgsModule;
+
+test("buildForwardedCommand strips --project and its value from argv.slice(2)-shaped input", () => {
+  const argv = ["all", "--project", "foo"];
+  assert.equal(buildForwardedCommand(argv), "claude-task-worker 'all'");
+});
+
+test("buildForwardedCommand preserves non-project tokens and their order", () => {
+  const argv = ["exec-issue", "--epic", "100", "--project", "my-app", "--label", "priority-high"];
+  assert.equal(buildForwardedCommand(argv), "claude-task-worker 'exec-issue' '--epic' '100' '--label' 'priority-high'");
+});
+
+test("buildForwardedCommand handles multiple --project flags", () => {
+  const argv = ["all", "--project", "foo", "--project", "bar"];
+  assert.equal(buildForwardedCommand(argv), "claude-task-worker 'all'");
+});
+
+test("buildForwardedCommand returns bare command when argv is empty", () => {
+  assert.equal(buildForwardedCommand([]), "claude-task-worker");
+});
+
+test("buildForwardedCommand shell-quotes tokens containing single quotes", () => {
+  const argv = ["exec-issue", "--label", "it's-a-label"];
+  assert.equal(buildForwardedCommand(argv), `claude-task-worker 'exec-issue' '--label' ${shellQuote("it's-a-label")}`);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,19 @@ import { install } from "./commands/install";
 import { update } from "./commands/update";
 import { version } from "./commands/version";
 import { buildTokenLimitText, send } from "./slack";
+import {
+  hasProjectFilter,
+  parseProjectFilters,
+  assertProjectCompatibleCommand,
+  buildForwardedCommand,
+} from "./dispatch-args";
+import { loadProjectsConfig, resolveTargetProjects, ProjectsConfigError } from "./projects-config";
+// dispatcher.ts / herdr.ts はワーカー起動には不要な --project 専用モジュールで、
+// dispatcher.ts のトップレベル await が即時実行されるのを避けるため、
+// 静的importではなく --project 使用時にのみ実行される動的importで遅延読込する。
+import type * as DispatcherModule from "./dispatcher";
+import type { SessionRegistry, MonitorHandle } from "./dispatcher";
+import type * as HerdrModule from "./herdr";
 
 const WORKERS: Record<string, (opts?: { epicFilters?: number[]; labelFilters?: string[] }) => Promise<void>> = {
   "exec-issue": execIssueWorker,
@@ -32,7 +45,7 @@ const WORKERS: Record<string, (opts?: { epicFilters?: number[]; labelFilters?: s
 };
 
 function printUsage(): void {
-  console.log(`Usage: claude-task-worker <command> [--epic <issue-number>] [--label <label-name>]
+  console.log(`Usage: claude-task-worker <command> [--project <name>] [--epic <issue-number>] [--label <label-name>]
 
 Commands:
   init [--force]    Create required GitHub labels and config file (use --force to overwrite existing files)
@@ -56,6 +69,7 @@ Workers:
   yolo              Poll all workers including triage-created-issue, triage-pr, check-dependabot
 
 Options:
+  --project <name>  Dispatch to project(s) via herdr instead of running the worker locally. Accepts a project name, a project group name, or "all". Repeatable.
   --epic <number>   Limit issue-based workers to sub-issues of the specified epic issue. Repeatable: any matching parent (OR).
   --label <name>    Limit issue-based workers to issues that also carry the specified label. Repeatable: all must be present (AND).
 
@@ -66,7 +80,10 @@ Example:
   claude-task-worker all --epic 100 --epic 200
   claude-task-worker all --label priority-high
   claude-task-worker all --label priority-high --label needs-design
-  claude-task-worker yolo --epic 100 --epic 200 --label priority-high`);
+  claude-task-worker yolo --epic 100 --epic 200 --label priority-high
+  claude-task-worker all --project all
+  claude-task-worker all --project igsa
+  claude-task-worker exec-issue --project my-app --epic 100`);
 }
 
 const workerType = process.argv[2];
@@ -93,6 +110,10 @@ if (
   console.error(`Unknown command: ${workerType}`);
   printUsage();
   process.exit(1);
+}
+
+if (hasProjectFilter()) {
+  assertProjectCompatibleCommand(workerType);
 }
 
 function collectFlagValues(flag: string): string[] {
@@ -130,36 +151,76 @@ process.on("unhandledRejection", (err) => {
   process.exit(1);
 });
 
-process.on("SIGTERM", async () => {
-  if (isShuttingDown()) return;
-  setShuttingDown();
-  console.log(
-    "\n[worker] Stopping new tasks. Waiting for in-flight tasks to finish... (Send SIGTERM again to force kill)",
-  );
-  await waitForAllProcesses();
-  process.exit(0);
-});
+if (!hasProjectFilter()) {
+  process.on("SIGTERM", async () => {
+    if (isShuttingDown()) return;
+    setShuttingDown();
+    console.log(
+      "\n[worker] Stopping new tasks. Waiting for in-flight tasks to finish... (Send SIGTERM again to force kill)",
+    );
+    await waitForAllProcesses();
+    process.exit(0);
+  });
 
-let forceKilling = false;
-process.on("SIGINT", async () => {
-  if (isShuttingDown()) {
-    if (forceKilling) return;
-    forceKilling = true;
-    console.log("\n[worker] Force killing running tasks... (cleaning up labels and worktrees)");
-    shutdown("SIGKILL");
-    const cleanupTimeout = new Promise<void>((resolve) => setTimeout(resolve, 60_000).unref());
-    await Promise.race([waitForAllProcesses(), cleanupTimeout]);
-    process.exit(1);
-  }
-  setShuttingDown();
-  console.log(
-    "\n[worker] Stopping new tasks. Waiting for in-flight tasks to finish... (Press Ctrl-C again to force kill)",
-  );
-  await waitForAllProcesses();
-  process.exit(0);
-});
+  let forceKilling = false;
+  process.on("SIGINT", async () => {
+    if (isShuttingDown()) {
+      if (forceKilling) return;
+      forceKilling = true;
+      console.log("\n[worker] Force killing running tasks... (cleaning up labels and worktrees)");
+      shutdown("SIGKILL");
+      const cleanupTimeout = new Promise<void>((resolve) => setTimeout(resolve, 60_000).unref());
+      await Promise.race([waitForAllProcesses(), cleanupTimeout]);
+      process.exit(1);
+    }
+    setShuttingDown();
+    console.log(
+      "\n[worker] Stopping new tasks. Waiting for in-flight tasks to finish... (Press Ctrl-C again to force kill)",
+    );
+    await waitForAllProcesses();
+    process.exit(0);
+  });
+}
 
-if (workerType === "init") {
+if (hasProjectFilter()) {
+  (async () => {
+    // sessions/monitorHandle は起動処理完了前に SIGTERM/SIGINT を受けても
+    // shutdownDispatcher に安全に渡せるよう、起動前の空値で先に宣言する。
+    let sessions: SessionRegistry = new Map();
+    let monitorHandle: MonitorHandle | undefined;
+
+    // 起動処理（runDispatcher/monitorSessions）が完了する前にシグナルを受けても
+    // タブ・セッションが放置されないよう、動的import・起動処理より前にハンドラを登録する。
+    const handleShutdown = async () => {
+      const dispatcherModulePath = ["./dispatcher", "ts"].join(".");
+      const { shutdownDispatcher } = (await import(dispatcherModulePath)) as typeof DispatcherModule;
+      await shutdownDispatcher(sessions, monitorHandle);
+    };
+    process.on("SIGTERM", handleShutdown);
+    process.on("SIGINT", handleShutdown);
+
+    // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求する一方、
+    // tsc --noEmit は静的import文中の .ts 拡張子指定子を許容しないため、
+    // TSの静的解析対象にならない動的文字列結合でパスを構築している（dispatcher.ts と同様）。
+    const herdrModulePath = ["./herdr", "ts"].join(".");
+    const herdr = (await import(herdrModulePath)) as typeof HerdrModule;
+    try {
+      const config = loadProjectsConfig();
+      const projects = resolveTargetProjects(parseProjectFilters(), config);
+      const forwardedCommand = buildForwardedCommand(process.argv.slice(2));
+      const dispatcherModulePath = ["./dispatcher", "ts"].join(".");
+      const { runDispatcher, monitorSessions } = (await import(dispatcherModulePath)) as typeof DispatcherModule;
+      sessions = await runDispatcher(projects, forwardedCommand);
+      monitorHandle = monitorSessions(sessions, herdr);
+    } catch (err) {
+      if (err instanceof ProjectsConfigError || err instanceof herdr.HerdrUnavailableError) {
+        console.error(`[dispatcher] ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
+    }
+  })();
+} else if (workerType === "init") {
   const force = process.argv.slice(3).includes("--force");
   init({ force });
 } else if (workerType === "install") {


### PR DESCRIPTION
## 概要

--project 指定時にワーカー起動の代わりにディスパッチャーへ分岐する配線を index.ts に追加し、printUsage() に --project を反映する。--project 未指定時の既存動作は一切変えない（回帰ゼロ）。

## 変更内容

- `hasProjectFilter()` で `--project` 指定を検知し、`assertProjectCompatibleCommand(workerType)` → `loadProjectsConfig()` → `resolveTargetProjects(...)` → `buildForwardedCommand(...)` → `runDispatcher(...)` → `monitorSessions(...)` の順で呼ぶ分岐を追加
- `ProjectsConfigError` / `HerdrUnavailableError` を捕捉し、エラーメッセージを出力して `process.exit(1)`
- 既存ワーカー用 SIGINT/SIGTERM ハンドラ登録を `!hasProjectFilter()` でガードし、`--project` 指定時はディスパッチャー専用の SIGINT/SIGTERM ハンドラ（`shutdownDispatcher`）を登録する排他方式に変更
- `dispatcher.ts` / `herdr.ts` は `--project` 使用時のみ動的importで遅延読込し、ワーカー起動時の不要な初期化を回避
- `printUsage()` の synopsis・Options・Example に `--project` の説明と使用例（`all --project all` / `all --project igsa` / `exec-issue --project my-app --epic 100`）を追記

## 関連Issue

Closes #67

## テスト内容

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] 動作確認（該当する場合、確認手順を記述）

## その他の確認事項

- [ ] 破壊的変更がある場合、README.md / CLAUDE.md を更新した

## 修正履歴

### 2026-07-11: レビュー指摘対応（1件）
- CI（buildワークフロー）の Format check が `src/dispatch-args.test.ts` のフォーマット崩れ（`assert.equal(...)` の折り返し）で失敗していたため、`npm run format` で整形して解消（対応コミット: 30ad85f）

### 2026-07-11: レビュー指摘対応（3件）
- `buildForwardedCommand(process.argv)` が node 実行パス・スクリプトパスまで転送先コマンドに含めてしまい `Unknown command` エラーを招くバグを修正。`process.argv.slice(2)` を渡すよう変更（対応コミット: 4f7cb3b）
- `--project` 分岐内の `herdr` / `dispatcher` の動的import が拡張子なしで `node --experimental-strip-types` 実行時に解決失敗しうる問題を修正。`dispatcher.ts` と同じ `["path", "ts"].join(".")` 方式に統一（対応コミット: 4f7cb3b）
- `--project` 分岐の SIGTERM/SIGINT ハンドラが `runDispatcher`/`monitorSessions` 完了後にしか登録されておらず、起動処理中にシグナルを受けるとセッションが放置される競合状態を修正。`sessions`/`monitorHandle` を outer scope 化し、起動処理より前にハンドラを登録する構成に変更。あわせて `buildForwardedCommand` のユニットテスト（`src/dispatch-args.test.ts`）を追加（対応コミット: 4f7cb3b）
