### PR TITLE
fix: treat empty herdr stdout as success for fire-and-forget commands

### DIFF
--- a/src/herdr.test.ts
+++ b/src/herdr.test.ts
@@ -6,7 +6,8 @@ import type * as HerdrModule from "./herdr";
 
 const childProcess = createRequire(import.meta.url)("node:child_process") as typeof ChildProcess;
 
-const { tabCreate, tabList, paneProcessInfo, HerdrError } = (await import("./herdr.ts")) as typeof HerdrModule;
+const { tabCreate, tabList, paneProcessInfo, paneSendText, paneSendKeys, HerdrError } =
+  (await import("./herdr.ts")) as typeof HerdrModule;
 
 type ExecFileCallback = (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void;
 
@@ -37,6 +38,39 @@ test("execHerdr includes stderr content in the error message when stdout is inva
     assert.match(error.message, /herdr: connection refused/);
     return true;
   });
+});
+
+test("paneSendText resolves without throwing when herdr returns empty stdout and stderr on success", async (t) => {
+  // herdr の `pane send-text` は成功時に空stdout・空stderr・終了コード0を返すため、
+  // invalid JSON 扱いにせず正常完了させる。
+  mockExecFile(t, "", "");
+  await assert.doesNotReject(paneSendText("w3:pB", "claude-task-worker 'yolo'"));
+});
+
+test("paneSendKeys resolves without throwing when herdr returns empty stdout and stderr on success", async (t) => {
+  mockExecFile(t, "", "");
+  await assert.doesNotReject(paneSendKeys("w3:pB", "enter"));
+});
+
+test("paneSendText still throws invalid JSON when stdout is non-empty but not JSON", async (t) => {
+  mockExecFile(t, "not json", "");
+  await assert.rejects(paneSendText("w3:pB", "hello"), /invalid JSON output/);
+});
+
+test("paneSendText throws when stdout is empty but stderr is non-empty", async (t) => {
+  // exit 0 でも stderr に出力があれば、失敗を握りつぶさずエラーにする。
+  mockExecFile(t, "", "herdr: pane busy");
+  await assert.rejects(paneSendText("w3:pB", "hello"), (error: Error) => {
+    assert.match(error.message, /invalid JSON output/);
+    assert.match(error.message, /herdr: pane busy/);
+    return true;
+  });
+});
+
+test("tabList rejects an empty stdout response because it must return JSON", async (t) => {
+  // allowEmptyResult を指定しないコマンドでは、空stdoutを正常応答として扱わない。
+  mockExecFile(t, "", "");
+  await assert.rejects(tabList(), /invalid JSON output/);
 });
 
 test("tabCreate throws an explicit error when root_pane is missing from the response", async (t) => {

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -51,6 +51,7 @@ export class HerdrError extends Error {
 interface HerdrRawResult {
   execError: NodeJS.ErrnoException | null;
   parsed: HerdrResponse | undefined;
+  stdout: string;
   stderr: string;
 }
 
@@ -71,14 +72,17 @@ function runHerdr(args: string[]): Promise<HerdrRawResult> {
         } catch {
           parsed = undefined;
         }
-        resolve({ execError: error as NodeJS.ErrnoException | null, parsed, stderr });
+        resolve({ execError: error as NodeJS.ErrnoException | null, parsed, stdout, stderr });
       },
     );
   });
 }
 
-async function execHerdr(args: string[]): Promise<unknown> {
-  const { execError, parsed, stderr } = await runHerdr(args);
+// allowEmptyResult: `pane send-text` / `pane send-keys` など結果を返さない
+// fire-and-forget 系コマンド専用のフラグ。これらは成功時に空stdout・空stderr・
+// 終了コード0を返すため、空応答を正常完了として扱えるようにする。
+async function execHerdr(args: string[], options?: { allowEmptyResult?: boolean }): Promise<unknown> {
+  const { execError, parsed, stdout, stderr } = await runHerdr(args);
   const stderrSuffix = stderr.trim() ? `: ${stderr.trim()}` : "";
   // stdout に有効な error JSON が乗っているケースは execFile の失敗より優先して扱う。
   if (parsed?.error) {
@@ -91,6 +95,13 @@ async function execHerdr(args: string[]): Promise<unknown> {
     throw new Error(`herdr ${args.join(" ")} failed: ${execError.message}${stderrSuffix}`);
   }
   if (!parsed) {
+    // fire-and-forget 系コマンド（allowEmptyResult 指定時）に限り、stdout も stderr も
+    // 空なら「結果なしの正常応答」とみなす。stderr に出力がある場合は exit 0 でも
+    // 失敗を握りつぶさないようエラーにする。JSONを返すべき他コマンド（tab list/create 等）
+    // では空stdoutを従来どおり invalid JSON 扱いにする。
+    if (options?.allowEmptyResult && stdout.trim() === "" && stderr.trim() === "") {
+      return undefined;
+    }
     throw new Error(`herdr ${args.join(" ")} failed: invalid JSON output${stderrSuffix}`);
   }
   return parsed.result;
@@ -132,11 +143,11 @@ export async function tabList(): Promise<TabInfo[]> {
 }
 
 export async function paneSendText(paneId: string, text: string): Promise<void> {
-  await execHerdr(["pane", "send-text", paneId, text]);
+  await execHerdr(["pane", "send-text", paneId, text], { allowEmptyResult: true });
 }
 
 export async function paneSendKeys(paneId: string, ...keys: string[]): Promise<void> {
-  await execHerdr(["pane", "send-keys", paneId, ...keys]);
+  await execHerdr(["pane", "send-keys", paneId, ...keys], { allowEmptyResult: true });
 }
 
 export async function paneProcessInfo(paneId: string): Promise<PaneProcessInfo> {


### PR DESCRIPTION
## 概要

`--project` でディスパッチ実行すると、以下のエラーで全プロジェクトのディスパッチが失敗していた問題を修正します。

```
[dispatcher] failed to dispatch project "dementia_app": Error: herdr pane send-text w3:pB claude-task-worker 'yolo' failed: invalid JSON output
```

## 原因

`herdr pane send-text` / `pane send-keys` は fire-and-forget 系コマンドで、**成功時に空stdout・空stderr・終了コード0** を返す（実機 herdr 0.7.3 で確認）。一方 `execHerdr()` は全コマンドがJSONを返す前提で書かれており、`JSON.parse("")` の失敗で `parsed = undefined` となり `invalid JSON output` を投げていた。

実際にはコマンドはペインに送信・実行されているにもかかわらず `execHerdr` が誤ってエラーを投げるため、`dispatcher.ts` の catch がセッションを削除し `tabClose` でタブごと破棄 → ディスパッチが失敗扱いになっていた。`shutdownDispatcher` の ctrl-c 送信（`paneSendKeys`）も同じ理由で毎回失敗していた。

## 修正内容

- `execHerdr()`: 結果を返さない fire-and-forget 系コマンド（`paneSendText` / `paneSendKeys`、`allowEmptyResult` 指定時）に限り、**stdout も stderr も空なら「結果なしの正常応答」** とみなし result なしで返す。stderr に出力がある場合、および JSON を返すべき他コマンド（`tab list` / `tab create` 等）での空stdoutは、従来どおり `invalid JSON output` を投げる。
- `runHerdr()` の戻り値に `stdout` を追加。
- `checkHerdrAvailable`（`runHerdr` を直接使う別系統）は変更なし。サーバー不通判定は維持。
- テスト追加: `send-text` / `send-keys` の空応答成功、非空不正JSONでの失敗、**stderr 非空での失敗**、**`tabList` の空stdout reject 回帰テスト**。

## 検証

- `npm run build`（tsc + esbuild）: 成功
- `npm test`: 全93件パス（`herdr.test.ts` 14件・`dispatcher.test.ts` 22件を含む）
- `npm run lint` / `prettier --check`: クリーン
- 実機 herdr 0.7.3 でテスト用タブを作り `send-text` / `send-keys` / `process-info` の出力形式を直接確認

## 修正履歴

### 2026-07-12: レビュー指摘対応（2件）
- 空stdout成功分岐を fire-and-forget 系（`send-text` / `send-keys`、`allowEmptyResult` 指定時）に限定し、stderr も空である場合のみ成功扱いに変更。stderr 非空・他コマンドの空stdoutは失敗扱いを維持（Gemini・CodeRabbit 指摘）（対応コミット: fc88a75）
- `tabList` が空stdout応答を reject する回帰テストと、`paneSendText` が stderr 非空で reject するテストを追加（対応コミット: fc88a75）
- CodeRabbit nitpick（テストの import specifier を `.js` に統一）は **skip**: `.ts` は `node --experimental-strip-types` でのテスト実行に必須のため（PRコメントに理由を記載）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 結果なしの操作で、stdout / stderr がともに空の場合は例外にせず正常完了として扱います。
  - テキスト／キー送信（fire-and-forget）で、空出力でも不要な失敗が起きません。
  - 不正なJSON出力は `invalid JSON output` と stderr 内容を含めて確実に拒否されます。
  - tabList でも空出力時のJSON要求は同様に拒否されます。
- **テスト**
  - 空・不正出力時の挙動を追加検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->