### PR TITLE
chore(plugin): Bump version to 0.2.14

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-task-worker",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "claude-task-worker と組み合わせて使う getty104's base tool set (skills/agents/hooks)",
   "author": {
     "name": "getty104"


### PR DESCRIPTION
claude-task-worker プラグインのバージョンを 0.2.13 から 0.2.14 に更新（patch bump）。

#101（triage-created-issue の回答受け入れ原則の修正）のマージ後にマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * プラグインのバージョンを **0.2.14** に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->