### PR TITLE
chore(plugin): Bump version to 0.2.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,17 @@ claude-task-worker all             # Run all workers concurrently
 
 いずれもスキル本文の「バックグラウンド実行禁止」プロンプトを補完するハードガード。
 
+### Stopフックによる起動プロセスの後片付け（`plugin/scripts/stop-servers.mjs`）
+
+上記の同期実行ガードでフォアグラウンド実行を強制しても、`docker compose up -d` やE2E/テストランナーが起動するWebサーバーのように、claudeプロセスから切り離されて init/launchd に再ペアレントされるサーバー・プロセスは、スキル完了後もポートを掴んだまま残留しうる。ワーカーはスキル終了直後にそのworktreeを削除するため、worktreeをcwdに持つ残留プロセスはリソースを浪費するだけでなくworktree削除の妨げにもなる。
+
+これを防ぐため、ワーカー起動スキルのフロントマターに `Stop` フック（`plugin/scripts/stop-servers.mjs`）を設ける。スキルの `claude -p` セッション終了時に起動プロセスをベストエフォートで停止する（フックは常に exit 0 を返しスキルを異常終了させないが、即座に返るわけではなく、各サブコマンドの `timeout` 分は同期的に待機しうる。支配的なのは `docker compose down` の最大120秒待機）。処理は2段階:
+
+1. **`docker compose down --volumes --remove-orphans`**: 実行cwd直下に compose ファイル（`docker-compose.yml` / `docker-compose.yaml` / `compose.yml` / `compose.yaml`）が存在する場合のみ実行。docker未導入・未起動でも無視して継続する。
+2. **worktree配下を作業ディレクトリに持つ残留プロセスへ `SIGTERM`**: 実行cwd（worktree、`.claude/worktrees/<adj-noun-NNNN>` で一意）を cwd に持つプロセスだけを対象にする。切り離されたプロセスも起動時の cwd を保持し、worktree名はこの実行に固有なため、「この実行が起動したプロセス」だけを、ユーザー自身や別実行のプロセスに触れずに特定できる。ただし本フック自身の祖先チェーン（node フック・そのシェル・`claude` プロセスはいずれもworktreeをcwdに持つ）は除外し、自プロセスの巻き添え停止を防ぐ。プロセス列挙は Linux では `/proc/<pid>/cwd`、macOS 等では `lsof` を用いる。
+
+判定ロジック（`selectPidsToKill` / `parseLsofCwds` / `isUnder` / `resolveTargetDir`）は純粋関数として export し、`plugin/scripts/stop-servers.test.mjs` でユニットテストする。対象スキルは同期実行ガードと同じ10スキル（`exec-issue` / `fix-review-point` / `answer-issue-questions` / `create-issue-from-issue-number` / `update-issue` / `triage-created-issue` / `triage-pr` / `resolve-pr-conflict` / `check-dependabot` / `create-epic-pr`）。
+
 ### `--project` ディスパッチ
 
 `src/index.ts` は起動時に `hasProjectFilter()` で `--project` フラグの有無を判定し、指定されている場合はワーカー起動の代わりにディスパッチャーを起動する（複数プロジェクトへ同一コマンドを一括転送する仕組み）。

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-task-worker",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "claude-task-worker と組み合わせて使う getty104's base tool set (skills/agents/hooks)",
   "author": {
     "name": "getty104"

--- a/plugin/scripts/stop-servers.mjs
+++ b/plugin/scripts/stop-servers.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+// Stop hook for the worker-driven skills (exec-issue / fix-review-point / ...).
+//
+// When a `claude -p` skill run finishes, tear down anything the run started so it does
+// not linger past the run: docker services, orphaned dev/E2E web servers holding ports,
+// database processes, etc. The outer worker cleans up the run's worktree right after the
+// skill exits, and a leftover server holding that directory as its cwd both wastes
+// resources and can block the worktree removal.
+//
+// The `block-async-execution` PreToolUse guard already prevents foreground work from
+// surviving turn-end, so anything still alive at Stop time has detached and reparented
+// to init/launchd (e.g. `docker compose up -d`, a Playwright `webServer`, a test runner
+// that daemonizes). A detached process keeps whatever cwd it was started in, and the
+// run's worktree cwd (`.claude/worktrees/<adj-noun-NNNN>`) is unique to this run, so
+// "cwd is inside the run cwd" cleanly identifies the processes this run spawned without
+// ever touching the user's own or a sibling run's processes.
+//
+// Two teardown steps, both best-effort and non-fatal. The hook ALWAYS exits 0 (a teardown
+// hiccup never fails the skill), but it is not instant: each external command carries its
+// own timeout, dominated by `docker compose down` at up to 120s:
+//   1. `docker compose down --volumes --remove-orphans` when a compose file is present.
+//   2. SIGTERM every process whose cwd is inside the run cwd, excluding this hook's own
+//      ancestor chain (the node hook, its shell, and the `claude` process all share the
+//      worktree cwd — killing them would abort the run mid-Stop and corrupt the exit code
+//      the worker keys its label transitions off of).
+//
+// The pure decision logic (`selectPidsToKill` / `parseLsofCwds` / `isUnder`) is exported
+// so it can be unit tested; the OS-touching plumbing only runs as the hook entry point.
+
+import { readFileSync, readdirSync, readlinkSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+
+export function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const COMPOSE_FILES = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"];
+
+/** True when `cwd` is `dir` itself or nested inside it. */
+export function isUnder(cwd, dir) {
+  if (typeof cwd !== "string" || typeof dir !== "string" || cwd === "" || dir === "") {
+    return false;
+  }
+  // `path.relative` normalizes separators and trailing slashes for us. `cwd` is inside
+  // `dir` when the relative path neither escapes upward (`..`) nor is absolute. Match `..`
+  // only as a whole segment so a real child like `..foo` is not mistaken for an escape.
+  const rel = path.relative(dir, cwd);
+  return rel === "" || (rel !== ".." && !rel.startsWith(".." + path.sep) && !path.isAbsolute(rel));
+}
+
+/**
+ * Choose which PIDs to SIGTERM: processes whose cwd is inside `targetDir`, excluding
+ * pid<=1 and any protected pid (this hook's ancestor chain).
+ * @param {Array<{pid:number,cwd:string}>} processList
+ * @param {string} targetDir
+ * @param {Set<number>} protectedPids
+ * @returns {number[]}
+ */
+export function selectPidsToKill(processList, targetDir, protectedPids) {
+  if (!Array.isArray(processList) || typeof targetDir !== "string" || targetDir === "") {
+    return [];
+  }
+  const guarded = protectedPids instanceof Set ? protectedPids : new Set();
+  const seen = new Set();
+  const pids = [];
+  for (const entry of processList) {
+    if (!isRecord(entry)) continue;
+    const pid = entry.pid;
+    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 1) continue;
+    if (guarded.has(pid) || seen.has(pid)) continue;
+    if (!isUnder(entry.cwd, targetDir)) continue;
+    seen.add(pid);
+    pids.push(pid);
+  }
+  return pids;
+}
+
+/**
+ * Parse `lsof -w -n -d cwd -Fpn` output into {pid, cwd} records. Field-per-line format:
+ * a `p<pid>` line opens a process set, and a following `n<path>` line is its cwd (the
+ * `-d cwd` filter guarantees the only descriptor reported is the cwd).
+ * @param {string} output
+ * @returns {Array<{pid:number,cwd:string}>}
+ */
+export function parseLsofCwds(output) {
+  if (typeof output !== "string") return [];
+  const records = [];
+  let pid = null;
+  for (const line of output.split("\n")) {
+    if (line === "") continue;
+    const tag = line[0];
+    const rest = line.slice(1);
+    if (tag === "p") {
+      const n = Number.parseInt(rest, 10);
+      pid = Number.isInteger(n) ? n : null;
+    } else if (tag === "n" && pid !== null) {
+      records.push({ pid, cwd: rest });
+    }
+  }
+  return records;
+}
+
+/** Resolve the parent pid of `pid` via `ps` (portable across macOS and Linux). */
+function getParentPid(pid) {
+  try {
+    const out = execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    const ppid = Number.parseInt(out.trim(), 10);
+    return Number.isInteger(ppid) ? ppid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walk the parent chain from `startPid` up to init, collecting every ancestor pid so we
+ * never SIGTERM ourselves, our shell, or the `claude` process that hosts this hook.
+ */
+function collectAncestorPids(startPid) {
+  const ancestors = new Set();
+  let pid = startPid;
+  for (let i = 0; i < 64 && Number.isInteger(pid) && pid > 1; i++) {
+    if (ancestors.has(pid)) break;
+    ancestors.add(pid);
+    const ppid = getParentPid(pid);
+    if (ppid === null || ppid === pid) break;
+    pid = ppid;
+  }
+  return ancestors;
+}
+
+/** Enumerate every reachable process' cwd, preferring Linux /proc, falling back to lsof. */
+function listProcessCwds() {
+  if (existsSync("/proc")) {
+    const records = [];
+    let entries;
+    try {
+      entries = readdirSync("/proc");
+    } catch {
+      entries = [];
+    }
+    for (const name of entries) {
+      if (!/^\d+$/.test(name)) continue;
+      const pid = Number.parseInt(name, 10);
+      try {
+        const cwd = readlinkSync(`/proc/${name}/cwd`);
+        records.push({ pid, cwd });
+      } catch {
+        // Process gone or not readable — skip.
+      }
+    }
+    if (records.length > 0) return records;
+  }
+  try {
+    const out = execFileSync("lsof", ["-w", "-n", "-d", "cwd", "-Fpn"], {
+      encoding: "utf-8",
+      timeout: 15000,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return parseLsofCwds(out);
+  } catch {
+    return [];
+  }
+}
+
+/** Best-effort `docker compose down` when the run cwd holds a compose file. */
+function dockerComposeDown(cwd) {
+  const hasCompose = COMPOSE_FILES.some((f) => existsSync(path.join(cwd, f)));
+  if (!hasCompose) return;
+  try {
+    execFileSync("docker", ["compose", "down", "--volumes", "--remove-orphans"], {
+      cwd,
+      timeout: 120000,
+      stdio: "ignore",
+    });
+  } catch {
+    // Docker unavailable / not running / nothing to tear down — non-fatal.
+  }
+}
+
+/**
+ * Resolve the run's working directory from the Stop hook stdin, falling back to `fallback`.
+ * The result is normalized to an absolute path so it compares cleanly against the absolute
+ * cwds reported by `/proc` / `lsof` even when the stdin `cwd` arrives relative.
+ */
+export function resolveTargetDir(payload, fallback) {
+  const raw = isRecord(payload) && typeof payload.cwd === "string" && payload.cwd !== "" ? payload.cwd : fallback;
+  return path.resolve(raw);
+}
+
+function main() {
+  // When invoked as a Stop hook the JSON payload arrives on stdin; when run by hand from
+  // an interactive shell stdin is a TTY and `readFileSync(0)` would block on EOF forever,
+  // so skip the read and fall back to the process cwd in that case.
+  let payload = {};
+  if (!process.stdin.isTTY) {
+    try {
+      payload = JSON.parse(readFileSync(0, "utf-8") || "{}");
+    } catch {
+      payload = {};
+    }
+  }
+
+  const targetDir = resolveTargetDir(payload, process.cwd());
+
+  // 1. Tear down docker services declared in the run cwd.
+  dockerComposeDown(targetDir);
+
+  // 2. SIGTERM leftover processes rooted in the run cwd, sparing our own ancestor chain.
+  const protectedPids = collectAncestorPids(process.pid);
+  const pids = selectPidsToKill(listProcessCwds(), targetDir, protectedPids);
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Already exited or not permitted — ignore.
+    }
+  }
+
+  // Always exit 0 so a teardown failure never fails the skill itself. Note this is not
+  // instant: the steps above wait up to their subcommand timeouts (docker compose: 120s).
+  process.exit(0);
+}
+
+const invokedAsScript = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsScript) {
+  main();
+}

--- a/plugin/scripts/stop-servers.test.mjs
+++ b/plugin/scripts/stop-servers.test.mjs
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { isRecord, isUnder, selectPidsToKill, parseLsofCwds, resolveTargetDir } from "./stop-servers.mjs";
+
+const sep = path.sep;
+const dir = (...parts) => parts.join(sep);
+
+test("isRecord distinguishes plain objects from null/arrays/primitives", () => {
+  assert.equal(isRecord({}), true);
+  assert.equal(isRecord({ a: 1 }), true);
+  assert.equal(isRecord(null), false);
+  assert.equal(isRecord([]), false);
+  assert.equal(isRecord("x"), false);
+  assert.equal(isRecord(42), false);
+});
+
+test("isUnder matches the dir itself and nested paths, not siblings/prefixes", () => {
+  const root = dir("", "home", "u", ".claude", "worktrees", "brave-otter-0421");
+  assert.equal(isUnder(root, root), true);
+  assert.equal(isUnder(dir(root, "frontend"), root), true);
+  assert.equal(isUnder(dir(root, "a", "b", "c"), root), true);
+  // Trailing separator on the target dir is tolerated.
+  assert.equal(isUnder(dir(root, "frontend"), root + sep), true);
+  // Un-normalized segments in the child path still resolve correctly.
+  assert.equal(isUnder(dir(root, "a", "..", "b"), root), true);
+  // A real child whose name merely starts with ".." is not mistaken for an escape.
+  assert.equal(isUnder(dir(root, "..foo"), root), true);
+  // Sibling directory sharing a name prefix must not match.
+  assert.equal(isUnder(root + "-sibling", root), false);
+  assert.equal(isUnder(dir("", "home", "u"), root), false);
+  // A child path that escapes above the dir via `..` is not under it.
+  assert.equal(isUnder(dir(root, "..", "sibling"), root), false);
+  assert.equal(isUnder("", root), false);
+  assert.equal(isUnder(root, ""), false);
+});
+
+test("selectPidsToKill keeps only in-tree, unprotected, valid pids", () => {
+  const root = dir("", "run", "wt");
+  const list = [
+    { pid: 100, cwd: dir(root, "frontend") }, // keep
+    { pid: 101, cwd: root }, // keep (exact dir)
+    { pid: 102, cwd: dir("", "elsewhere") }, // drop: outside
+    { pid: 103, cwd: dir(root, "api") }, // drop: protected (ancestor)
+    { pid: 1, cwd: root }, // drop: init
+    { pid: 0, cwd: root }, // drop: pid<=1
+  ];
+  const result = selectPidsToKill(list, root, new Set([103]));
+  assert.deepEqual(result, [100, 101]);
+});
+
+test("selectPidsToKill dedupes repeated pids and ignores malformed entries", () => {
+  const root = dir("", "run", "wt");
+  const list = [
+    { pid: 200, cwd: root },
+    { pid: 200, cwd: dir(root, "x") }, // duplicate pid
+    null,
+    "nope",
+    { pid: "201", cwd: root }, // non-numeric pid
+    { pid: 2.5, cwd: root }, // non-integer pid
+    { cwd: root }, // missing pid
+  ];
+  assert.deepEqual(selectPidsToKill(list, root, new Set()), [200]);
+});
+
+test("selectPidsToKill returns [] for bad inputs", () => {
+  assert.deepEqual(selectPidsToKill(null, "/x", new Set()), []);
+  assert.deepEqual(selectPidsToKill([{ pid: 5, cwd: "/x" }], "", new Set()), []);
+  // A non-Set `protectedPids` is treated as "nothing protected", never throws.
+  assert.deepEqual(selectPidsToKill([{ pid: 5, cwd: "/x" }], "/x", null), [5]);
+});
+
+test("parseLsofCwds pairs each process line with its cwd", () => {
+  const out = ["p100", "fcwd", "n/run/wt", "p200", "fcwd", "n/run/wt/api", ""].join("\n");
+  assert.deepEqual(parseLsofCwds(out), [
+    { pid: 100, cwd: "/run/wt" },
+    { pid: 200, cwd: "/run/wt/api" },
+  ]);
+});
+
+test("parseLsofCwds ignores name lines with no preceding pid and bad input", () => {
+  assert.deepEqual(parseLsofCwds("n/orphan\np50\nn/run/wt"), [{ pid: 50, cwd: "/run/wt" }]);
+  assert.deepEqual(parseLsofCwds(""), []);
+  assert.deepEqual(parseLsofCwds(null), []);
+});
+
+test("resolveTargetDir prefers the stdin cwd, falls back otherwise", () => {
+  const abs = (p) => path.resolve(p);
+  assert.equal(resolveTargetDir({ cwd: abs("/run/wt") }, abs("/fallback")), abs("/run/wt"));
+  assert.equal(resolveTargetDir({ cwd: "" }, abs("/fallback")), abs("/fallback"));
+  assert.equal(resolveTargetDir({}, abs("/fallback")), abs("/fallback"));
+  assert.equal(resolveTargetDir(null, abs("/fallback")), abs("/fallback"));
+});
+
+test("resolveTargetDir normalizes a relative stdin cwd to an absolute path", () => {
+  const result = resolveTargetDir({ cwd: dir("rel", "worktree") }, "/fallback");
+  assert.equal(path.isAbsolute(result), true);
+  assert.equal(result, path.resolve(dir("rel", "worktree")));
+});

--- a/plugin/skills/answer-issue-questions/SKILL.md
+++ b/plugin/skills/answer-issue-questions/SKILL.md
@@ -12,7 +12,7 @@ hooks:
     - matcher: ""
       hooks:
         - type: command
-          command: docker compose down --volumes --remove-orphans
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Answer Issue Questions

--- a/plugin/skills/check-dependabot/SKILL.md
+++ b/plugin/skills/check-dependabot/SKILL.md
@@ -12,7 +12,7 @@ hooks:
     - matcher: ""
       hooks:
         - type: command
-          command: docker compose down --volumes --remove-orphans
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Check Dependabot

--- a/plugin/skills/create-epic-pr/SKILL.md
+++ b/plugin/skills/create-epic-pr/SKILL.md
@@ -9,6 +9,11 @@ hooks:
       hooks:
         - type: command
           command: node ${CLAUDE_PLUGIN_ROOT}/scripts/block-async-execution.mjs
+  Stop:
+    - matcher: ""
+      hooks:
+        - type: command
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Create Epic Pull Request

--- a/plugin/skills/create-issue-from-issue-number/SKILL.md
+++ b/plugin/skills/create-issue-from-issue-number/SKILL.md
@@ -8,6 +8,11 @@ hooks:
       hooks:
         - type: command
           command: node ${CLAUDE_PLUGIN_ROOT}/scripts/block-async-execution.mjs
+  Stop:
+    - matcher: ""
+      hooks:
+        - type: command
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Create Issue From Issue Number

--- a/plugin/skills/exec-issue/SKILL.md
+++ b/plugin/skills/exec-issue/SKILL.md
@@ -12,7 +12,7 @@ hooks:
     - matcher: ""
       hooks:
         - type: command
-          command: docker compose down --volumes --remove-orphans
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Execute Issue

--- a/plugin/skills/fix-review-point/SKILL.md
+++ b/plugin/skills/fix-review-point/SKILL.md
@@ -12,7 +12,7 @@ hooks:
     - matcher: ""
       hooks:
         - type: command
-          command: docker compose down --volumes --remove-orphans
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Fix Review Point

--- a/plugin/skills/resolve-pr-conflict/SKILL.md
+++ b/plugin/skills/resolve-pr-conflict/SKILL.md
@@ -8,6 +8,11 @@ hooks:
       hooks:
         - type: command
           command: node ${CLAUDE_PLUGIN_ROOT}/scripts/block-async-execution.mjs
+  Stop:
+    - matcher: ""
+      hooks:
+        - type: command
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Resolve PR Conflict

--- a/plugin/skills/triage-created-issue/SKILL.md
+++ b/plugin/skills/triage-created-issue/SKILL.md
@@ -12,7 +12,7 @@ hooks:
     - matcher: ""
       hooks:
         - type: command
-          command: docker compose down --volumes --remove-orphans
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Triage Created Issue

--- a/plugin/skills/triage-pr/SKILL.md
+++ b/plugin/skills/triage-pr/SKILL.md
@@ -12,7 +12,7 @@ hooks:
     - matcher: ""
       hooks:
         - type: command
-          command: docker compose down --volumes --remove-orphans
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Triage PR

--- a/plugin/skills/update-issue/SKILL.md
+++ b/plugin/skills/update-issue/SKILL.md
@@ -8,6 +8,11 @@ hooks:
       hooks:
         - type: command
           command: node ${CLAUDE_PLUGIN_ROOT}/scripts/block-async-execution.mjs
+  Stop:
+    - matcher: ""
+      hooks:
+        - type: command
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Update Issue


### PR DESCRIPTION
## 概要
`claude-task-worker` プラグインのバージョン更新（0.2.9 → 0.2.10, patch bump）と、ワーカー起動スキルの `Stop` フックによる「起動したサーバー/プロセスの停止」機能の追加をまとめて行う。

## 変更内容

### プラグインバージョン
- `plugin/.claude-plugin/plugin.json` を `0.2.9` → `0.2.10`（patch bump）

### Stop フックによる起動プロセスの後片付け（新機能）
ワーカーの `claude -p` スキルが起動したサーバー/プロセス（`docker compose up -d`、E2E/テストの webサーバー等）が、スキル完了後もポートを掴んだまま残留するのを防ぐ。同期実行ガードでフォアグラウンド実行を強制しても、init/launchd に再ペアレントされて切り離されたプロセスは残り得るため、Stop 時に後片付けする。

- **新規 `plugin/scripts/stop-servers.mjs`**: スキルセッション終了時に、常に exit 0（スキルを異常終了させない。ただし即時完了は保証されず、各サブコマンドの `timeout` 分は待機しうる＝支配的なのは `docker compose down` の最大120秒）で2段階のベストエフォート後片付けを行う共有 Stop フックスクリプト
  1. 実行cwd直下に compose ファイル（`docker-compose.yml` 等）があれば `docker compose down --volumes --remove-orphans`
  2. 実行 worktree（`.claude/worktrees/<adj-noun-NNNN>`、この実行に固有）を作業ディレクトリに持つ残留プロセスへ `SIGTERM`。本フック自身の祖先チェーン（node・シェル・`claude` 本体はいずれも worktree を cwd に持つ）は除外して自プロセスの巻き添え停止を防止。プロセス列挙は Linux は `/proc/<pid>/cwd`、macOS 等は `lsof`
- **10ワーカースキルへの配線**: 同期実行ガードと同じ10スキル（`exec-issue` / `fix-review-point` / `answer-issue-questions` / `create-issue-from-issue-number` / `update-issue` / `triage-created-issue` / `triage-pr` / `resolve-pr-conflict` / `check-dependabot` / `create-epic-pr`）の `Stop` フックを本スクリプトに統一（既存インラインの `docker compose down` を置換 + Stop フック未設定だった4スキルに追加）
- **ユニットテスト `plugin/scripts/stop-servers.test.mjs`**: 判定ロジック（`selectPidsToKill` / `parseLsofCwds` / `isUnder` / `resolveTargetDir`）を検証
- **`CLAUDE.md`**: 本フックの解説を追記

## テスト観点
- `npm test`（全127件 PASS）: 純粋関数のユニットテスト
- エンドツーエンド手動検証: worktree配下プロセスの停止 / 兄弟プレフィックスのプロセス保護 / 祖先チェーン（自プロセス）保護 / 空stdin・相対cwd正規化での正常動作 / 空白入りプラグインパスでのクォート済み Stop フック起動
- `npm run lint` / `npm run format:check` クリーン

## 修正履歴

### 2026-07-13: レビュー指摘対応（2件）
- Stop フックが「絶対にブロックしない」という CLAUDE.md ／ `stop-servers.mjs` 内コメントの記述を是正。`dockerComposeDown` は `execFileSync(..., timeout: 120000)` の同期実行のため、exit 0 は常に保証するが即時性は保証されず、`docker compose down` は最大120秒まで待機しうる旨へ修正（対応コミット: 8528cd8）
- 10スキルの Stop フック `command:` 行で `${CLAUDE_PLUGIN_ROOT}` をダブルクォートで囲み、プラグイン配置先パスに空白が含まれてもシェルの単語分割で起動失敗しないよう修正（対応コミット: 8528cd8）

### 2026-07-13: レビュー指摘対応（3件）
- `isUnder` のパス親子判定を手動の `endsWith`/`startsWith` から `path.relative` ベースへ置き換え、パス区切り文字・末尾スラッシュ・`..foo` のような正当な子ディレクトリのエッジケースを堅牢化（対応コミット: f3b6ecf）
- `main()` の stdin 読み込みに `process.stdin.isTTY` ガードを追加し、対話シェルからの手動実行時に EOF 待ちでハングしないよう修正（対応コミット: f3b6ecf）
- `resolveTargetDir` を `path.resolve` で絶対パス正規化し、`payload.cwd` が相対パスでも `/proc`・`lsof` 由来の絶対 cwd と `isUnder` で正しく比較できるよう修正（対応コミット: f3b6ecf）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * プラグインのバージョンを 0.2.10 に更新しました。
* **不具合修正**
  * スキル終了時の停止処理を改善し、起動したサーバや関連プロセスが残りにくくなりました。
* **その他**
  * サーバ停止のための専用処理を追加し、複数スキルの Stop フックで利用するよう更新しました。
  * 停止処理ロジックのテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
