### PR TITLE
fix(table): herdrモードの実行中タスクが完了セクションに表示される問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ claude-task-worker all             # Run all workers concurrently
 - **`src/index.ts`** - CLI エントリポイント。コマンドルーティング
 - **`src/gh.ts`** - GitHub CLI (`gh`) ラッパー。全GitHub操作を集約
 - **`src/process-manager.ts`** - 子プロセス管理。リアルタイムステータステーブル表示、プロセスライフサイクル管理
+- **`src/table.ts`** - 端末テーブル描画のヘルパー。`getDisplayWidth()`/`truncateToWidth()`/`padToWidth()`（全角を幅2として扱う桁揃え）、`buildTaskTableLines()`（ステータステーブルの行組み立て）。`buildTaskTableLines()` は副作用を持たない純粋関数で、`process-manager.ts` の `renderTable()` が `console.clear()` + 出力のみを担う。**実行中/完了のセクション振り分けは `TaskTableEntry.status` で行い、表示用の status 文字列では判定しない**。herdr モードの実行中行は `running:working` のように agentStatus を併記した装飾済み文字列になるため、表示値で `=== "running"` を見ると実行中タスクが完了セクション（区切り罫線の下）へ紛れ込む
 - **`src/commands/init.ts`** - GitHub ラベル初期作成コマンド。あわせて CodeGraph のセットアップ（グローバル gitignore への `.codegraph/` 登録 → `codegraph init` によるインデックス構築）も行う
 - **`src/commands/install.ts`** - マーケットプレイス追加・プラグインインストール・CLI自体のインストール・CodeGraph CLI のインストールを一括で行うコマンド
 - **`src/commands/update.ts`** - プラグイン/マーケットプレイス・CLI自体・CodeGraph CLI の更新コマンド

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -67,7 +67,6 @@ export function isWorkerAtCapacity(workerName: string): boolean {
   return count >= getWorkerConfig(workerName).maxConcurrentTasks;
 }
 
-
 function renderTable(): void {
   const lines = buildTaskTableLines([...tasks.values()]);
   if (lines.length === 0) return;

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -4,7 +4,7 @@ import { basename } from "node:path";
 import { getWorkerConfig } from "./config.js";
 import type { AgentStatus } from "./herdr.js";
 import type { HerdrTask } from "./herdr-runner.js";
-import { getDisplayWidth, truncateToWidth, padToWidth } from "./table.js";
+import { buildTaskTableLines } from "./table.js";
 import { STDERR_TAIL_LIMIT, buildTaskResult } from "./task-result.js";
 import type { TaskResult } from "./task-result.js";
 import { findProjectNameByPath, getRunMode } from "./user-config.js";
@@ -19,7 +19,7 @@ const herdrTasks = new Map<number, HerdrTask>();
 // force kill 時に herdr タスクの待機ループを抜けさせるためのフラグ。
 const herdrAbortSignal = { aborted: false };
 
-interface TaskEntry {
+export interface TaskEntry {
   id: number;
   title: string;
   status: TaskStatus;
@@ -67,112 +67,10 @@ export function isWorkerAtCapacity(workerName: string): boolean {
   return count >= getWorkerConfig(workerName).maxConcurrentTasks;
 }
 
-function formatDuration(start: Date, end: Date = new Date()): string {
-  const diffMs = end.getTime() - start.getTime();
-  const totalSeconds = Math.floor(diffMs / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
-}
-
-function formatTime(date: Date): string {
-  const h = String(date.getHours()).padStart(2, "0");
-  const m = String(date.getMinutes()).padStart(2, "0");
-  const s = String(date.getSeconds()).padStart(2, "0");
-  return `${h}:${m}:${s}`;
-}
 
 function renderTable(): void {
-  const entries = [...tasks.values()];
-  if (entries.length === 0) return;
-
-  const runningTasks = entries.filter((t) => t.status === "running");
-  const finishedTasks = entries.filter((t) => t.status !== "running");
-
-  const maxTitleWidth = 40;
-  const maxPathWidth = 40;
-
-  const allRows = [
-    ...runningTasks.map((t) => ({
-      id: `#${t.id}`,
-      title: getDisplayWidth(t.title) > maxTitleWidth ? truncateToWidth(t.title, maxTitleWidth) : t.title,
-      worker: t.workerName,
-      path: t.path ? (t.path.length > maxPathWidth ? truncateToWidth(t.path, maxPathWidth) : t.path) : "",
-      // herdr モードでは agent ステータス（working / blocked 等）を併記し、
-      // 人の介入が必要な blocked にも気づけるようにする。
-      status: t.agentStatus ? `${t.status}:${t.agentStatus}` : t.status,
-      time: formatTime(t.startedAt),
-      duration: formatDuration(t.startedAt),
-    })),
-    ...finishedTasks.map((t) => ({
-      id: `#${t.id}`,
-      title: getDisplayWidth(t.title) > maxTitleWidth ? truncateToWidth(t.title, maxTitleWidth) : t.title,
-      worker: t.workerName,
-      path: t.path ? (t.path.length > maxPathWidth ? truncateToWidth(t.path, maxPathWidth) : t.path) : "",
-      status: t.status,
-      time: formatTime(t.finishedAt ?? t.startedAt),
-      duration: formatDuration(t.startedAt, t.finishedAt),
-    })),
-  ];
-
-  const hasPath = allRows.some((r) => r.path !== "");
-
-  const colWidths = {
-    id: Math.max(3, ...allRows.map((r) => r.id.length)),
-    title: Math.max(5, ...allRows.map((r) => getDisplayWidth(r.title))),
-    worker: Math.max(6, ...allRows.map((r) => r.worker.length)),
-    ...(hasPath ? { path: Math.max(8, ...allRows.map((r) => r.path.length)) } : {}),
-    status: Math.max(6, ...allRows.map((r) => r.status.length)),
-    time: Math.max(4, ...allRows.map((r) => r.time.length)),
-    duration: Math.max(8, ...allRows.map((r) => r.duration.length)),
-  };
-
-  const pad = (s: string, w: number, useDisplayWidth = false) =>
-    useDisplayWidth ? padToWidth(s, w) : s + " ".repeat(w - s.length);
-  const cols = hasPath
-    ? [
-        colWidths.id,
-        colWidths.title,
-        colWidths.worker,
-        colWidths.path!,
-        colWidths.status,
-        colWidths.time,
-        colWidths.duration,
-      ]
-    : [colWidths.id, colWidths.title, colWidths.worker, colWidths.status, colWidths.time, colWidths.duration];
-  const line = (l: string, m: string, r: string, f: string) => `${l}${cols.map((w) => f.repeat(w + 2)).join(m)}${r}`;
-
-  const row = (
-    id: string,
-    title: string,
-    worker: string,
-    path: string,
-    status: string,
-    time: string,
-    duration: string,
-  ) =>
-    hasPath
-      ? `│ ${pad(id, colWidths.id)} │ ${pad(title, colWidths.title, true)} │ ${pad(worker, colWidths.worker)} │ ${pad(path, colWidths.path!)} │ ${pad(status, colWidths.status)} │ ${pad(time, colWidths.time)} │ ${pad(duration, colWidths.duration)} │`
-      : `│ ${pad(id, colWidths.id)} │ ${pad(title, colWidths.title, true)} │ ${pad(worker, colWidths.worker)} │ ${pad(status, colWidths.status)} │ ${pad(time, colWidths.time)} │ ${pad(duration, colWidths.duration)} │`;
-
-  const lines: string[] = [];
-  lines.push(line("┌", "┬", "┐", "─"));
-  lines.push(row("#", "Title", "Worker", "Worktree", "Status", "Time", "Duration"));
-  lines.push(line("├", "┼", "┤", "─"));
-
-  for (const r of allRows.filter((r) => r.status === "running")) {
-    lines.push(row(r.id, r.title, r.worker, r.path, r.status, r.time, r.duration));
-  }
-
-  if (runningTasks.length > 0 && finishedTasks.length > 0) {
-    lines.push(line("├", "┼", "┤", "─"));
-  }
-
-  for (const r of allRows.filter((r) => r.status !== "running")) {
-    lines.push(row(r.id, r.title, r.worker, r.path, r.status, r.time, r.duration));
-  }
-
-  lines.push(line("└", "┴", "┘", "─"));
+  const lines = buildTaskTableLines([...tasks.values()]);
+  if (lines.length === 0) return;
 
   console.clear();
   console.log(lines.join("\n"));

--- a/src/table.test.ts
+++ b/src/table.test.ts
@@ -5,7 +5,9 @@ import type * as TableModule from "./table";
 // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求するため、
 // .ts 拡張子付きのリテラル文字列で動的importする。
 // allowImportingTsExtensions により tsc --noEmit もこの指定子を許容する。
-const { getDisplayWidth, truncateToWidth, padToWidth } = (await import("./table.ts")) as typeof TableModule;
+const { getDisplayWidth, truncateToWidth, padToWidth, buildTaskTableLines } = (await import(
+  "./table.ts"
+)) as typeof TableModule;
 
 test("getDisplayWidth returns 0 for empty string", () => {
   assert.equal(getDisplayWidth(""), 0);
@@ -157,4 +159,143 @@ test("padToWidth returns the string unchanged when its display width already equ
 
 test("padToWidth returns the string unchanged when its display width already exceeds targetWidth", () => {
   assert.equal(padToWidth("あいう", 4), "あいう");
+});
+
+// --- buildTaskTableLines ---
+
+type TaskTableEntry = TableModule.TaskTableEntry;
+
+const NOW = new Date("2026-07-20T12:00:30");
+const STARTED = new Date("2026-07-20T12:00:00");
+
+function task(overrides: Partial<TaskTableEntry> & Pick<TaskTableEntry, "id" | "status">): TaskTableEntry {
+  return {
+    title: `task ${overrides.id}`,
+    workerName: "exec-issue",
+    startedAt: STARTED,
+    ...overrides,
+  };
+}
+
+/** 罫線・ヘッダーを除いたデータ行だけを、上から順に取り出す。 */
+function dataRows(lines: string[]): string[] {
+  return lines.filter((l) => l.startsWith("│") && !l.includes("Duration"));
+}
+
+/**
+ * データ行を、実行中セクションの区切り罫線を境に上下へ分ける。
+ * 区切りが無い場合は全行を before に入れる（呼び出し側が hasSectionDivider と併用する）。
+ */
+function sections(lines: string[]): { before: string[]; after: string[] } {
+  // ヘッダー行とその下の罫線を落とし、残りを区切り罫線で二分する
+  const body = lines.filter((l) => l.startsWith("│") || l.startsWith("├")).slice(2);
+  const divider = body.findIndex((l) => l.startsWith("├"));
+  if (divider === -1) return { before: body, after: [] };
+  return { before: body.slice(0, divider), after: body.slice(divider + 1) };
+}
+
+/** データ行のあいだにセクション区切りの罫線があるか。 */
+function hasSectionDivider(lines: string[]): boolean {
+  return sections(lines).after.length > 0;
+}
+
+test("buildTaskTableLines returns no lines when there are no tasks", () => {
+  assert.deepEqual(buildTaskTableLines([], NOW), []);
+});
+
+test("buildTaskTableLines lists running tasks above finished ones", () => {
+  const lines = buildTaskTableLines(
+    [
+      task({ id: 1, status: "completed", finishedAt: NOW }),
+      task({ id: 2, status: "running" }),
+      task({ id: 3, status: "failed", finishedAt: NOW }),
+    ],
+    NOW,
+  );
+
+  const rows = dataRows(lines);
+  assert.equal(rows.length, 3);
+  assert.match(rows[0], /#2/);
+  assert.match(rows[1], /#1/);
+  assert.match(rows[2], /#3/);
+});
+
+// リグレッション: herdr モードの running 行は status が `running:working` のように
+// 装飾されるため、表示文字列で running を判定すると完了セクションへ落ちてしまっていた。
+test("buildTaskTableLines keeps a herdr running task with an agent status in the running section", () => {
+  const lines = buildTaskTableLines(
+    [
+      task({ id: 1, status: "completed", finishedAt: NOW }),
+      task({ id: 2, status: "running", agentStatus: "working" }),
+      task({ id: 3, status: "running", agentStatus: "blocked" }),
+    ],
+    NOW,
+  );
+
+  // 区切り罫線の上（実行中セクション）に居ることまで確かめる。
+  // 行の並び順だけでは、完了セクションへ落ちていても順序が偶然一致して見逃す。
+  const { before, after } = sections(lines);
+  assert.equal(before.length, 2);
+  assert.match(before[0], /#2.*running:working/);
+  assert.match(before[1], /#3.*running:blocked/);
+  assert.equal(after.length, 1);
+  assert.match(after[0], /#1.*completed/);
+});
+
+test("buildTaskTableLines renders the agent status alongside the task status", () => {
+  const lines = buildTaskTableLines([task({ id: 7, status: "running", agentStatus: "blocked" })], NOW);
+
+  assert.match(dataRows(lines)[0], /running:blocked/);
+});
+
+test("buildTaskTableLines draws a divider between the running and finished sections", () => {
+  const lines = buildTaskTableLines(
+    [task({ id: 1, status: "running", agentStatus: "working" }), task({ id: 2, status: "completed", finishedAt: NOW })],
+    NOW,
+  );
+
+  assert.equal(hasSectionDivider(lines), true);
+});
+
+test("buildTaskTableLines draws no divider when every task is still running", () => {
+  const lines = buildTaskTableLines(
+    [task({ id: 1, status: "running", agentStatus: "working" }), task({ id: 2, status: "running" })],
+    NOW,
+  );
+
+  assert.equal(hasSectionDivider(lines), false);
+});
+
+test("buildTaskTableLines draws no divider when every task has finished", () => {
+  const lines = buildTaskTableLines(
+    [task({ id: 1, status: "completed", finishedAt: NOW }), task({ id: 2, status: "failed", finishedAt: NOW })],
+    NOW,
+  );
+
+  assert.equal(hasSectionDivider(lines), false);
+});
+
+test("buildTaskTableLines sizes the status column to fit a decorated herdr status", () => {
+  const lines = buildTaskTableLines([task({ id: 1, status: "running", agentStatus: "working" })], NOW);
+
+  // 全行の表示幅が揃っている（幅算出が装飾済み status を含んでいる）ことを確認する
+  const widths = new Set(lines.map((l) => getDisplayWidth(l)));
+  assert.equal(widths.size, 1);
+});
+
+test("buildTaskTableLines shows the worktree column only when some task has a path", () => {
+  const withPath = buildTaskTableLines(
+    [task({ id: 1, status: "running", path: ".claude/worktrees/brave-otter-1234" })],
+    NOW,
+  );
+  const withoutPath = buildTaskTableLines([task({ id: 1, status: "running" })], NOW);
+
+  assert.match(withPath.join("\n"), /Worktree/);
+  assert.doesNotMatch(withoutPath.join("\n"), /Worktree/);
+});
+
+test("buildTaskTableLines measures elapsed time against the supplied clock", () => {
+  const lines = buildTaskTableLines([task({ id: 1, status: "running" })], NOW);
+
+  assert.match(dataRows(lines)[0], /0m 30s/);
 });

--- a/src/table.test.ts
+++ b/src/table.test.ts
@@ -5,9 +5,8 @@ import type * as TableModule from "./table";
 // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求するため、
 // .ts 拡張子付きのリテラル文字列で動的importする。
 // allowImportingTsExtensions により tsc --noEmit もこの指定子を許容する。
-const { getDisplayWidth, truncateToWidth, padToWidth, buildTaskTableLines } = (await import(
-  "./table.ts"
-)) as typeof TableModule;
+const { getDisplayWidth, truncateToWidth, padToWidth, buildTaskTableLines } =
+  (await import("./table.ts")) as typeof TableModule;
 
 test("getDisplayWidth returns 0 for empty string", () => {
   assert.equal(getDisplayWidth(""), 0);

--- a/src/table.ts
+++ b/src/table.ts
@@ -44,3 +44,130 @@ export function padToWidth(str: string, targetWidth: number): string {
   const padding = targetWidth - currentWidth;
   return padding > 0 ? str + " ".repeat(padding) : str;
 }
+
+/** ステータステーブル1行分のタスク情報。process-manager の TaskEntry を構造的に受け取る。 */
+export interface TaskTableEntry {
+  id: number;
+  title: string;
+  status: string;
+  workerName: string;
+  path?: string;
+  startedAt: Date;
+  finishedAt?: Date;
+  // herdr モードのみ。working / blocked 等の agent ステータス。
+  agentStatus?: string;
+}
+
+function formatDuration(start: Date, end: Date = new Date()): string {
+  const diffMs = end.getTime() - start.getTime();
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
+function formatTime(date: Date): string {
+  const h = String(date.getHours()).padStart(2, "0");
+  const m = String(date.getMinutes()).padStart(2, "0");
+  const s = String(date.getSeconds()).padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}
+
+/** ステータステーブルの各行を組み立てる。副作用を持たないのでそのままテストできる。 */
+export function buildTaskTableLines(entries: TaskTableEntry[], now: Date = new Date()): string[] {
+  if (entries.length === 0) return [];
+
+  const runningTasks = entries.filter((t) => t.status === "running");
+  const finishedTasks = entries.filter((t) => t.status !== "running");
+
+  const maxTitleWidth = 40;
+  const maxPathWidth = 40;
+
+  const runningRows = runningTasks.map((t) => ({
+    id: `#${t.id}`,
+    title: getDisplayWidth(t.title) > maxTitleWidth ? truncateToWidth(t.title, maxTitleWidth) : t.title,
+    worker: t.workerName,
+    path: t.path ? (t.path.length > maxPathWidth ? truncateToWidth(t.path, maxPathWidth) : t.path) : "",
+    // herdr モードでは agent ステータス（working / blocked 等）を併記し、
+    // 人の介入が必要な blocked にも気づけるようにする。
+    status: t.agentStatus ? `${t.status}:${t.agentStatus}` : t.status,
+    time: formatTime(t.startedAt),
+    duration: formatDuration(t.startedAt, now),
+  }));
+
+  const finishedRows = finishedTasks.map((t) => ({
+    id: `#${t.id}`,
+    title: getDisplayWidth(t.title) > maxTitleWidth ? truncateToWidth(t.title, maxTitleWidth) : t.title,
+    worker: t.workerName,
+    path: t.path ? (t.path.length > maxPathWidth ? truncateToWidth(t.path, maxPathWidth) : t.path) : "",
+    status: t.status,
+    time: formatTime(t.finishedAt ?? t.startedAt),
+    duration: formatDuration(t.startedAt, t.finishedAt ?? now),
+  }));
+
+  // 列幅の算出は全行を対象にするが、セクションの振り分けには使わない。
+  // status 文字列は herdr モードで `running:working` のように装飾されるため、
+  // 表示値で running か否かを判定すると実行中タスクが完了セクションへ紛れ込む。
+  const allRows = [...runningRows, ...finishedRows];
+
+  const hasPath = allRows.some((r) => r.path !== "");
+
+  const colWidths = {
+    id: Math.max(3, ...allRows.map((r) => r.id.length)),
+    title: Math.max(5, ...allRows.map((r) => getDisplayWidth(r.title))),
+    worker: Math.max(6, ...allRows.map((r) => r.worker.length)),
+    ...(hasPath ? { path: Math.max(8, ...allRows.map((r) => r.path.length)) } : {}),
+    status: Math.max(6, ...allRows.map((r) => r.status.length)),
+    time: Math.max(4, ...allRows.map((r) => r.time.length)),
+    duration: Math.max(8, ...allRows.map((r) => r.duration.length)),
+  };
+
+  const pad = (s: string, w: number, useDisplayWidth = false) =>
+    useDisplayWidth ? padToWidth(s, w) : s + " ".repeat(w - s.length);
+  const cols = hasPath
+    ? [
+        colWidths.id,
+        colWidths.title,
+        colWidths.worker,
+        colWidths.path!,
+        colWidths.status,
+        colWidths.time,
+        colWidths.duration,
+      ]
+    : [colWidths.id, colWidths.title, colWidths.worker, colWidths.status, colWidths.time, colWidths.duration];
+  const line = (l: string, m: string, r: string, f: string) => `${l}${cols.map((w) => f.repeat(w + 2)).join(m)}${r}`;
+
+  const row = (
+    id: string,
+    title: string,
+    worker: string,
+    path: string,
+    status: string,
+    time: string,
+    duration: string,
+  ) =>
+    hasPath
+      ? `│ ${pad(id, colWidths.id)} │ ${pad(title, colWidths.title, true)} │ ${pad(worker, colWidths.worker)} │ ${pad(path, colWidths.path!)} │ ${pad(status, colWidths.status)} │ ${pad(time, colWidths.time)} │ ${pad(duration, colWidths.duration)} │`
+      : `│ ${pad(id, colWidths.id)} │ ${pad(title, colWidths.title, true)} │ ${pad(worker, colWidths.worker)} │ ${pad(status, colWidths.status)} │ ${pad(time, colWidths.time)} │ ${pad(duration, colWidths.duration)} │`;
+
+  const lines: string[] = [];
+  lines.push(line("┌", "┬", "┐", "─"));
+  lines.push(row("#", "Title", "Worker", "Worktree", "Status", "Time", "Duration"));
+  lines.push(line("├", "┼", "┤", "─"));
+
+  for (const r of runningRows) {
+    lines.push(row(r.id, r.title, r.worker, r.path, r.status, r.time, r.duration));
+  }
+
+  if (runningRows.length > 0 && finishedRows.length > 0) {
+    lines.push(line("├", "┼", "┤", "─"));
+  }
+
+  for (const r of finishedRows) {
+    lines.push(row(r.id, r.title, r.worker, r.path, r.status, r.time, r.duration));
+  }
+
+  lines.push(line("└", "┴", "┘", "─"));
+
+  return lines;
+}


### PR DESCRIPTION
## 概要

herdr モードでワーカーを動かしている際、実行中（running）のタスクがステータステーブルの完了セクション（区切り罫線の下）に表示されてしまうバグを修正します。

## 原因

`renderTable()` は行データを組み立てたあと、セクション振り分けを**表示用の status 文字列**で判定していました。

```ts
status: t.agentStatus ? `${t.status}:${t.agentStatus}` : t.status,  // herdr では "running:working"
...
for (const r of allRows.filter((r) => r.status === "running")) { ... }   // 上段
for (const r of allRows.filter((r) => r.status !== "running")) { ... }   // 下段
```

herdr モードでは agentStatus が併記されて `"running:working"` になるため `=== "running"` が偽になり、実行中タスクが全て区切り罫線の下へ落ちていました。default モードでは agentStatus が付かないので発生しません。

## 変更内容

- 振り分けを表示文字列ではなく `status` フィールドベースの `runningRows` / `finishedRows` 配列で行うよう修正。列幅の算出だけは全行対象のまま
- 描画ロジックを `src/table.ts` の純粋関数 `buildTaskTableLines()` へ切り出し。`process-manager.ts` は `./config.js` 形式の import を持つため `--experimental-strip-types` のテストから読み込めず、そのままではテストできなかったため。`renderTable()` は `console.clear()` + 出力のみを担当
- `src/table.test.ts` に回帰テスト9件を追加
- CLAUDE.md に `src/table.ts` の項目と、この判定に関する注意を追記

## 修正後の表示

```
│ #42 │ ヘッダーのレイアウトを修正する │ exec-issue       │ ... │ running:working │
│ #43 │ レビュー指摘の対応             │ fix-review-point │ ... │ running:blocked │
├─────┼────────────────────────────────┼──────────────────┼─────┼─────────────────┤
│ #41 │ Dependabot PR の確認           │ triage-pr        │ ... │ completed       │
```

## テストについて

当初書いた回帰テストは行の並び順のみを検証しており、バグ版のコードでも通ってしまいました（`allRows` の順序上、順番だけは偶然一致する）。症状は「順序」ではなく「区切り罫線に対する位置」なので、区切り線を境に上下へ分けて検証する形に直しています。

**バグ版のコードに戻すと該当テストが落ちることを実際に確認済み**です。

## 検証

- `npm run build` 通過
- `npm run lint` 通過
- `npm test` 217件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)