### PR TITLE
chore(plugin): Bump version to 0.2.13

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-task-worker",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "claude-task-worker と組み合わせて使う getty104's base tool set (skills/agents/hooks)",
   "author": {
     "name": "getty104"


### PR DESCRIPTION
claude-task-worker プラグインのバージョンを 0.2.12 から 0.2.13 に更新（patch bump）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * プラグインのバージョンを 0.2.13 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->