### PR TITLE
feat: usage実行時にRunCat Neo用のスナップショットを書き出す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ claude-task-worker all             # Run all workers concurrently
 - **`src/commands/init.ts`** - GitHub ラベル初期作成コマンド
 - **`src/commands/install.ts`** - マーケットプレイス追加・プラグインインストール・CLI自体のインストールを一括で行うコマンド
 - **`src/commands/update.ts`** - プラグイン/マーケットプレイス・CLI自体の更新コマンド
+- **`src/runcat.ts`** - RunCat Neo 用の利用状況スナップショット書き出し。`usage` コマンド実行時に `~/.claude/runcat-usage.json`（`RUNCAT_OUT_FILE` で上書き可）へ一時ファイル + rename で原子的に書き込む。フォーマットは `~/dotfiles/claude/statusline.py` の出力と揃えてある（`buildRuncatSnapshot`/`resetStamp`/`resetHour`）
 - **`src/workers/`** - 各ワーカー実装
 - **`plugin/`** - Claude Code プラグイン本体（`.claude-plugin/plugin.json`, `skills/`, `agents/`, `hooks/`, `scripts/`, `.mcp.json`）
 - **`.claude-plugin/marketplace.json`** - このリポジトリを Claude Code マーケットプレイスとして公開するための定義

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ claude-task-worker all             # Run all workers concurrently
 - **`src/commands/init.ts`** - GitHub ラベル初期作成コマンド
 - **`src/commands/install.ts`** - マーケットプレイス追加・プラグインインストール・CLI自体のインストールを一括で行うコマンド
 - **`src/commands/update.ts`** - プラグイン/マーケットプレイス・CLI自体の更新コマンド
-- **`src/runcat.ts`** - RunCat Neo 用の利用状況スナップショット書き出し。`usage` コマンド実行時に `~/.claude/runcat-usage.json`（`RUNCAT_OUT_FILE` で上書き可）へ一時ファイル + rename で原子的に書き込む。フォーマットは `~/dotfiles/claude/statusline.py` の出力と揃えてある（`buildRuncatSnapshot`/`resetStamp`/`resetHour`）
+- **`src/runcat.ts`** - RunCat Neo 用の利用状況スナップショット書き出し。`~/.claude/runcat-usage.json`（`RUNCAT_OUT_FILE` で上書き可）へ一時ファイル + rename で原子的に書き込む。フォーマットは `~/dotfiles/claude/statusline.py` の出力と揃えてある（`buildRuncatSnapshot`/`resetStamp`/`resetHour`）。書き出しは `slack.ts` の `buildTokenLimitText()` 経由で行われるため、`usage` コマンド実行時に加えてワーカーのタスク完了/失敗通知のたびに更新される（Slack webhook 未設定でも通知が no-op になるだけでスナップショットは更新される）。ただし利用状況の取得自体は `/tmp/claude-usage-cache.json` の360秒キャッシュを挟むため、値の鮮度は最大6分古くなりうる
 - **`src/workers/`** - 各ワーカー実装
 - **`plugin/`** - Claude Code プラグイン本体（`.claude-plugin/plugin.json`, `skills/`, `agents/`, `hooks/`, `scripts/`, `.mcp.json`）
 - **`.claude-plugin/marketplace.json`** - このリポジトリを Claude Code マーケットプレイスとして公開するための定義

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,7 @@ import { init } from "./commands/init";
 import { install } from "./commands/install";
 import { update } from "./commands/update";
 import { version } from "./commands/version";
-import { fetchUsageInfo, formatTokenLimitText, send } from "./slack";
-import { writeRuncatUsage } from "./runcat";
+import { buildTokenLimitText, send } from "./slack";
 import {
   hasProjectFilter,
   parseProjectFilters,
@@ -250,14 +249,12 @@ if (hasProjectFilter()) {
   })();
 } else if (workerType === "usage") {
   (async () => {
-    const usage = await fetchUsageInfo();
-    if (!usage) {
+    // buildTokenLimitText は取得した利用状況で RunCat 用スナップショットも更新する
+    const text = await buildTokenLimitText();
+    if (!text) {
       console.error("Failed to fetch usage info");
       process.exit(1);
     }
-    // RunCat Neo 用のスナップショット。書き出し失敗はログのみで Slack 通知は継続する
-    writeRuncatUsage(usage);
-    const text = formatTokenLimitText(usage);
     console.log(text.trim());
     await send({ text: `📊 Usage${text}` });
   })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ import { init } from "./commands/init";
 import { install } from "./commands/install";
 import { update } from "./commands/update";
 import { version } from "./commands/version";
-import { buildTokenLimitText, send } from "./slack";
+import { fetchUsageInfo, formatTokenLimitText, send } from "./slack";
+import { writeRuncatUsage } from "./runcat";
 import {
   hasProjectFilter,
   parseProjectFilters,
@@ -249,11 +250,14 @@ if (hasProjectFilter()) {
   })();
 } else if (workerType === "usage") {
   (async () => {
-    const text = await buildTokenLimitText();
-    if (!text) {
+    const usage = await fetchUsageInfo();
+    if (!usage) {
       console.error("Failed to fetch usage info");
       process.exit(1);
     }
+    // RunCat Neo 用のスナップショット。書き出し失敗はログのみで Slack 通知は継続する
+    writeRuncatUsage(usage);
+    const text = formatTokenLimitText(usage);
     console.log(text.trim());
     await send({ text: `📊 Usage${text}` });
   })();

--- a/src/runcat.test.ts
+++ b/src/runcat.test.ts
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type * as RuncatModule from "./runcat";
+import type { UsageInfo } from "./slack";
+
+const { buildRuncatSnapshot, resetStamp, resetHour, writeRuncatUsage } =
+  (await import("./runcat.ts")) as typeof RuncatModule;
+
+// 2026-07-19 21:00 JST
+const NOW = new Date("2026-07-19T12:00:00Z");
+
+const usage: UsageInfo = {
+  fiveHourUtilization: 12,
+  fiveHourResetsAt: "2026-07-19T14:00:00Z", // 23:00 JST（同日）
+  sevenDayUtilization: 34.5678,
+  sevenDayResetsAt: "2026-07-22T01:30:00Z", // 07/22 10:30 JST（別日）
+};
+
+test("resetStamp omits the date when the reset is on the same JST day", () => {
+  assert.equal(resetStamp("2026-07-19T14:00:00Z", NOW), "23:00");
+});
+
+test("resetStamp includes the date when the reset falls on another JST day", () => {
+  assert.equal(resetStamp("2026-07-22T01:30:00Z", NOW), "07/22 10:30");
+});
+
+test("resetStamp and resetHour return an empty string for an unparsable value", () => {
+  assert.equal(resetStamp("not-a-date", NOW), "");
+  assert.equal(resetHour("not-a-date"), "");
+});
+
+test("resetHour returns the JST hour only", () => {
+  assert.equal(resetHour("2026-07-19T14:00:00Z"), "23");
+});
+
+test("buildRuncatSnapshot formats metrics like statusline.py", () => {
+  const snapshot = buildRuncatSnapshot(usage, NOW);
+  assert.equal(snapshot.title, "Claude Code");
+  assert.equal(snapshot.symbol, "staroflife");
+  assert.deepEqual(snapshot.metrics, [
+    { title: "5h", formattedValue: "12% ↻23:00", normalizedValue: 0.12 },
+    { title: "7d", formattedValue: "34.5678% ↻07/22 10:30", normalizedValue: 0.3457 },
+  ]);
+});
+
+test("buildRuncatSnapshot builds a compact bar value with the 5h reset hour", () => {
+  assert.equal(buildRuncatSnapshot(usage, NOW).metricsBarValue, "12/34.5678 ↻23");
+});
+
+test("buildRuncatSnapshot drops the reset marker from the bar when the 5h reset is unparsable", () => {
+  const snapshot = buildRuncatSnapshot({ ...usage, fiveHourResetsAt: "" }, NOW);
+  assert.equal(snapshot.metricsBarValue, "12/34.5678");
+  assert.equal(snapshot.metrics[0].formattedValue, "12%");
+});
+
+test("buildRuncatSnapshot stamps lastUpdatedDate as UTC without milliseconds", () => {
+  assert.equal(buildRuncatSnapshot(usage, NOW).lastUpdatedDate, "2026-07-19T12:00:00Z");
+});
+
+test("writeRuncatUsage writes the snapshot and leaves no temp file behind", () => {
+  const dir = mkdtempSync(join(tmpdir(), "runcat-test-"));
+  const out = join(dir, "nested", "runcat-usage.json");
+  writeRuncatUsage(usage, out);
+
+  const written = JSON.parse(readFileSync(out, "utf-8"));
+  assert.equal(written.title, "Claude Code");
+  assert.equal(written.metrics.length, 2);
+  assert.deepEqual(readdirSync(join(dir, "nested")), ["runcat-usage.json"]);
+});

--- a/src/runcat.ts
+++ b/src/runcat.ts
@@ -1,0 +1,107 @@
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { UsageInfo } from "./slack";
+
+// RunCat Neo が読み取るスナップショットの出力先（statusline.py と同じ既定パス・同じ環境変数で上書き可能）
+const RUNCAT_OUT_FILE =
+  process.env.RUNCAT_OUT_FILE ?? join(process.env.HOME ?? homedir(), ".claude", "runcat-usage.json");
+
+const JST = "Asia/Tokyo";
+
+export interface RuncatMetric {
+  title: string;
+  formattedValue: string;
+  normalizedValue: number;
+}
+
+export interface RuncatSnapshot {
+  title: string;
+  symbol: string;
+  metrics: RuncatMetric[];
+  metricsBarValue?: string;
+  lastUpdatedDate: string;
+}
+
+/** Python の `%g` 相当。有効数字6桁に丸めつつ末尾の 0 を落とす（12.0 → "12"、12.3456789 → "12.3457"） */
+function formatG(value: number): string {
+  return String(Number(value.toPrecision(6)));
+}
+
+function jstFields(date: Date): { month: string; day: string; hour: string; minute: string } {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: JST,
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const pick = (type: Intl.DateTimeFormatPartTypes): string => parts.find((p) => p.type === type)?.value ?? "";
+  return { month: pick("month"), day: pick("day"), hour: pick("hour"), minute: pick("minute") };
+}
+
+function parseResetsAt(isoString: string): Date | null {
+  const date = new Date(isoString);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** 'HH:MM' 形式。日を跨ぐ場合は 'MM/DD HH:MM' として日付も付ける。不正値は空文字。 */
+export function resetStamp(isoString: string, now: Date = new Date()): string {
+  const date = parseResetsAt(isoString);
+  if (!date) return "";
+  const reset = jstFields(date);
+  const today = jstFields(now);
+  const time = `${reset.hour}:${reset.minute}`;
+  if (reset.month === today.month && reset.day === today.day) return time;
+  return `${reset.month}/${reset.day} ${time}`;
+}
+
+/** 'HH' のみ。バーのように幅が限られる用途向け。不正値は空文字。 */
+export function resetHour(isoString: string): string {
+  const date = parseResetsAt(isoString);
+  return date ? jstFields(date).hour : "";
+}
+
+function metric(title: string, pct: number, resetsAt: string, now: Date): RuncatMetric {
+  const stamp = resetStamp(resetsAt, now);
+  return {
+    title,
+    formattedValue: `${formatG(pct)}%` + (stamp ? ` ↻${stamp}` : ""),
+    normalizedValue: Math.round((pct / 100) * 10000) / 10000,
+  };
+}
+
+export function buildRuncatSnapshot(usage: UsageInfo, now: Date = new Date()): RuncatSnapshot {
+  // バーは狭いので % は省き、5h のリセットを時 (HH) だけ添える
+  const bar = `${formatG(usage.fiveHourUtilization)}/${formatG(usage.sevenDayUtilization)}`;
+  const stamp = resetHour(usage.fiveHourResetsAt);
+  return {
+    title: "Claude Code",
+    symbol: "staroflife",
+    metrics: [
+      metric("5h", usage.fiveHourUtilization, usage.fiveHourResetsAt, now),
+      metric("7d", usage.sevenDayUtilization, usage.sevenDayResetsAt, now),
+    ],
+    metricsBarValue: stamp ? `${bar} ↻${stamp}` : bar,
+    lastUpdatedDate: now.toISOString().replace(/\.\d{3}Z$/, "Z"),
+  };
+}
+
+/**
+ * RunCat Neo 用のスナップショットを書き出す。
+ * RunCat 側が読み取り中の中途半端な内容を掴まないよう、一時ファイルへ書いてから rename で差し替える。
+ */
+export function writeRuncatUsage(usage: UsageInfo, outFile: string = RUNCAT_OUT_FILE): void {
+  const snapshot = buildRuncatSnapshot(usage);
+  const dir = dirname(outFile);
+  const tmp = join(dir, `.runcat-${process.pid}-${Date.now()}.json`);
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(tmp, JSON.stringify(snapshot), "utf-8");
+    renameSync(tmp, outFile);
+  } catch (err) {
+    rmSync(tmp, { force: true });
+    console.error(`[runcat] Failed to write ${outFile}: ${err}`);
+  }
+}

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -24,7 +24,7 @@ export async function send(payload: Record<string, unknown>): Promise<void> {
   }
 }
 
-interface UsageInfo {
+export interface UsageInfo {
   fiveHourUtilization: number;
   fiveHourResetsAt: string;
   sevenDayUtilization: number;
@@ -73,7 +73,7 @@ function writeUsageCache(data: UsageInfo): void {
   }
 }
 
-async function fetchUsageInfo(): Promise<UsageInfo | null> {
+export async function fetchUsageInfo(): Promise<UsageInfo | null> {
   const cached = readUsageCache();
   if (cached) return cached;
 
@@ -121,16 +121,18 @@ function formatResetTimeJST(isoString: string): string {
   });
 }
 
-export async function buildTokenLimitText(): Promise<string> {
-  const usage = await fetchUsageInfo();
-  if (!usage) return "";
-
+export function formatTokenLimitText(usage: UsageInfo): string {
   const fiveH = usage.fiveHourUtilization.toFixed(1);
   const sevenD = usage.sevenDayUtilization.toFixed(1);
   const emoji = utilizationEmoji(Math.max(usage.fiveHourUtilization, usage.sevenDayUtilization));
   const fiveHReset = formatResetTimeJST(usage.fiveHourResetsAt);
   const sevenDReset = formatResetTimeJST(usage.sevenDayResetsAt);
   return ` | ${emoji} 5h: ${fiveH}% (reset: ${fiveHReset}) / 7d: ${sevenD}% (reset: ${sevenDReset})`;
+}
+
+export async function buildTokenLimitText(): Promise<string> {
+  const usage = await fetchUsageInfo();
+  return usage ? formatTokenLimitText(usage) : "";
 }
 
 export async function notifyTaskCompleted(

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -3,6 +3,8 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+// runcat.ts 側の slack.ts への import は type-only なので、実行時の循環参照は発生しない
+import { writeRuncatUsage } from "./runcat";
 
 const execAsync = promisify(exec);
 
@@ -73,7 +75,7 @@ function writeUsageCache(data: UsageInfo): void {
   }
 }
 
-export async function fetchUsageInfo(): Promise<UsageInfo | null> {
+async function fetchUsageInfo(): Promise<UsageInfo | null> {
   const cached = readUsageCache();
   if (cached) return cached;
 
@@ -121,7 +123,7 @@ function formatResetTimeJST(isoString: string): string {
   });
 }
 
-export function formatTokenLimitText(usage: UsageInfo): string {
+function formatTokenLimitText(usage: UsageInfo): string {
   const fiveH = usage.fiveHourUtilization.toFixed(1);
   const sevenD = usage.sevenDayUtilization.toFixed(1);
   const emoji = utilizationEmoji(Math.max(usage.fiveHourUtilization, usage.sevenDayUtilization));
@@ -130,9 +132,16 @@ export function formatTokenLimitText(usage: UsageInfo): string {
   return ` | ${emoji} 5h: ${fiveH}% (reset: ${fiveHReset}) / 7d: ${sevenD}% (reset: ${sevenDReset})`;
 }
 
+/**
+ * 現在の利用状況を取得し、RunCat Neo 用スナップショットを更新したうえで通知に添えるテキストを返す。
+ * ワーカーの完了/失敗通知はすべてここを通るため、タスクが終わるたびに RunCat 側も最新化される
+ * （Slack webhook 未設定でも通知が no-op になるだけで、スナップショットの更新は行われる）。
+ */
 export async function buildTokenLimitText(): Promise<string> {
   const usage = await fetchUsageInfo();
-  return usage ? formatTokenLimitText(usage) : "";
+  if (!usage) return "";
+  writeRuncatUsage(usage);
+  return formatTokenLimitText(usage);
 }
 
 export async function notifyTaskCompleted(


### PR DESCRIPTION
## 概要

`claude-task-worker usage` の実行時に、RunCat Neo が読み取る `~/.claude/runcat-usage.json` へ利用状況のスナップショットを書き出すようにしました。

出力先は `RUNCAT_OUT_FILE` で上書きできます。フォーマットは `~/dotfiles/claude/statusline.py` の `write_runcat` の出力と揃えてあるため、statusline / usage コマンドのどちらの経路で書いても RunCat Neo 側は同じスキーマを読めます。

## 変更内容

- **`src/runcat.ts`（新規）**
  - スナップショット形式（`title` / `symbol` / `metrics` / `metricsBarValue` / `lastUpdatedDate`）、`%g` 相当の数値整形、`normalizedValue` の小数4桁丸め、バー用に時（`HH`）のみ添える挙動まで statusline.py に合わせた
  - 一時ファイル → `rename` の原子的書き込みで、RunCat 側が書きかけの内容を掴まないようにする
  - 書き出しに失敗しても `[runcat]` プレフィックスのログのみで、Slack 通知は止めない
- **`src/slack.ts`**: `buildTokenLimitText` を取得（`fetchUsageInfo`）と整形（`formatTokenLimitText`）に分離。既存呼び出し側のシグネチャは変更なし
- **`src/index.ts`**: `usage` ブランチで取得した `UsageInfo` を RunCat 書き出しと Slack 通知で使い回す
- **`CLAUDE.md`**: コア構成に `src/runcat.ts` を追記

### statusline.py との差分

1. **リセット時刻の入力形式** — statusline は Claude Code から UNIX epoch 秒で受け取るが、usage API は ISO 文字列を返すためそちらをパースする
2. **タイムゾーン** — statusline はローカルタイム、こちらは既存の `formatResetTimeJST` に合わせて JST 固定

## 動作確認

- `npm test` — 139件 pass（`src/runcat.test.ts` の新規9件を含む）
- `tsc --noEmit` / `eslint` / `prettier --check` — いずれも通過
- `RUNCAT_OUT_FILE` を差し替えて `usage` を実行し（webhook は空にして通知は飛ばさず）、書き出し内容を確認:

```json
{"title":"Claude Code","symbol":"staroflife","metrics":[{"title":"5h","formattedValue":"21% ↻13:00","normalizedValue":0.21},{"title":"7d","formattedValue":"62% ↻10:00","normalizedValue":0.62}],"metricsBarValue":"21/62 ↻13","lastUpdatedDate":"2026-07-18T23:58:40Z"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)