### PR TITLE
chore(plugin): Bump version to 0.2.20

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-task-worker",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "claude-task-worker と組み合わせて使う getty104's base tool set (skills/agents/hooks)",
   "author": {
     "name": "getty104"


### PR DESCRIPTION
claude-task-worker プラグインのバージョンを 0.2.19 から 0.2.20 に更新（patch bump）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)