### PR TITLE
refactor: ワーカーのタスクタイムアウト処理を削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ claude-task-worker all             # Run all workers concurrently
 
 1. **spawn 環境変数**（`src/claude-args.ts` の `CLAUDE_SPAWN_ENV`、`process-manager.ts` の spawn で `process.env` に上書きマージ）: 全ワーカー起動に一律注入される。対象プロジェクトのリポジトリ設定に依存させないため、settings.json ではなく spawn 環境変数で渡す（プラグインの settings.json は env を配布できない）。
    - `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`: Claude 管理下のバックグラウンド機構（Bash の `run_in_background`・サブエージェントの自動バックグラウンド化）のみを無効化する。`nohup`/`disown`/末尾 `&` によるシェルレベルの detach や `docker compose up -d` 等が起動する切り離しプロセスまでは防げないため、未完のままターンが終わる事故を完全には防止できない（Stop フックによる起動プロセスの後片付けや、下記4のワーカーレベル完了検証が引き続き必要）。プロンプトでのバックグラウンド禁止ルールやツール単位のガードは不要になった（かつて存在した PreToolUse フック `block-async-execution.mjs` と `worker-skill-executor` エージェントは撤去済み）。
-   - `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0`: 万一バックグラウンド化される経路が残った場合の保険。`claude -p` のバックグラウンドサブエージェント待機（v2.1.182+ でデフォルト10分上限）を無制限にする。外側はワーカーの `TASK_TIMEOUT_MS`（`src/task-result.ts`）が上限として効く。
+   - `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0`: 万一バックグラウンド化される経路が残った場合の保険。`claude -p` のバックグラウンドサブエージェント待機（v2.1.182+ でデフォルト10分上限）を無制限にする。ワーカー側にタスク実行時間の上限は設けていない（長時間タスクを途中で強制終了するとラベル・worktreeが中途半端な状態で残るため）。
 2. **CLI レベルの `--disallowedTools`**（`src/claude-args.ts` の `DISALLOWED_TOOLS`）: 自律非対話実行では原理的に使い道がない（または有害な）ツールを完全無効化する。対象カテゴリ:
    - 遅延/yield: `Monitor` / `ScheduleWakeup`（後続ウェイクアップ前提だが print モードでは発火せず、プロセスが早期終了する）
    - 対話/承認: `AskUserQuestion` / `EnterPlanMode`（回答・承認するユーザーが存在しない）

--- a/src/claude-args.ts
+++ b/src/claude-args.ts
@@ -48,7 +48,6 @@ export const DISALLOWED_TOOLS_ARG = DISALLOWED_TOOLS.join(",");
 // - CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0: 万一バックグラウンド化される経路が残った
 //   場合の保険。`claude -p` はバックグラウンドサブエージェントの完了を待つが、
 //   v2.1.182+ ではデフォルト10分で打ち切られる。0 は「無制限に待機」を意味する。
-//   待機の外側はワーカーの TASK_TIMEOUT_MS（process-manager）が上限として効く。
 //
 // 対象プロジェクトのリポジトリ設定に依存させないため、settings.json ではなく spawn 環境
 // 変数として全ワーカー起動に一律注入する（プラグインの settings.json は env を配布できない）。

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -2,7 +2,7 @@ import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { getWorkerConfig } from "./config.js";
 import { getDisplayWidth, truncateToWidth, padToWidth } from "./table.js";
-import { TASK_TIMEOUT_MS, STDERR_TAIL_LIMIT, buildTaskResult } from "./task-result.js";
+import { STDERR_TAIL_LIMIT, buildTaskResult } from "./task-result.js";
 
 type TaskStatus = "running" | "completed" | "failed";
 
@@ -219,29 +219,9 @@ export function run(
     }
   });
 
-  let timedOut = false;
-  const timeoutHandle = setTimeout(() => {
-    timedOut = true;
-    console.error(`[worker] task #${id} timed out after ${TASK_TIMEOUT_MS / 1000}s, terminating`);
-    if (child.pid) {
-      try {
-        process.kill(-child.pid, "SIGTERM");
-      } catch {
-        try {
-          child.kill("SIGTERM");
-        } catch {
-          // ignore
-        }
-      }
-    }
-  }, TASK_TIMEOUT_MS);
-  timeoutHandle.unref();
-
   child.on("close", async (code) => {
-    clearTimeout(timeoutHandle);
     const { status: finalStatus, output } = buildTaskResult(
       code,
-      timedOut,
       Buffer.concat(outputChunks).toString("utf-8"),
       Buffer.concat(stderrChunks).toString("utf-8").slice(-STDERR_TAIL_LIMIT),
     );
@@ -265,7 +245,6 @@ export function run(
   });
 
   child.on("error", async (err) => {
-    clearTimeout(timeoutHandle);
     console.error(`[worker] failed to spawn process for #${id}: ${err.message}`);
     try {
       await Promise.race([

--- a/src/task-result.test.ts
+++ b/src/task-result.test.ts
@@ -5,44 +5,38 @@ import type * as TaskResultModule from "./task-result";
 const { buildTaskResult } = (await import("./task-result.ts")) as typeof TaskResultModule;
 
 test("exit 0 with output is completed and keeps stdout as-is", () => {
-  const result = buildTaskResult(0, false, "判定: パターンB-通常（マージ済み）\n", "");
+  const result = buildTaskResult(0, "判定: パターンB-通常（マージ済み）\n", "");
   assert.equal(result.status, "completed");
   assert.equal(result.output, "判定: パターンB-通常（マージ済み）\n");
 });
 
 test("exit 0 with empty stdout is failed (aborted session before the model ran)", () => {
-  const result = buildTaskResult(0, false, "", "");
+  const result = buildTaskResult(0, "", "");
   assert.equal(result.status, "failed");
   assert.match(result.output, /exited with code 0 but produced no output/);
 });
 
 test("exit 0 with whitespace-only stdout is failed", () => {
-  const result = buildTaskResult(0, false, "\n", "");
+  const result = buildTaskResult(0, "\n", "");
   assert.equal(result.status, "failed");
   assert.match(result.output, /produced no output/);
 });
 
 test("non-zero exit is failed and reports the exit code", () => {
-  const result = buildTaskResult(1, false, "partial output", "");
+  const result = buildTaskResult(1, "partial output", "");
   assert.equal(result.status, "failed");
   assert.match(result.output, /^partial output/);
   assert.match(result.output, /exited with code 1/);
 });
 
-test("timeout is failed with a timeout note even on exit 0", () => {
-  const result = buildTaskResult(0, true, "some output", "");
-  assert.equal(result.status, "failed");
-  assert.match(result.output, /timed out after/);
-});
-
 test("stderr tail is appended on failure", () => {
-  const result = buildTaskResult(1, false, "", "fatal: something broke");
+  const result = buildTaskResult(1, "", "fatal: something broke");
   assert.equal(result.status, "failed");
   assert.match(result.output, /\[stderr\] fatal: something broke/);
 });
 
 test("stderr tail is not appended on success", () => {
-  const result = buildTaskResult(0, false, "ok", "warning: noise");
+  const result = buildTaskResult(0, "ok", "warning: noise");
   assert.equal(result.status, "completed");
   assert.equal(result.output, "ok");
 });

--- a/src/task-result.ts
+++ b/src/task-result.ts
@@ -1,5 +1,3 @@
-export const TASK_TIMEOUT_MS = 120 * 60 * 1000;
-
 // 失敗時の通知に含める stderr 末尾の上限。claude -p はエラーを stderr にしか出さない
 // ことがあり、破棄すると失敗通知が空になって原因調査ができなくなる。
 export const STDERR_TAIL_LIMIT = 8 * 1024;
@@ -19,18 +17,11 @@ export interface TaskResult {
  * 再装填される triage-pr では毎ポーリングで空振りセッションを起動し続ける
  * 無限リトライループになる。
  */
-export function buildTaskResult(
-  code: number | null,
-  timedOut: boolean,
-  stdout: string,
-  stderrTail: string,
-): TaskResult {
+export function buildTaskResult(code: number | null, stdout: string, stderrTail: string): TaskResult {
   const emptyOutput = stdout.trim() === "";
-  const completed = !timedOut && code === 0 && !emptyOutput;
+  const completed = code === 0 && !emptyOutput;
   let output = stdout;
-  if (timedOut) {
-    output += `\n[worker] task timed out after ${TASK_TIMEOUT_MS / 1000}s`;
-  } else if (code === 0 && emptyOutput) {
+  if (code === 0 && emptyOutput) {
     output +=
       "[worker] claude exited with code 0 but produced no output " +
       "(session aborted before the model ran; e.g. a skill preamble command failed)";


### PR DESCRIPTION
## 概要

ワーカーがタスクを120分で強制終了するタイムアウト処理を削除しました。

長時間タスクを途中で打ち切ると、ラベル遷移や worktree のクリーンアップが中途半端な状態で残るため、claude プロセスの自然終了を待つ方針に変更します。

## 変更内容

- `src/task-result.ts`: `TASK_TIMEOUT_MS` 定数、`buildTaskResult()` の `timedOut` 引数とタイムアウト注記の分岐を削除
- `src/process-manager.ts`: 120分経過でプロセスグループに `SIGTERM` を送る `setTimeout` ガードと、`close` / `error` ハンドラの `clearTimeout` を削除
- `src/task-result.test.ts`: タイムアウトのテストケースを削除し、他ケースを新シグネチャに追従
- `src/claude-args.ts` / `CLAUDE.md`: `TASK_TIMEOUT_MS` を「外側の上限」として説明していた記述を更新

## 維持したもの（別機構のため対象外）

- `onComplete` の120秒レースガード（コールバックのハング防止）
- `src/dispatcher.ts` のシャットダウン待機タイムアウト
- `src/herdr.ts` の `HERDR_TIMEOUT_MS`（herdr コマンド自体の実行タイムアウト）
- `src/index.ts` のシャットダウン時60秒クリーンアップ待ち

## 影響

ハングしたタスクは自動停止しなくなり、`Ctrl-C`（`shutdown()`）による手動停止が必要になります。

## 確認

- `npm run build` 成功
- `npm test` 130 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更点**
  * タスク実行時間の固定上限を廃止し、長時間の処理も継続できるようになりました。
  * 実行結果は終了コードと標準出力に基づいて判定され、空の出力や異常終了は失敗として表示されます。
  * 失敗時にはエラー内容の末尾が結果に追加され、問題の確認が容易になりました。
* **ドキュメント**
  * バックグラウンド待機上限に関する説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->