### PR TITLE
chore: タスクタイムアウトを90分から120分に延長

### DIFF
--- a/src/task-result.ts
+++ b/src/task-result.ts
@@ -1,4 +1,4 @@
-export const TASK_TIMEOUT_MS = 90 * 60 * 1000;
+export const TASK_TIMEOUT_MS = 120 * 60 * 1000;
 
 // 失敗時の通知に含める stderr 末尾の上限。claude -p はエラーを stderr にしか出さない
 // ことがあり、破棄すると失敗通知が空になって原因調査ができなくなる。


### PR DESCRIPTION
## 概要

ワーカーが起動する `claude -p` タスクの上限時間 `TASK_TIMEOUT_MS` を 90 分 → 120 分に延長する。

## 変更内容

- `src/task-result.ts`: `TASK_TIMEOUT_MS` を `90 * 60 * 1000` → `120 * 60 * 1000`

この定数は `src/process-manager.ts:237` の強制終了タイマーで使われる唯一の箇所のため、全ワーカー共通のタスク上限が 120 分になる。他に 90 分をハードコードしている箇所やドキュメント記述はなし。

## 確認

- `npm run build` が通ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * タスクのタイムアウト時間を90分から120分に延長しました。
  * タイムアウト時に表示される案内も、延長後の時間に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->