### PR TITLE
fix: send ctrl+c (not ctrl-c) to herdr on dispatcher shutdown

### DIFF
--- a/src/dispatcher.test.ts
+++ b/src/dispatcher.test.ts
@@ -435,12 +435,14 @@ function makeShutdownFakeHerdr(options: {
   ctrlCThreshold?: Record<string, number>;
   ctrlCCounts: Record<string, number>;
   closedTabIds: string[];
+  sentKeys?: string[];
 }): typeof HerdrModule {
-  const { ctrlCThreshold = {}, ctrlCCounts, closedTabIds } = options;
+  const { ctrlCThreshold = {}, ctrlCCounts, closedTabIds, sentKeys } = options;
   return {
     HerdrError,
-    paneSendKeys: async (paneId: string) => {
+    paneSendKeys: async (paneId: string, ...keys: string[]) => {
       ctrlCCounts[paneId] = (ctrlCCounts[paneId] ?? 0) + 1;
+      sentKeys?.push(...keys);
     },
     paneProcessInfo: async (paneId: string) => {
       const threshold = ctrlCThreshold[paneId] ?? 1;
@@ -464,7 +466,8 @@ test("shutdownDispatcher: 全セッションが1回目のctrl-c送信後にタ�
   mockTabClose(t, []);
   const ctrlCCounts: Record<string, number> = {};
   const closedTabIds: string[] = [];
-  const fakeHerdr = makeShutdownFakeHerdr({ ctrlCCounts, closedTabIds });
+  const sentKeys: string[] = [];
+  const fakeHerdr = makeShutdownFakeHerdr({ ctrlCCounts, closedTabIds, sentKeys });
 
   const session = makeSession();
   const sessions: DispatcherModule.SessionRegistry = new Map([[session.name, session]]);
@@ -478,6 +481,9 @@ test("shutdownDispatcher: 全セッションが1回目のctrl-c送信後にタ�
   });
 
   assert.equal(ctrlCCounts[session.paneId], 1);
+  // herdr は `+` 区切りのキーコンボ文字列のみ受理する。`ctrl-c`（ハイフン）は
+  // invalid_key で拒否されるため、送信キーが `ctrl+c` であることを固定する。
+  assert.deepEqual(sentKeys, ["ctrl+c"]);
   assert.equal(sessions.size, 0);
   assert.deepEqual(exitCodes, [0]);
 });

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -227,11 +227,15 @@ export interface ShutdownOptions {
   forceKill?: boolean;
 }
 
+// herdr のキー名は `+` 区切りのキーコンボ文字列（例: `ctrl+c`）。
+// `ctrl-c` のようなハイフン区切りは `invalid_key` エラーになり送信されない。
+const CTRL_C_KEY = "ctrl+c";
+
 async function sendCtrlCToAllSessions(sessions: SessionRegistry, herdr: typeof HerdrModule): Promise<void> {
   await Promise.all(
     [...sessions.values()].map(async (session) => {
       try {
-        await herdr.paneSendKeys(session.paneId, "ctrl-c");
+        await herdr.paneSendKeys(session.paneId, CTRL_C_KEY);
       } catch (error) {
         console.error(`[dispatcher] failed to send ctrl-c to session "${session.name}": ${error}`);
       }


### PR DESCRIPTION
## 概要

`--project` 実行後に SIGINT/SIGTERM でシャットダウンすると、各セッションへ Ctrl-C を送れず以下のエラーが出ていた問題を修正します。

```
[dispatcher] failed to send ctrl-c to session "dementia_app": Error: herdr pane send-keys w3:pD ctrl-c failed: Command failed: herdr pane send-keys w3:pD ctrl-c
{"error":{"code":"invalid_key","message":"unsupported key ctrl-c"},"id":"cli:request"}
```

## 原因

`src/dispatcher.ts` の `sendCtrlCToAllSessions()` が herdr へ送るキー名を `"ctrl-c"`（ハイフン区切り）にしていた。herdr のキー名は `ctrl+c` のような **`+` 区切りのキーコンボ文字列**のみを受理し、ハイフン区切りは `invalid_key` エラーになる（herdr CHANGELOG #613、実機で `ctrl-c`→エラー / `ctrl+c`→成功 を検証済み）。

## 修正内容

- `src/dispatcher.ts` — 送信キーを `"ctrl-c"` → `"ctrl+c"` に修正。誤修正防止のため `CTRL_C_KEY` 定数に切り出し、herdr のキー名仕様をコメントで明記。
- `src/dispatcher.test.ts` — バグがすり抜けていた原因はモックの `paneSendKeys` が第2引数（キー名）を検証していなかったこと。送信キーを記録・検証するリグレッションガードを追加。

ログ文言中の「ctrl-c」（Ctrl-C キーを指す慣用表現）はそのまま維持（機能に影響なし）。

## テスト

- 全99テストパス
- lint パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * セッション終了時に送信される Ctrl-C キーの形式を修正し、正しく終了処理できるようにしました。

* **テスト**
  * Ctrl-C の送信内容を検証するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->