### PR TITLE
feat(dispatcher): prefix dispatched tab labels with "ctw:"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ claude-task-worker all             # Run all workers concurrently
 - **`src/workers/`** - 各ワーカー実装
 - **`plugin/`** - Claude Code プラグイン本体（`.claude-plugin/plugin.json`, `skills/`, `agents/`, `hooks/`, `scripts/`, `.mcp.json`）
 - **`.claude-plugin/marketplace.json`** - このリポジトリを Claude Code マーケットプレイスとして公開するための定義
-- **`src/dispatcher.ts`** - ディスパッチャー本体。`runDispatcher()`（herdr疎通確認 → プロジェクトごとにタブ作成しコマンド送信）、`monitorSessions()`（セッション生存監視＋ステータステーブル描画ループの起動）、`renderSessionTable()`（稼働セッション一覧のテーブル描画）、`shutdownDispatcher()`（SIGINT/SIGTERM時、各セッションへctrl-c送信 → 終了待機 → タブクローズのグレースフルシャットダウン）
+- **`src/dispatcher.ts`** - ディスパッチャー本体。`runDispatcher()`（herdr疎通確認 → プロジェクトごとにタブ作成しコマンド送信。作成タブのラベルは `tabLabelFor()` で `ctw:` プレフィックス付き（`TAB_LABEL_PREFIX`）にし、既存タブの重複判定も同プレフィックスで行う）、`monitorSessions()`（セッション生存監視＋ステータステーブル描画ループの起動）、`renderSessionTable()`（稼働セッション一覧のテーブル描画）、`shutdownDispatcher()`（SIGINT/SIGTERM時、各セッションへctrl-c送信 → 終了待機 → タブクローズのグレースフルシャットダウン）
 - **`src/herdr.ts`** - herdr CLIラッパー。`tabCreate`/`tabClose`/`tabList`（タブ管理）、`paneSendText`/`paneSendKeys`（ペインへの入力送信）、`paneProcessInfo`（フォアグラウンドプロセス確認）、`checkHerdrAvailable`（herdr導入・疎通確認）
 - **`src/projects-config.ts`** - `projects.json`（`~/.config/claude-task-worker/projects.json` または `$XDG_CONFIG_HOME` 配下）のロード・検証・対象プロジェクト解決。`ProjectsConfig`（`projects`/`projectGroups` のネスト構造）、`loadProjectsConfig()`（読み込み・検証）、`resolveTargetProjects()`（プロジェクト名/グループ名/予約語 `all` の展開）
 - **`src/dispatch-args.ts`** - `--project` ディスパッチ用CLI引数ヘルパー。`PROJECT_INCOMPATIBLE_COMMANDS`（`--project` と併用不可なコマンド一覧: `init`/`install`/`update`/`usage`/`version`）、`parseProjectFilters()`/`hasProjectFilter()`（`--project` の抽出・検出）、`buildForwardedCommand()`（`--project` とその値を除去し他プロジェクトへ転送するコマンド文字列を構築）

--- a/src/dispatcher.test.ts
+++ b/src/dispatcher.test.ts
@@ -24,7 +24,7 @@ interface HerdrScenario {
   brokenPaneLabels?: string[];
 }
 
-function mockHerdr(t: TestContext, scenario: HerdrScenario, closedTabIds?: string[]): void {
+function mockHerdr(t: TestContext, scenario: HerdrScenario, closedTabIds?: string[], createdLabels?: string[]): void {
   t.mock.method(
     childProcess,
     "execFile",
@@ -40,7 +40,11 @@ function mockHerdr(t: TestContext, scenario: HerdrScenario, closedTabIds?: strin
       }
       if (args[0] === "tab" && args[1] === "create") {
         const labelIndex = args.indexOf("--label");
-        const label = args[labelIndex + 1];
+        const rawLabel = args[labelIndex + 1];
+        createdLabels?.push(rawLabel);
+        // ラベルには "ctw:" プレフィックスが付与されるため、id導出・シナリオ判定は
+        // プレフィックスを剥がしたプロジェクト名ベースで行う。
+        const label = rawLabel.startsWith("ctw:") ? rawLabel.slice("ctw:".length) : rawLabel;
         if (scenario.brokenCreateLabels?.includes(label)) {
           callback(null, JSON.stringify({ error: { code: "internal", message: "boom" } }), "");
           return;
@@ -114,7 +118,7 @@ test("logs a non-Error thrown value via String(error) when herdr availability ch
 });
 
 test("skips a project whose label already has a tab and does not create a new one", async (t) => {
-  mockHerdr(t, { existingLabels: ["my-app"] });
+  mockHerdr(t, { existingLabels: ["ctw:my-app"] });
   const warnLogs: string[] = [];
   t.mock.method(console, "warn", (message: string) => {
     warnLogs.push(message);
@@ -125,6 +129,19 @@ test("skips a project whose label already has a tab and does not create a new on
 
   assert.equal(sessions.size, 0);
   assert.ok(warnLogs.some((line) => line.includes("my-app")));
+});
+
+test("creates tabs with a 'ctw:' prefixed label", async (t) => {
+  const createdLabels: string[] = [];
+  mockHerdr(t, {}, undefined, createdLabels);
+
+  const projects: ResolvedProject[] = [
+    { name: "my-app", path: "/tmp/my-app" },
+    { name: "other-app", path: "/tmp/other-app" },
+  ];
+  await runDispatcher(projects, "claude-task-worker all");
+
+  assert.deepEqual(createdLabels, ["ctw:my-app", "ctw:other-app"]);
 });
 
 test("registers a WorkerSession in the SessionRegistry on success", async (t) => {
@@ -207,7 +224,8 @@ test("closes the dangling tab and removes the leaked session when paneSendKeys (
       }
       if (args[0] === "tab" && args[1] === "create") {
         const labelIndex = args.indexOf("--label");
-        const label = args[labelIndex + 1];
+        const rawLabel = args[labelIndex + 1];
+        const label = rawLabel.startsWith("ctw:") ? rawLabel.slice("ctw:".length) : rawLabel;
         callback(
           null,
           JSON.stringify({

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -20,6 +20,14 @@ const { getDisplayWidth, truncateToWidth, padToWidth } = await loadTable();
 export const POLL_INTERVAL_MS = 7 * 1000;
 export const SHUTDOWN_TIMEOUT_MS = 10 * 60 * 1000;
 
+// ディスパッチャーが作成するherdrタブのラベルに付与するプレフィックス。
+// claude-task-worker が起動したタブを他のタブと区別できるようにする。
+export const TAB_LABEL_PREFIX = "ctw:";
+
+export function tabLabelFor(projectName: string): string {
+  return `${TAB_LABEL_PREFIX}${projectName}`;
+}
+
 export type WorkerSessionStatus = "running";
 
 export interface WorkerSession {
@@ -49,14 +57,14 @@ export async function runDispatcher(projects: ResolvedProject[], forwardedComman
   const sessions: SessionRegistry = new Map();
 
   for (const project of projects) {
-    if (existingLabels.has(project.name)) {
+    if (existingLabels.has(tabLabelFor(project.name))) {
       console.warn(`[dispatcher] project "${project.name}" already has a running tab, skipping`);
       continue;
     }
 
     let createdTabId: string | undefined;
     try {
-      const { paneId, tabId } = await tabCreate({ label: project.name, cwd: project.path });
+      const { paneId, tabId } = await tabCreate({ label: tabLabelFor(project.name), cwd: project.path });
       createdTabId = tabId;
       sessions.set(project.name, {
         name: project.name,


### PR DESCRIPTION
## 概要

`--project` ディスパッチでタブを作成する際、タブ名（herdrタブのラベル）に `ctw:` プレフィックスを付与するようにしました。claude-task-worker が起動したタブを他のタブと区別しやすくします。

## 変更内容

- `src/dispatcher.ts`
  - `TAB_LABEL_PREFIX = "ctw:"` 定数と `tabLabelFor(projectName)` ヘルパーを追加
  - `tabCreate()` に渡すラベルを `tabLabelFor(project.name)`（例: `ctw:my-app`）に変更
  - 既存タブの重複判定（再実行時のスキップ）も `tabLabelFor()` でプレフィックス付き比較に変更
  - `session.name`（ステータステーブル表示・レジストリキー）はプレフィックスなしのプロジェクト名のまま維持
- `src/dispatcher.test.ts`
  - モックがラベルからID（`tab-*`/`pane-*`）を導出する際に `ctw:` を剥がすよう調整し既存アサーションを維持
  - 重複スキップテストの `existingLabels` を `["ctw:my-app"]` に更新
  - タブ作成ラベルが `ctw:` 付きになることを検証する新テストを追加
- `CLAUDE.md`
  - `runDispatcher()` の説明にプレフィックス仕様を追記

## テスト

- `npm run build`（`tsc --noEmit`）成功
- `npm test` 全104件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 作成されるタブのラベルに `ctw:` プレフィックスを付与し、関連タブの識別性を向上しました。
  * 既存タブの重複判定と作成時のラベル指定を同じルールで統一しました。
* **テスト**
  * プレフィックス付きラベルでタブが作成されること、既存タブがある場合にスキップされることを検証するテストを追加・調整しました。
* **ドキュメント**
  * ラベル運用方針について、Architecture / コア構成の説明を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->