### PR TITLE
feat(config): headroom オプションでタスクを headroom wrap claude 経由で実行できるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ claude-task-worker all             # Run all workers concurrently
   - **`--cwd` は必ず絶対パスへ解決してから渡す**（`cwdArgs()`）。`--cwd` を解決するのはワーカーではなく herdr サーバー（別プロセス）のため、相対パスを渡すとワーカーのcwdではなく herdr サーバーのcwd基準で解決される。実測では**エラーにならず黙ってホームディレクトリで起動**するため、worktree を渡したつもりのタスクがリポジトリ外で走る。`getWorktreePath()` は相対パス（`.claude/worktrees/<id>`）を返し、default モードの `spawn({cwd})` はワーカーのcwd基準で正しく解決されるため、この差は herdr モードでだけ牙をむく
   - herdr は大半のコマンドで「終了コード0＋stdoutにJSON」を返すが、一部（実測では存在しないタブへの `tab close`）は「終了コード非0＋**stderr**にJSON」を返す。`runHerdr()` は stdout から error を取れなかった場合のみ stderr も解析し、どちらの形でも `HerdrError`（`code` 付き）にする。取り出せないと `stopHerdrTask()` の「`tab_not_found` は正常系」判定が効かず、claudeがグレースフル終了するたびに偽のエラーログが出る。ただし `result`（成功値）の取得元は stdout のみ
 - **`src/herdr-runner.ts`** - herdrモードのタスク実行。`startHerdrTask()`（`tabCreate` → そのタブ限定で `agentStart` → 余ったシェルペインを `paneClose` で1タスク=1タブにする）、`waitForHerdrTask()`（agentステータスのポーリング。`done` または `working`→`idle` で完了、`pane_not_found` で失敗、`blocked` は待機継続）、`buildHerdrTaskResult()`（ペイン出力が空なら空振りとして失敗扱い）、`stopHerdrTask()`（ctrl-c送信 → タブクローズ）、`taskTabLabel()`（`ctw:<project>:#<n>`）
-- **`src/user-config.ts`** - `config.json`（`~/.config/claude-task-worker/config.json` または `$XDG_CONFIG_HOME` 配下）のロード・検証・対象プロジェクト解決。`UserConfig`（`mode`/`projects`/`projectGroups`）、`loadUserConfig()`（読み込み・検証）、`resolveTargetProjects()`（プロジェクト名/グループ名/予約語 `all` の展開）、`getRunMode()`（`mode` の解決。設定ファイル不在・projects破損でも `"default"` を返し、プロセス内でキャッシュする）、`findProjectNameByPath()`（herdrモードのタブラベル用にパスからプロジェクト名を逆引き）。リポジトリ直下の `claude-task-worker.json` を扱う `src/config.ts` とは別物
+- **`src/user-config.ts`** - `config.json`（`~/.config/claude-task-worker/config.json` または `$XDG_CONFIG_HOME` 配下）のロード・検証・対象プロジェクト解決。`UserConfig`（`mode`/`headroom`/`projects`/`projectGroups`）、`loadUserConfig()`（読み込み・検証）、`resolveTargetProjects()`（プロジェクト名/グループ名/予約語 `all` の展開）、`getRunMode()`（`mode` の解決。設定ファイル不在・projects破損でも `"default"` を返し、プロセス内でキャッシュする）、`getHeadroomEnabled()`（`headroom` の解決。`getRunMode()` と同じくプロセス内でキャッシュし、判定できなければ `false`）、`findProjectNameByPath()`（herdrモードのタブラベル用にパスからプロジェクト名を逆引き）。リポジトリ直下の `claude-task-worker.json` を扱う `src/config.ts` とは別物
 - **`src/dispatch-args.ts`** - `--project` ディスパッチ用CLI引数ヘルパー。`PROJECT_INCOMPATIBLE_COMMANDS`（`--project` と併用不可なコマンド一覧: `init`/`install`/`update`/`usage`/`version`）、`parseProjectFilters()`/`hasProjectFilter()`（`--project` の抽出・検出）、`buildForwardedCommand()`（`--project` とその値を除去し他プロジェクトへ転送するコマンド文字列を構築）
 
 ### Worker共通ライフサイクル
@@ -127,6 +127,17 @@ TUI起動時の引数は `buildClaudeArgs()` が組み立て、`-p` の有無以
 - `~/.config/herdr/config.toml` の `[ui.sound] enabled = false`（herdrサーバー全体。`herdr server reload-config` で適用）
 - 同 `[ui.sound.agents] claude = "off"`（claudeエージェント全体。対話セッションも無音になる）
 - ワーカー用に別 herdr セッションを `HERDR_DISABLE_SOUND=1 herdr --session <name>` で起動し、その中でディスパッチャーを動かす（サーバーへのenv継承は未検証）
+
+### `headroom`（Headroom 経由でのタスク実行）
+
+`config.json` のトップレベル `headroom`（boolean、既定 `false`）が `true` のとき、タスクを `claude` の直接起動ではなく `headroom wrap claude -- <引数>` で起動する（Headroom がローカルプロキシを立て `ANTHROPIC_BASE_URL` を差し替えてコンテキストを圧縮する）。`mode` と同じくトップレベル一括の設定で、`getHeadroomEnabled()` がプロセス起動時に一度だけ解決してキャッシュする。
+
+コマンドの組み立ては `src/claude-args.ts` の `buildClaudeExecution()`（`{ command, args }` を返す）。`mode` とは直交し、default モードでは `spawn` の command に、herdr モードでは `agentStart` の argv 先頭になる。どちらもシェルを経由せず argv を直接実行するためクォートの考慮は不要。
+
+- **claude の引数はすべて `--` の後ろに置く**。`headroom wrap claude` は自前のオプション（`--port` / `--memory` / `--no-mcp` 等）を持ち、`-p` のように衝突しうるフラグは `--` の後ろでないと claude へ届かない（headroom 側は click の `ignore_unknown_options` + `UNPROCESSED` で `--` を消費し、残りを `subprocess.run([claude_bin, *claude_args])` へそのまま渡す）。未知フラグのパススルーに頼らず全引数を後ろへ回すことで、将来 headroom にオプションが増えたときの衝突も防ぐ
+- exit code は headroom が claude のものを `SystemExit(result.returncode)` で伝播するため、default モードの成否判定はそのまま使える
+- **`headroom wrap claude` は claude 起動前に起動バナーを無条件で stdout へ出す**（`--verbose` と無関係で、抑止するオプションも無い）。これをそのまま数えると「exit 0 かつ stdout が空＝空振りセッション」の検知が永久に効かなくなるため、`buildTaskResult()` / `buildHerdrTaskResult()` は `headroom` が有効なとき `stripHeadroomBanner()`（先頭から続く空行 / 2スペース始まりの行を落とす）を通してから空判定する。バナーは claude 起動前にすべて出力され各行が空行か2スペース始まりなので、この形で claude 本体の出力に触れずに除去できる。通知に載せる `output` は元の stdout のままにしてあり、判定を誤っても失敗側（ラベルを進めない安全側）に倒れる
+- `headroom: true` で headroom コマンドが PATH に無い場合は `assertHeadroomAvailable()`（`src/index.ts`）がワーカー起動時にエラー終了させる（直接起動へのサイレントフォールバックはしない）
 
 ### `--project` ディスパッチ
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 }
 ```
 
-`mode` については [`mode`（タスクの実行形態）](#modeタスクの実行形態) を参照。
+`mode` については [`mode`（タスクの実行形態）](#modeタスクの実行形態) を、`headroom` については [`headroom`（Headroom 経由でのタスク実行）](#headroomheadroom-経由でのタスク実行) を参照。
 
 `--project` は繰り返し指定可能で、複数指定した場合は解決後のプロジェクト集合の和集合が対象になる（重複は一意化される）。`--epic` / `--label` と併用でき、ディスパッチ先の各プロジェクトで実行されるコマンドにそのまま引き継がれる。
 
@@ -330,6 +330,31 @@ claude-task-worker exec-issue --project app-a --epic 100 --label priority-high
   ```
 
   適用は `herdr server reload-config`。この設定は herdr サーバー全体に効くため、ワーカー以外の対話セッションの完了音も鳴らなくなる（`[ui.sound.agents] claude = "off"` でも実質同じ範囲）。ワーカーだけを無音にしたい場合は、`HERDR_DISABLE_SOUND=1 herdr --session <name>` で別セッションを起動し、その中でディスパッチャーを動かす
+
+### `headroom`（Headroom 経由でのタスク実行）
+
+`config.json` のトップレベルに `"headroom": true` を書くと、ワーカーは各タスクの claude を [Headroom](https://github.com/headroom-ai/headroom) 経由（`headroom wrap claude`）で起動する。Headroom がローカルプロキシを立ててコンテキストを圧縮し、`ANTHROPIC_BASE_URL` を差し替えた状態で claude を起動する。既定は `false`（`claude` を直接起動する）。
+
+`mode` と同じくトップレベル一括の設定で、プロジェクト単位・ワーカー単位の指定はできない。
+
+```json
+{
+  "headroom": true,
+  "projects": { "app-a": "/Users/me/repos/app-a" }
+}
+```
+
+| `headroom` | 実行されるコマンド |
+|-----------|------------------|
+| `false`（既定） | `claude <引数>` |
+| `true` | `headroom wrap claude -- <引数>` |
+
+補足:
+
+- `mode` とは独立して組み合わせられる（`mode: "herdr"` の TUI 起動も `headroom wrap claude` になる）
+- claude へ渡す引数はすべて `--` の後ろに置かれる。`headroom wrap claude` 自身も `--port` / `--memory` などのオプションを持ち、`-p` のように衝突しうるフラグは `--` の後ろでないと claude に届かないため
+- `headroom: true` で headroom コマンドが PATH に無い場合、ワーカーは起動時にエラー終了する（`mode: "herdr"` と同じく、サイレントに直接起動へフォールバックはしない）
+- `headroom wrap claude` は claude を起動する前に起動バナー（枠線・`ANTHROPIC_BASE_URL=...` など）を stdout へ出力し、これを抑止するオプションは無い。ワーカーは空振りセッション検知（exit 0 かつ無出力を失敗とみなす判定）の前にこのバナーを取り除くため、検知は `headroom: true` でも従来どおり機能する。ただし Slack 通知の本文にはバナーがそのまま含まれる
 
 ### exec-issue
 

--- a/src/claude-args.test.ts
+++ b/src/claude-args.test.ts
@@ -2,8 +2,17 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import type * as ClaudeArgsModule from "./claude-args";
 
-const { DISALLOWED_TOOLS, DISALLOWED_TOOLS_ARG, CLAUDE_SPAWN_ENV, SYSTEM_PROMPT, buildClaudeArgs, buildClaudeEnv } =
-  (await import("./claude-args.ts")) as typeof ClaudeArgsModule;
+const {
+  DISALLOWED_TOOLS,
+  DISALLOWED_TOOLS_ARG,
+  CLAUDE_SPAWN_ENV,
+  SYSTEM_PROMPT,
+  CLAUDE_COMMAND,
+  HEADROOM_COMMAND,
+  buildClaudeArgs,
+  buildClaudeEnv,
+  buildClaudeExecution,
+} = (await import("./claude-args.ts")) as typeof ClaudeArgsModule;
 
 test("DISALLOWED_TOOLS covers the tools with no autonomous use", () => {
   assert.deepEqual(
@@ -109,4 +118,56 @@ test("buildClaudeEnv drops the print-only ceiling in herdr mode", () => {
 
 test("buildClaudeEnv does not pass HERDR_DISABLE_SOUND (read by the herdr server, not the pane)", () => {
   assert.ok(!("HERDR_DISABLE_SOUND" in buildClaudeEnv("herdr")));
+});
+
+test("buildClaudeExecution runs claude directly when headroom is off", () => {
+  const invocation = { mode: "default", prompt: "/skill 123", model: "sonnet", effort: "high" } as const;
+  const expectedArgs = buildClaudeArgs(invocation);
+
+  for (const headroom of [undefined, false]) {
+    const execution = buildClaudeExecution({ ...invocation, headroom });
+    assert.equal(execution.command, CLAUDE_COMMAND);
+    assert.deepEqual(execution.args, expectedArgs);
+  }
+});
+
+test("buildClaudeExecution wraps claude with headroom when enabled", () => {
+  const invocation = { mode: "default", prompt: "/skill 123", model: "sonnet", effort: "high" } as const;
+  const execution = buildClaudeExecution({ ...invocation, headroom: true });
+
+  assert.equal(execution.command, HEADROOM_COMMAND);
+  assert.deepEqual(execution.args, ["wrap", "claude", "--", ...buildClaudeArgs(invocation)]);
+});
+
+test("buildClaudeExecution puts every claude flag after the -- separator", () => {
+  // `headroom wrap claude` has its own options (--port / --memory / --no-mcp ...), and
+  // flags like -p are only forwarded to claude when they follow `--`.
+  for (const mode of ["default", "herdr"] as const) {
+    const execution = buildClaudeExecution({
+      mode,
+      prompt: "/skill 1",
+      model: "opus",
+      effort: "xhigh",
+      headroom: true,
+    });
+    const separator = execution.args.indexOf("--");
+    assert.equal(separator, 2);
+    // Nothing before the separator except `wrap claude`.
+    assert.deepEqual(execution.args.slice(0, separator), ["wrap", "claude"]);
+    for (const flag of ["-p", "--model", "--effort", "--disallowedTools", "--append-system-prompt"]) {
+      const index = execution.args.indexOf(flag);
+      if (index === -1) continue; // -p is default-mode only
+      assert.ok(index > separator, `${flag} must come after the -- separator`);
+    }
+  }
+});
+
+test("buildClaudeExecution keeps headroom orthogonal to the run mode", () => {
+  const common = { prompt: "/skill 1", model: "opus", effort: "high", headroom: true } as const;
+  const defaultArgs = buildClaudeExecution({ mode: "default", ...common }).args;
+  const herdrArgs = buildClaudeExecution({ mode: "herdr", ...common }).args;
+
+  // -p remains the only difference between the two modes, even when wrapped.
+  assert.equal(defaultArgs[3], "-p");
+  assert.deepEqual(defaultArgs.slice(4), herdrArgs.slice(3));
 });

--- a/src/claude-args.ts
+++ b/src/claude-args.ts
@@ -101,6 +101,9 @@ export interface ClaudeInvocation {
   effort: string;
 }
 
+export const CLAUDE_COMMAND = "claude";
+export const HEADROOM_COMMAND = "headroom";
+
 // claude の起動引数を組み立てる。モードによる差は `-p`（非対話 print モード）の有無だけで、
 // ツール制限・システムプロンプト・モデル指定は両モードで共通にする。
 export function buildClaudeArgs({ mode, prompt, model, effort }: ClaudeInvocation): string[] {
@@ -118,6 +121,36 @@ export function buildClaudeArgs({ mode, prompt, model, effort }: ClaudeInvocatio
     "--effort",
     effort,
   ];
+}
+
+export interface ClaudeExecution {
+  command: string;
+  args: string[];
+}
+
+/**
+ * タスクを起動する実行可能ファイルと引数を組み立てる。
+ *
+ * `headroom` が有効な場合は `headroom wrap claude -- <claude の引数>` になる
+ * （Headroom がプロキシを起動し、`ANTHROPIC_BASE_URL` を差し替えて claude を起動する）。
+ *
+ * **`--` の区切りは必須**。`headroom wrap claude` は自前のオプション
+ * （`--port` / `--memory` / `--no-mcp` 等）を持ち、`-p` のように headroom 側の解釈と
+ * 衝突しうるフラグは `--` の後ろに置かないと claude まで届かない
+ * （headroom のヘルプも `headroom wrap claude -- -p` を print モードの例として挙げている）。
+ * 未知フラグのパススルーに頼らず全引数を `--` の後ろへ置くことで、将来 headroom 側に
+ * 追加されたオプションと `buildClaudeArgs()` のフラグが衝突する事故も防ぐ。
+ *
+ * 実行形態（default / herdr）とは直交する。default モードでは spawn の command に、
+ * herdr モードでは `agent start ... -- <argv>` の argv 先頭になる。どちらも
+ * シェルを経由せず argv を直接実行するため、クォートの考慮は不要。
+ */
+export function buildClaudeExecution(invocation: ClaudeInvocation & { headroom?: boolean }): ClaudeExecution {
+  const args = buildClaudeArgs(invocation);
+  if (!invocation.headroom) {
+    return { command: CLAUDE_COMMAND, args };
+  }
+  return { command: HEADROOM_COMMAND, args: ["wrap", CLAUDE_COMMAND, "--", ...args] };
 }
 
 // claude へ渡す環境変数を組み立てる。

--- a/src/herdr-runner.test.ts
+++ b/src/herdr-runner.test.ts
@@ -74,6 +74,12 @@ test("buildHerdrTaskResult passes the pane content through on success", () => {
   assert.equal(result.output, "done: created PR #12");
 });
 
+test("buildHerdrTaskResult sees through the headroom launch banner", () => {
+  const banner = "\n  ╔═══════╗\n  ║ HEADROOM WRAP: CLAUDE ║\n  ANTHROPIC_BASE_URL=http://127.0.0.1:8787\n\n";
+  assert.equal(buildHerdrTaskResult(banner, { headroom: true }).status, "failed");
+  assert.equal(buildHerdrTaskResult(`${banner}done: created PR #12`, { headroom: true }).status, "completed");
+});
+
 interface FakeHerdrOptions {
   statuses: AgentStatus[];
   paneOutput?: string;

--- a/src/herdr-runner.ts
+++ b/src/herdr-runner.ts
@@ -1,6 +1,9 @@
 import type * as HerdrModule from "./herdr";
 import type { AgentStatus } from "./herdr";
 import type { TaskResult } from "./task-result";
+// node --experimental-strip-types は実ファイル解決を要求するため、値のimportは
+// .ts 拡張子付きにする（herdr-runner.ts はテストから直接 .ts で読み込まれる）。
+import { stripHeadroomBanner } from "./task-result.ts";
 
 // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求するため、
 // .ts 拡張子付きのリテラル文字列で動的importする（dispatcher.ts と同様）。
@@ -75,9 +78,14 @@ export function observeAgentStatus(
  * 「ペインの内容が空か」だけで成否を判定する。プリアンブル失敗などでモデルが
  * 起動しないまま idle になったセッションを空振りとして失敗扱いにする狙いは
  * task-result.ts の buildTaskResult と同じ。
+ *
+ * `headroom` が有効な場合、ペインには claude の手前に headroom の起動バナーが残りうる。
+ * バナーだけのペインを「出力あり」と誤認しないよう、default モードと同じく空判定の前に
+ * 取り除く（通知に載せる output は元のペイン内容のままにする）。
  */
-export function buildHerdrTaskResult(paneOutput: string): TaskResult {
-  if (paneOutput.trim() === "") {
+export function buildHerdrTaskResult(paneOutput: string, options?: { headroom?: boolean }): TaskResult {
+  const meaningful = options?.headroom ? stripHeadroomBanner(paneOutput) : paneOutput;
+  if (meaningful.trim() === "") {
     return {
       status: "failed",
       output:
@@ -158,6 +166,7 @@ export async function waitForHerdrTask(
     onBlocked?: () => void;
     onStatus?: (status: AgentStatus) => void;
     signal?: { aborted: boolean };
+    headroom?: boolean;
   },
 ): Promise<TaskResult> {
   const mod = options?.herdr ?? (await loadHerdr());
@@ -191,7 +200,7 @@ export async function waitForHerdrTask(
 
     if (observed.decision === "completed") {
       const output = await readPaneOutput(paneId, mod);
-      return buildHerdrTaskResult(output);
+      return buildHerdrTaskResult(output, { headroom: options?.headroom });
     }
     if (observed.decision === "blocked-first-seen") {
       options?.onBlocked?.();

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,8 @@ import {
   assertProjectCompatibleCommand,
   buildForwardedCommand,
 } from "./dispatch-args";
-import { loadUserConfig, resolveTargetProjects, UserConfigError, getRunMode } from "./user-config";
+import { loadUserConfig, resolveTargetProjects, UserConfigError, getRunMode, getHeadroomEnabled } from "./user-config";
+import { HEADROOM_COMMAND } from "./claude-args";
 // dispatcher.ts / herdr.ts はワーカー起動には不要な --project 専用モジュールで、
 // dispatcher.ts のトップレベル await が即時実行されるのを避けるため、
 // 静的importではなく --project 使用時にのみ実行される動的importで遅延読込する。
@@ -169,6 +170,29 @@ async function assertRunModeAvailable(): Promise<void> {
   console.log("[worker] run mode: herdr (each task runs as a TUI session in its own herdr tab)");
 }
 
+// headroom: true のワーカーは全タスクを `headroom wrap claude` で起動するため、headroom が
+// PATH に無ければ spawn が ENOENT で即失敗する（＝ラベルだけ書き換わって全タスクが失敗する）。
+// assertRunModeAvailable() と同じ方針で、起動時に存在を確認して落とす。
+async function assertHeadroomAvailable(): Promise<void> {
+  if (!getHeadroomEnabled()) return;
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  try {
+    await promisify(execFile)(HEADROOM_COMMAND, ["--version"]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[worker] config.json has headroom: true but the headroom CLI is unavailable: ${message}`);
+    process.exit(1);
+  }
+  console.log("[worker] headroom: enabled (each task runs as `headroom wrap claude`)");
+}
+
+// 起動前の前提チェックをまとめて実行する。
+async function assertRunPrerequisites(): Promise<void> {
+  await assertRunModeAvailable();
+  await assertHeadroomAvailable();
+}
+
 if (!hasProjectFilter()) {
   process.on("SIGTERM", async () => {
     if (isShuttingDown()) return;
@@ -279,7 +303,7 @@ if (hasProjectFilter()) {
   const epicFilters = parseEpicFilters();
   const labelFilters = parseLabelFilters();
   (async () => {
-    await assertRunModeAvailable();
+    await assertRunPrerequisites();
     // 前回の異常終了で残った worktree・ブランチをワーカー起動前に回収する
     await removeStaleWorktrees();
     await Promise.all([
@@ -296,7 +320,7 @@ if (hasProjectFilter()) {
   const epicFilters = parseEpicFilters();
   const labelFilters = parseLabelFilters();
   (async () => {
-    await assertRunModeAvailable();
+    await assertRunPrerequisites();
     await removeStaleWorktrees();
     await Promise.all([
       execIssueWorker({ epicFilters, labelFilters }),
@@ -315,7 +339,7 @@ if (hasProjectFilter()) {
   const epicFilters = parseEpicFilters();
   const labelFilters = parseLabelFilters();
   (async () => {
-    await assertRunModeAvailable();
+    await assertRunPrerequisites();
     await removeStaleWorktrees();
     await WORKERS[workerType]({ epicFilters, labelFilters });
   })();

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -7,7 +7,7 @@ import type { HerdrTask } from "./herdr-runner.js";
 import { buildTaskTableLines } from "./table.js";
 import { STDERR_TAIL_LIMIT, buildTaskResult } from "./task-result.js";
 import type { TaskResult } from "./task-result.js";
-import { findProjectNameByPath, getRunMode } from "./user-config.js";
+import { findProjectNameByPath, getHeadroomEnabled, getRunMode } from "./user-config.js";
 
 type TaskStatus = "running" | "completed" | "failed";
 
@@ -149,6 +149,7 @@ async function runViaHerdr(
     herdrTasks.set(id, task);
     result = await waitForHerdrTask(task.paneId, {
       signal: herdrAbortSignal,
+      headroom: getHeadroomEnabled(),
       onBlocked: () => console.warn(`[worker] #${id} is blocked and waiting for input in herdr tab "${label}"`),
       onStatus: (status) => {
         const task = tasks.get(id);
@@ -229,6 +230,7 @@ export function run(
       code,
       Buffer.concat(outputChunks).toString("utf-8"),
       Buffer.concat(stderrChunks).toString("utf-8").slice(-STDERR_TAIL_LIMIT),
+      { headroom: getHeadroomEnabled() },
     );
     // 台帳からの削除は onComplete（ラベル操作・worktree 削除）の完了後に行う。
     // 先に削除すると waitForAllProcesses() が後片付けの途中でプロセスの終了を許してしまう。

--- a/src/task-result.test.ts
+++ b/src/task-result.test.ts
@@ -2,7 +2,20 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import type * as TaskResultModule from "./task-result";
 
-const { buildTaskResult } = (await import("./task-result.ts")) as typeof TaskResultModule;
+const { buildTaskResult, stripHeadroomBanner } = (await import("./task-result.ts")) as typeof TaskResultModule;
+
+// `headroom wrap claude` が claude 起動前に必ず stdout へ出すバナー（実測を要約したもの）。
+const HEADROOM_BANNER = [
+  "",
+  "  ╔═══════════════════════════════════════════════╗",
+  "  ║            HEADROOM WRAP: CLAUDE              ║",
+  "  ╚═══════════════════════════════════════════════╝",
+  "",
+  "  Launching Claude Code (API routed through Headroom)...",
+  "  ANTHROPIC_BASE_URL=http://127.0.0.1:8787",
+  "  Extra args: -p /claude-task-worker:exec-issue 123",
+  "",
+].join("\n");
 
 test("exit 0 with output is completed and keeps stdout as-is", () => {
   const result = buildTaskResult(0, "判定: パターンB-通常（マージ済み）\n", "");
@@ -39,4 +52,40 @@ test("stderr tail is not appended on success", () => {
   const result = buildTaskResult(0, "ok", "warning: noise");
   assert.equal(result.status, "completed");
   assert.equal(result.output, "ok");
+});
+
+test("stripHeadroomBanner removes the launch banner and keeps the report", () => {
+  assert.equal(stripHeadroomBanner(`${HEADROOM_BANNER}判定: パターンB\n`), "判定: パターンB\n");
+});
+
+test("stripHeadroomBanner leaves a banner-only stdout empty", () => {
+  assert.equal(stripHeadroomBanner(HEADROOM_BANNER).trim(), "");
+});
+
+test("stripHeadroomBanner only strips the leading block, not indented report lines", () => {
+  // claude のレポート本文に含まれるインデント行まで落とさないこと。
+  const report = "## 完了報告\n  - 変更点A\n  - 変更点B\n";
+  assert.equal(stripHeadroomBanner(`${HEADROOM_BANNER}${report}`), report);
+});
+
+test("headroom mode still detects an empty session behind the launch banner", () => {
+  // バナーを数えてしまうと「exit 0 かつ無出力＝空振り」の検知が効かなくなり、
+  // triage-pr のようにトリガーラベルが再装填されるワーカーが無限リトライに陥る。
+  const result = buildTaskResult(0, HEADROOM_BANNER, "", { headroom: true });
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /produced no output/);
+});
+
+test("headroom mode keeps a real report completed and notifies with the full stdout", () => {
+  const stdout = `${HEADROOM_BANNER}判定: パターンB\n`;
+  const result = buildTaskResult(0, stdout, "", { headroom: true });
+  assert.equal(result.status, "completed");
+  // 通知には元の stdout をそのまま載せる（バナー除去は空判定にのみ使う）。
+  assert.equal(result.output, stdout);
+});
+
+test("the banner is only stripped when headroom is enabled", () => {
+  // headroom 無効時に同じ整形をすると、インデントで始まる正当な出力を空と誤判定しうる。
+  const result = buildTaskResult(0, HEADROOM_BANNER, "");
+  assert.equal(result.status, "completed");
 });

--- a/src/task-result.ts
+++ b/src/task-result.ts
@@ -8,6 +8,27 @@ export interface TaskResult {
 }
 
 /**
+ * `headroom wrap claude` が claude を起動する前に stdout へ出す起動バナーを取り除く。
+ *
+ * headroom は起動時に枠線・`ANTHROPIC_BASE_URL=...`・`Extra args: ...` などを
+ * **無条件で stdout へ**出力する（`--verbose` とは無関係で、抑止するオプションも無い）。
+ * これをそのまま数えると「exit 0 かつ stdout が空＝空振りセッション」の検知が
+ * 常に空振りしなくなり、無限リトライループを止める最後の砦が効かなくなる。
+ *
+ * バナーの各行は空行か2スペース始まり（`click.echo("  ...")`）で、claude を起動する
+ * **前に**すべて出力される。そのため「先頭から続く空行 / 2スペース始まりの行」だけを
+ * 落とせば、claude 本体の出力には触れずにバナーを除去できる。判定を誤って claude の
+ * 出力を落としても失敗側（＝ラベルを進めない安全側）に倒れるだけになるよう、
+ * 通知に載せる `output` は元の stdout のままにし、この結果は空判定にのみ使う。
+ */
+export function stripHeadroomBanner(stdout: string): string {
+  const lines = stdout.split("\n");
+  let i = 0;
+  while (i < lines.length && (lines[i].trim() === "" || lines[i].startsWith("  "))) i++;
+  return lines.slice(i).join("\n");
+}
+
+/**
  * 子プロセスの終了状態を completed / failed に分類し、通知用の出力文字列を組み立てる。
  *
  * exit 0 でも stdout が空の場合は失敗として扱う。claude -p は正常完了時に必ず最終
@@ -16,9 +37,19 @@ export interface TaskResult {
  * これを完了扱いにするとワーカーがラベル遷移を進めてしまい、トリガーラベルが
  * 再装填される triage-pr では毎ポーリングで空振りセッションを起動し続ける
  * 無限リトライループになる。
+ *
+ * `headroom` が有効な場合は claude の出力の手前に headroom の起動バナーが混ざるため、
+ * 空判定はバナーを除去してから行う（`stripHeadroomBanner`）。exit code は headroom が
+ * claude のものをそのまま伝播する（`SystemExit(result.returncode)`）ので調整不要。
  */
-export function buildTaskResult(code: number | null, stdout: string, stderrTail: string): TaskResult {
-  const emptyOutput = stdout.trim() === "";
+export function buildTaskResult(
+  code: number | null,
+  stdout: string,
+  stderrTail: string,
+  options?: { headroom?: boolean },
+): TaskResult {
+  const meaningful = options?.headroom ? stripHeadroomBanner(stdout) : stdout;
+  const emptyOutput = meaningful.trim() === "";
   const completed = code === 0 && !emptyOutput;
   let output = stdout;
   if (code === 0 && emptyOutput) {

--- a/src/user-config.test.ts
+++ b/src/user-config.test.ts
@@ -18,6 +18,8 @@ const {
   getUserConfigPath,
   getRunMode,
   resetRunModeCache,
+  getHeadroomEnabled,
+  resetHeadroomCache,
   findProjectNameByPath,
 } = (await import("./user-config.ts")) as typeof UserConfigModule;
 
@@ -82,6 +84,7 @@ test("loadUserConfig loads a valid config.json normally", () => {
 test("resolveTargetProjects throws UserConfigError for constructor/toString requests", () => {
   const config = {
     mode: "default" as const,
+    headroom: false,
     projects: { alpha: "/tmp/alpha" },
     projectGroups: { mygroup: ["alpha"] },
   };
@@ -93,6 +96,7 @@ test("resolveTargetProjects throws UserConfigError for constructor/toString requ
 test("resolveTargetProjects resolves known projects and groups normally", () => {
   const config = {
     mode: "default" as const,
+    headroom: false,
     projects: { alpha: "/tmp/alpha", beta: "/tmp/beta" },
     projectGroups: { mygroup: ["alpha", "beta"] },
   };
@@ -138,6 +142,7 @@ test("loadUserConfig throws UserConfigError when projects contains a __proto__ k
 test("resolveTargetProjects throws UserConfigError when resolution yields no projects", () => {
   const config = {
     mode: "default" as const,
+    headroom: false,
     projects: {},
     projectGroups: { empty: [] },
   };
@@ -147,6 +152,7 @@ test("resolveTargetProjects throws UserConfigError when resolution yields no pro
 function removeConfigFile(): void {
   rmSync(getUserConfigPath(), { force: true });
   resetRunModeCache();
+  resetHeadroomCache();
 }
 
 test("loadUserConfig defaults mode to default when it is not specified", () => {
@@ -198,6 +204,53 @@ test("getRunMode caches the mode resolved on first call", () => {
   assert.equal(getRunMode(), "herdr");
   resetRunModeCache();
   assert.equal(getRunMode(), "default");
+});
+
+test("loadUserConfig defaults headroom to false when it is not specified", () => {
+  removeConfigFile();
+  writeConfigFile(JSON.stringify({ projects: { alpha: process.cwd() } }));
+  assert.equal(loadUserConfig().headroom, false);
+});
+
+test("loadUserConfig accepts headroom true", () => {
+  removeConfigFile();
+  writeConfigFile(JSON.stringify({ headroom: true, projects: { alpha: process.cwd() } }));
+  assert.equal(loadUserConfig().headroom, true);
+});
+
+test("loadUserConfig falls back to false for a non-boolean headroom", () => {
+  removeConfigFile();
+  // "true" as a string must not enable headroom silently.
+  writeConfigFile(JSON.stringify({ headroom: "true", projects: { alpha: process.cwd() } }));
+  assert.equal(loadUserConfig().headroom, false);
+});
+
+test("getHeadroomEnabled returns false when no config file exists", () => {
+  removeConfigFile();
+  assert.equal(getHeadroomEnabled(), false);
+});
+
+test("getHeadroomEnabled reads headroom from the config file", () => {
+  removeConfigFile();
+  writeConfigFile(JSON.stringify({ headroom: true, projects: {} }));
+  assert.equal(getHeadroomEnabled(), true);
+});
+
+test("getHeadroomEnabled does not fail when the projects section is broken", () => {
+  removeConfigFile();
+  writeConfigFile(JSON.stringify({ headroom: true, projects: [] }));
+  assert.equal(getHeadroomEnabled(), true);
+});
+
+test("getHeadroomEnabled caches the value resolved on first call", () => {
+  removeConfigFile();
+  writeConfigFile(JSON.stringify({ headroom: true, projects: {} }));
+  assert.equal(getHeadroomEnabled(), true);
+  // 実行中に設定ファイルが書き換わっても、同一プロセス内では最初に確定した値を保つ。
+  writeConfigFile(JSON.stringify({ headroom: false, projects: {} }));
+  assert.equal(getHeadroomEnabled(), true);
+  resetHeadroomCache();
+  assert.equal(getHeadroomEnabled(), false);
 });
 
 test("findProjectNameByPath resolves a project name from its path", () => {

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -10,8 +10,13 @@ export type RunMode = "default" | "herdr";
 
 export const DEFAULT_RUN_MODE: RunMode = "default";
 
+// `headroom` が true のとき、タスクの claude を `headroom wrap claude` 経由で起動する
+// （Headroom のプロキシにAPI呼び出しを通してコンテキストを圧縮する）。既定は無効。
+export const DEFAULT_HEADROOM = false;
+
 export interface UserConfig {
   mode: RunMode;
+  headroom: boolean;
   projects: Record<string, string>;
   projectGroups: Record<string, string[]>;
 }
@@ -80,6 +85,14 @@ function parseMode(raw: Record<string, unknown>, path: string): RunMode {
   return DEFAULT_RUN_MODE;
 }
 
+function parseHeadroom(raw: Record<string, unknown>, path: string): boolean {
+  if (!("headroom" in raw)) return DEFAULT_HEADROOM;
+  const value = raw["headroom"];
+  if (typeof value === "boolean") return value;
+  console.warn(`[config] invalid headroom: ${JSON.stringify(value)} in ${path}, using ${DEFAULT_HEADROOM}`);
+  return DEFAULT_HEADROOM;
+}
+
 export function loadUserConfig(): UserConfig {
   const path = getUserConfigPath();
   const raw = readRawConfig();
@@ -108,6 +121,7 @@ export function loadUserConfig(): UserConfig {
   }
 
   const mode = parseMode(raw, path);
+  const headroom = parseHeadroom(raw, path);
   const rawProjects = raw["projects"] as Record<string, unknown>;
   const rawProjectGroups = ("projectGroups" in raw ? raw["projectGroups"] : {}) as Record<string, unknown>;
 
@@ -164,7 +178,7 @@ export function loadUserConfig(): UserConfig {
     projectGroups[groupName] = members;
   }
 
-  return { mode, projects, projectGroups };
+  return { mode, headroom, projects, projectGroups };
 }
 
 // mode はプロセス起動時に確定させる。実行中に設定ファイルが書き換わっても、
@@ -188,18 +202,49 @@ export function resetRunModeCache(): void {
 // 壊れているといった理由で実行形態の判定に失敗させない。mode だけを取り出し、
 // 判定できない場合は "default" を返す。
 function readRunMode(): RunMode {
+  const raw = readTopLevelConfig(`using "${DEFAULT_RUN_MODE}" mode`);
+  if (raw === undefined) return DEFAULT_RUN_MODE;
+  return parseMode(raw, getUserConfigPath());
+}
+
+// headroom も mode と同じくプロセス起動時に確定させる。実行中に設定ファイルが
+// 書き換わっても、同一プロセス内で「headroom 経由で起動したタスク」と
+// 「直接起動したタスク」が混在しないようにするため。
+let cachedHeadroom: boolean | undefined;
+
+export function getHeadroomEnabled(): boolean {
+  if (cachedHeadroom === undefined) {
+    cachedHeadroom = readHeadroom();
+  }
+  return cachedHeadroom;
+}
+
+// テスト用。設定ファイルを差し替えて再解決させる。
+export function resetHeadroomCache(): void {
+  cachedHeadroom = undefined;
+}
+
+function readHeadroom(): boolean {
+  const raw = readTopLevelConfig(`using headroom=${DEFAULT_HEADROOM}`);
+  if (raw === undefined) return DEFAULT_HEADROOM;
+  return parseHeadroom(raw, getUserConfigPath());
+}
+
+// トップレベルのスカラー設定（mode / headroom）を読み出すための共通処理。
+// 設定ファイルが無い・壊れている場合は undefined を返し、呼び出し側に既定値を使わせる。
+function readTopLevelConfig(fallbackDescription: string): Record<string, unknown> | undefined {
   let raw: Record<string, unknown> | undefined;
   try {
     raw = readRawConfig();
   } catch (err) {
-    console.warn(`[config] failed to read config file, using "${DEFAULT_RUN_MODE}" mode: ${err}`);
-    return DEFAULT_RUN_MODE;
+    console.warn(`[config] failed to read config file, ${fallbackDescription}: ${err}`);
+    return undefined;
   }
-  if (raw === undefined) return DEFAULT_RUN_MODE;
+  if (raw === undefined) return undefined;
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-    return DEFAULT_RUN_MODE;
+    return undefined;
   }
-  return parseMode(raw, getUserConfigPath());
+  return raw;
 }
 
 // herdr モードのタブラベル（ctw:<project>:#<n>）に使うプロジェクト名を、

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -1,4 +1,4 @@
-import { buildClaudeArgs, buildClaudeEnv } from "../claude-args.js";
+import { buildClaudeEnv, buildClaudeExecution } from "../claude-args.js";
 import { getWorkerConfig } from "../config";
 import { getCurrentUser, getRepoInfo, listIssuesByLabel, listIssuesByNumbers, removeLabel, addLabel } from "../gh";
 import type { Issue } from "../gh";
@@ -6,7 +6,7 @@ import { syncDefaultBranch, ensureEpicBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isShuttingDown, run } from "../process-manager";
 import { generateWorktreeName } from "../random-name";
 import { notifyTaskCompleted, notifyTaskFailed, notifyError } from "../slack";
-import { getRunMode } from "../user-config";
+import { getHeadroomEnabled, getRunMode } from "../user-config";
 import { removeWorktree, createWorktreeFromBranch, getWorktreePath } from "../worktree";
 
 const LABEL_TRIAGE_SCOPE = "cc-triage-scope";
@@ -92,7 +92,13 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
 
             const parentNumber = issue.parent?.number;
             const mode = getRunMode();
-            const claudeArgs = buildClaudeArgs({ mode, prompt: `${command} ${issue.number}`, model, effort });
+            const execution = buildClaudeExecution({
+              mode,
+              prompt: `${command} ${issue.number}`,
+              model,
+              effort,
+              headroom: getHeadroomEnabled(),
+            });
 
             // claude CLI の --worktree は locked な worktree を作り、異常終了時に
             // 削除不能な残骸（幽霊エントリ・checkout済み扱いのブランチ）を残すため使わない。
@@ -107,8 +113,8 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
             console.log(`[${config.name}] #${issue.number}: created worktree ${worktreeId} from ${baseBranch}`);
 
             run(
-              "claude",
-              claudeArgs,
+              execution.command,
+              execution.args,
               issue.number,
               issue.title,
               config.name,

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -1,4 +1,4 @@
-import { buildClaudeArgs, buildClaudeEnv } from "../claude-args.js";
+import { buildClaudeEnv, buildClaudeExecution } from "../claude-args.js";
 import { getWorkerConfig } from "../config";
 import {
   type PullRequestWithChecks,
@@ -12,7 +12,7 @@ import { syncDefaultBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isShuttingDown, run } from "../process-manager";
 import { generateWorktreeName } from "../random-name";
 import { notifyTaskCompleted, notifyTaskFailed, notifyError } from "../slack";
-import { getRunMode } from "../user-config";
+import { getHeadroomEnabled, getRunMode } from "../user-config";
 import {
   createWorktreeFromBranch,
   deleteLocalBranch,
@@ -89,9 +89,16 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
             const { model, effort, skill } = getWorkerConfig(config.name);
             const command = skill || config.command;
             const mode = getRunMode();
+            const execution = buildClaudeExecution({
+              mode,
+              prompt: `${command} ${pr.number}`,
+              model,
+              effort,
+              headroom: getHeadroomEnabled(),
+            });
             run(
-              "claude",
-              buildClaudeArgs({ mode, prompt: `${command} ${pr.number}`, model, effort }),
+              execution.command,
+              execution.args,
               pr.number,
               `PR #${pr.number} (${pr.headRefName})`,
               config.name,


### PR DESCRIPTION
## 概要

`config.json` のトップレベルに `headroom`（boolean、既定 `false`）を追加し、`true` の場合はタスクの claude を `headroom wrap claude -- <引数>` で起動できるようにした。Headroom がローカルプロキシを立て `ANTHROPIC_BASE_URL` を差し替えてコンテキストを圧縮する。

| `headroom` | 実行されるコマンド |
|-----------|------------------|
| `false`（既定） | `claude <引数>` |
| `true` | `headroom wrap claude -- <引数>` |

```json
{
  "headroom": true,
  "projects": { "app-a": "/Users/me/repos/app-a" }
}
```

## 実装

- **`src/user-config.ts`**: `UserConfig.headroom` と `getHeadroomEnabled()` を追加。`getRunMode()` と同じくプロセス起動時に一度だけ解決してキャッシュする（実行中に設定が書き換わっても、同一プロセス内で headroom 経由のタスクと直接起動のタスクが混在しない）。非 boolean 値は警告して `false` に倒す
- **`src/claude-args.ts`**: `buildClaudeExecution()` が `{ command, args }` を返す。`mode` とは直交し、default モードでは `spawn` の command、herdr モードでは `agentStart` の argv 先頭になる。どちらもシェルを経由せず argv を直接実行するためクォートの考慮は不要
- **`src/index.ts`**: `assertHeadroomAvailable()` を追加

## 判断が必要だった2点

### 1. `--` 区切りを必須にした

`headroom wrap claude` は自前のオプション（`--port` / `--memory` / `--no-mcp` 等）を持つため、`-p` のような衝突しうるフラグは `--` の後ろでないと claude に届かない（headroom のヘルプも `headroom wrap claude -- -p` を print モードの例に挙げている）。headroom 側の実装（click の `ignore_unknown_options` + `UNPROCESSED` で `--` を消費し、残りを `subprocess.run([claude_bin, *claude_args])` へそのまま渡す）も確認済み。未知フラグのパススルーに頼らず全引数を後ろへ回すことで、将来 headroom にオプションが増えたときの衝突も防ぐ。

### 2. 空振りセッション検知が壊れるのを防いだ

`headroom wrap claude` は claude 起動前に起動バナー（枠線・`ANTHROPIC_BASE_URL=...`）を**無条件で stdout へ**出力する（`--verbose` と無関係、抑止オプションなし）。これをそのまま数えると「exit 0 かつ stdout が空＝空振りセッション」の検知が永久に効かなくなり、`triage-pr` の無限リトライを止める最後の砦が失われる。

`stripHeadroomBanner()`（先頭から続く空行 / 2スペース始まりの行を落とす）を追加し、空判定の前だけバナーを除去するようにした。バナーは claude 起動前にすべて出力され各行が空行か2スペース始まりなので、この形で claude 本体の出力に触れずに除去できる。通知に載せる `output` は元の stdout のままなので、判定を誤っても失敗側（ラベルを進めない安全側）に倒れる。

exit code は headroom が claude のものを `SystemExit(result.returncode)` で伝播するため調整不要だった。

## 既知のトレードオフ

Slack 通知の本文には headroom のバナーがそのまま含まれる（抑止する手段が headroom 側に無いため許容）。

## 検証

- `npm run build`（tsc --noEmit + esbuild）通過
- `npm test` 235件全pass（`buildClaudeExecution` の `--` 配置・バナー除去・`getHeadroomEnabled` のキャッシュ挙動のテストを追加）
- `npm run lint` / prettier 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 設定で Headroom を有効にすると、Claude の実行が Headroom 経由になります。
  * 実行モードと Headroom を独立して設定できるようになりました。
  * Headroom が利用できない場合は、起動時にエラーを通知して終了します。

* **改善**
  * Headroom の起動バナーをタスク結果の空判定から除外し、実際の出力を正しく判定します。
  * Headroom の設定値が不正または判定できない場合は、安全に無効として扱います。

* **ドキュメント**
  * Headroom の設定方法、引数の扱い、エラー時の動作をREADMEと設定資料に追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->