### PR TITLE
feat(gh): listIssues系のlimitをワーカーのmaxConcurrentTasksで指定

### DIFF
--- a/src/gh.ts
+++ b/src/gh.ts
@@ -73,6 +73,7 @@ export async function listIssuesByLabel(
   labels: string[],
   excludeLabels: string[] = [],
   epicFilter?: { owner: string; repo: string; numbers: number[] },
+  limit = 10,
 ): Promise<Issue[]> {
   const labelArgs = labels.flatMap((label) => ["--label", label]);
   const searchTerms = ["sort:created-asc", "-is:blocked", ...excludeLabels.map((label) => `-label:"${label}"`)];
@@ -93,7 +94,7 @@ export async function listIssuesByLabel(
     "--search",
     search,
     "--limit",
-    "10",
+    String(limit),
   ]);
   return JSON.parse(output);
 }
@@ -208,6 +209,7 @@ export async function listPullRequestsWithChecks(
   assignee?: string,
   label?: string,
   excludeLabels: string[] = [],
+  limit = 10,
 ): Promise<PullRequestWithChecks[]> {
   const search = ["sort:created-asc", ...excludeLabels.map((l) => `-label:"${l}"`)].join(" ");
   const args = [
@@ -220,7 +222,7 @@ export async function listPullRequestsWithChecks(
     "--search",
     search,
     "--limit",
-    "10",
+    String(limit),
   ];
   if (assignee) {
     args.push("--assignee", assignee);

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -205,11 +205,14 @@ async function fetchPRChecks(prNumber: number): Promise<PRCheck[]> {
   return JSON.parse(output) as PRCheck[];
 }
 
+// CI 未完了の PR が古い順の先頭を占めると isCICompleted フィルタで除外され、
+// 後続の完了済み PR が取得枠から溢れて飢餓する。取得件数は同時実行数とは
+// 切り離し、フィルタ前に十分な件数を確保するため既定値を 5 とする。
 export async function listPullRequestsWithChecks(
   assignee?: string,
   label?: string,
   excludeLabels: string[] = [],
-  limit = 10,
+  limit = 5,
 ): Promise<PullRequestWithChecks[]> {
   const search = ["sort:created-asc", ...excludeLabels.map((l) => `-label:"${l}"`)].join(" ");
   const args = [

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -9,6 +9,11 @@ import { removeWorktree, createWorktreeFromBranch, getWorktreePath } from "../wo
 
 const LABEL_TRIAGE_SCOPE = "cc-triage-scope";
 
+// preflight を持つワーカー（現状は epic-issue）は、古い順の先頭候補が preflight で
+// skip され続けると後続の実行可能 Issue が取得枠から溢れて飢餓する。取得件数を
+// 同時実行数と切り離し、固定バッファ件数を取得するための上限。
+const PREFLIGHT_SEARCH_LIMIT = 5;
+
 export type PreflightResult = "proceed" | "skip" | "mark-pr-created";
 
 interface IssueWorkerConfig {
@@ -50,10 +55,11 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
             ? [...config.triggerLabels, ...config.labelFilters]
             : config.triggerLabels;
         const { maxConcurrentTasks } = getWorkerConfig(config.name);
+        const searchLimit = config.preflight ? PREFLIGHT_SEARCH_LIMIT : maxConcurrentTasks;
         const candidates =
           config.ownNumberFilters && config.ownNumberFilters.length > 0
             ? await listIssuesByNumbers(user, labels, excludeLabels, config.ownNumberFilters)
-            : await listIssuesByLabel(user, labels, excludeLabels, epicFilter, maxConcurrentTasks);
+            : await listIssuesByLabel(user, labels, excludeLabels, epicFilter, searchLimit);
 
         for (const issue of candidates) {
           if (isRunning(issue.number)) continue;

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -49,10 +49,11 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
           config.labelFilters && config.labelFilters.length > 0
             ? [...config.triggerLabels, ...config.labelFilters]
             : config.triggerLabels;
+        const { maxConcurrentTasks } = getWorkerConfig(config.name);
         const candidates =
           config.ownNumberFilters && config.ownNumberFilters.length > 0
             ? await listIssuesByNumbers(user, labels, excludeLabels, config.ownNumberFilters)
-            : await listIssuesByLabel(user, labels, excludeLabels, epicFilter);
+            : await listIssuesByLabel(user, labels, excludeLabels, epicFilter, maxConcurrentTasks);
 
         for (const issue of candidates) {
           if (isRunning(issue.number)) continue;

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -49,13 +49,7 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
       if (cooldownMs > 0 && lastCompletionAt > 0 && Date.now() - lastCompletionAt < cooldownMs) return;
       try {
         const excludeLabels = [LABEL_IN_PROGRESS, ...(config.excludeLabels ?? [])];
-        const { maxConcurrentTasks } = getWorkerConfig(config.name);
-        const candidates = await listPullRequestsWithChecks(
-          user,
-          config.triggerLabel,
-          excludeLabels,
-          maxConcurrentTasks,
-        );
+        const candidates = await listPullRequestsWithChecks(user, config.triggerLabel, excludeLabels);
 
         for (const pr of candidates) {
           if (isRunning(pr.number)) continue;

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -49,7 +49,13 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
       if (cooldownMs > 0 && lastCompletionAt > 0 && Date.now() - lastCompletionAt < cooldownMs) return;
       try {
         const excludeLabels = [LABEL_IN_PROGRESS, ...(config.excludeLabels ?? [])];
-        const candidates = await listPullRequestsWithChecks(user, config.triggerLabel, excludeLabels);
+        const { maxConcurrentTasks } = getWorkerConfig(config.name);
+        const candidates = await listPullRequestsWithChecks(
+          user,
+          config.triggerLabel,
+          excludeLabels,
+          maxConcurrentTasks,
+        );
 
         for (const pr of candidates) {
           if (isRunning(pr.number)) continue;


### PR DESCRIPTION
## 概要

`listIssues` 系のハードコードされた `--limit "10"` を、各ワーカーの `maxConcurrentTasks`（並行実行上限）の値で指定するように変更しました。

## 変更内容

### `src/gh.ts`
- `listIssuesByLabel` に `limit = 10` パラメータを追加し、`--limit` を `String(limit)` に変更
- `listPullRequestsWithChecks` に `limit = 10` パラメータを追加し、`--limit` を `String(limit)` に変更
- 後方互換のためデフォルト値は従来通り `10`

### `src/workers/issue-worker.ts`
- tick 内で `getWorkerConfig(config.name).maxConcurrentTasks` を取得し `listIssuesByLabel` に渡す

### `src/workers/pr-worker.ts`
- 同様に `maxConcurrentTasks` を取得し `listPullRequestsWithChecks` に渡す

## 補足

- ワーカーは `isWorkerAtCapacity` で上限に達すると候補の走査を `break` するため、上限件数だけ取得すれば1ティックあたりの起動には十分。
- 実行中の候補は `cc-in-progress` ラベルにより `excludeLabels` で除外されるため、検索結果には含まれない。
- `listIssuesByNumbers`（番号ベース取得）と `findOpenPrNumberByHeadRef`（特定 headRef の1件取得）は limit の意味が異なるため対象外。

## テスト

- `tsc` ビルド成功
- 既存テスト全104件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * IssueやPull Requestの取得件数を状況に応じて調整できるようになりました。
  * 並行処理数や事前チェックの設定に応じて、処理対象の候補数が適切に調整されます。

* **バグ修正**
  * CIチェック完了済みのPull Requestに偏りが生じ、処理対象が不足する可能性を改善しました。
  * 事前チェック実行時の候補取得数を最適化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->