### PR TITLE
fix(headroom): --1m/--memory/--code-graph を headroom wrap へ渡す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,11 +130,15 @@ TUI起動時の引数は `buildClaudeArgs()` が組み立て、`-p` の有無以
 
 ### `headroom`（Headroom 経由でのタスク実行）
 
-`config.json` のトップレベル `headroom`（boolean、既定 `false`）が `true` のとき、タスクを `claude` の直接起動ではなく `headroom wrap claude -- <引数>` で起動する（Headroom がローカルプロキシを立て `ANTHROPIC_BASE_URL` を差し替えてコンテキストを圧縮する）。`mode` と同じくトップレベル一括の設定で、`getHeadroomEnabled()` がプロセス起動時に一度だけ解決してキャッシュする。
+`config.json` のトップレベル `headroom`（boolean、既定 `false`）が `true` のとき、タスクを `claude` の直接起動ではなく `headroom wrap claude <HEADROOM_WRAP_OPTIONS> -- <引数>` で起動する（Headroom がローカルプロキシを立て `ANTHROPIC_BASE_URL` を差し替えてコンテキストを圧縮する）。`mode` と同じくトップレベル一括の設定で、`getHeadroomEnabled()` がプロセス起動時に一度だけ解決してキャッシュする。
 
 コマンドの組み立ては `src/claude-args.ts` の `buildClaudeExecution()`（`{ command, args }` を返す）。`mode` とは直交し、default モードでは `spawn` の command に、herdr モードでは `agentStart` の argv 先頭になる。どちらもシェルを経由せず argv を直接実行するためクォートの考慮は不要。
 
-- **claude の引数はすべて `--` の後ろに置く**。`headroom wrap claude` は自前のオプション（`--port` / `--memory` / `--no-mcp` 等）を持ち、`-p` のように衝突しうるフラグは `--` の後ろでないと claude へ届かない（headroom 側は click の `ignore_unknown_options` + `UNPROCESSED` で `--` を消費し、残りを `subprocess.run([claude_bin, *claude_args])` へそのまま渡す）。未知フラグのパススルーに頼らず全引数を後ろへ回すことで、将来 headroom にオプションが増えたときの衝突も防ぐ
+- **claude の引数はすべて `--` の後ろに置く**。`headroom wrap claude` は自前のオプション（`--port` / `--memory` / `--no-mcp` / `--1m` 等）を持ち、`-p` のように衝突しうるフラグは `--` の後ろでないと claude へ届かない（headroom 側は click の `ignore_unknown_options` + `UNPROCESSED` で `--` を消費し、残りを `subprocess.run([claude_bin, *claude_args])` へそのまま渡す）。未知フラグのパススルーに頼らず全引数を後ろへ回すことで、将来 headroom にオプションが増えたときの衝突も防ぐ
+- **headroom 自身へ渡すオプション（`HEADROOM_WRAP_OPTIONS`）は逆に `--` の前に置く**。`--` の後ろは claude へ素通しされ headroom には解釈されないため。現在渡しているのは `--1m` / `--memory` / `--code-graph` の3つ:
+  - `--1m`: proxy 経由でも 1M コンテキストウィンドウを維持する。**未指定だと headroom が 1M window を有効化せず context サイズが意図せず膨らむ**（headroom オプションを付けたら context が異常肥大した実測の原因がこれ）
+  - `--memory`: セッション横断の永続メモリを有効化する
+  - `--code-graph`: tokensave のコードグラフインデックスを即時構築する（headroom 既定の圧縮バックエンド）
 - exit code は headroom が claude のものを `SystemExit(result.returncode)` で伝播するため、default モードの成否判定はそのまま使える
 - **`headroom wrap claude` は claude 起動前に起動バナーを無条件で stdout へ出す**（`--verbose` と無関係で、抑止するオプションも無い）。これをそのまま数えると「exit 0 かつ stdout が空＝空振りセッション」の検知が永久に効かなくなるため、`buildTaskResult()` / `buildHerdrTaskResult()` は `headroom` が有効なとき `stripHeadroomBanner()`（先頭から続く空行 / 2スペース始まりの行を落とす）を通してから空判定する。バナーは claude 起動前にすべて出力され各行が空行か2スペース始まりなので、この形で claude 本体の出力に触れずに除去できる。通知に載せる `output` は元の stdout のままにしてあり、判定を誤っても失敗側（ラベルを進めない安全側）に倒れる
 - `headroom: true` で headroom コマンドが PATH に無い場合は `assertHeadroomAvailable()`（`src/index.ts`）がワーカー起動時にエラー終了させる（直接起動へのサイレントフォールバックはしない）

--- a/src/claude-args.test.ts
+++ b/src/claude-args.test.ts
@@ -12,6 +12,7 @@ const {
   buildClaudeArgs,
   buildClaudeEnv,
   buildClaudeExecution,
+  HEADROOM_WRAP_OPTIONS,
 } = (await import("./claude-args.ts")) as typeof ClaudeArgsModule;
 
 test("DISALLOWED_TOOLS covers the tools with no autonomous use", () => {
@@ -136,7 +137,23 @@ test("buildClaudeExecution wraps claude with headroom when enabled", () => {
   const execution = buildClaudeExecution({ ...invocation, headroom: true });
 
   assert.equal(execution.command, HEADROOM_COMMAND);
-  assert.deepEqual(execution.args, ["wrap", "claude", "--", ...buildClaudeArgs(invocation)]);
+  assert.deepEqual(execution.args, ["wrap", "claude", ...HEADROOM_WRAP_OPTIONS, "--", ...buildClaudeArgs(invocation)]);
+});
+
+test("buildClaudeExecution enables the 1M window and memory / code-graph backends", () => {
+  const execution = buildClaudeExecution({
+    mode: "default",
+    prompt: "/skill 1",
+    model: "opus",
+    effort: "high",
+    headroom: true,
+  });
+  const separator = execution.args.indexOf("--");
+  // Every headroom-own option must sit before the -- separator so headroom parses them.
+  for (const flag of ["--1m", "--memory", "--code-graph"]) {
+    const index = execution.args.indexOf(flag);
+    assert.ok(index > 1 && index < separator, `${flag} must be a headroom wrap option before --`);
+  }
 });
 
 test("buildClaudeExecution puts every claude flag after the -- separator", () => {
@@ -151,9 +168,9 @@ test("buildClaudeExecution puts every claude flag after the -- separator", () =>
       headroom: true,
     });
     const separator = execution.args.indexOf("--");
-    assert.equal(separator, 2);
-    // Nothing before the separator except `wrap claude`.
-    assert.deepEqual(execution.args.slice(0, separator), ["wrap", "claude"]);
+    assert.equal(separator, 2 + HEADROOM_WRAP_OPTIONS.length);
+    // Nothing before the separator except `wrap claude` and headroom's own options.
+    assert.deepEqual(execution.args.slice(0, separator), ["wrap", "claude", ...HEADROOM_WRAP_OPTIONS]);
     for (const flag of ["-p", "--model", "--effort", "--disallowedTools", "--append-system-prompt"]) {
       const index = execution.args.indexOf(flag);
       if (index === -1) continue; // -p is default-mode only
@@ -168,6 +185,8 @@ test("buildClaudeExecution keeps headroom orthogonal to the run mode", () => {
   const herdrArgs = buildClaudeExecution({ mode: "herdr", ...common }).args;
 
   // -p remains the only difference between the two modes, even when wrapped.
-  assert.equal(defaultArgs[3], "-p");
-  assert.deepEqual(defaultArgs.slice(4), herdrArgs.slice(3));
+  const defaultSep = defaultArgs.indexOf("--");
+  const herdrSep = herdrArgs.indexOf("--");
+  assert.equal(defaultArgs[defaultSep + 1], "-p");
+  assert.deepEqual(defaultArgs.slice(defaultSep + 2), herdrArgs.slice(herdrSep + 1));
 });

--- a/src/claude-args.ts
+++ b/src/claude-args.ts
@@ -104,6 +104,17 @@ export interface ClaudeInvocation {
 export const CLAUDE_COMMAND = "claude";
 export const HEADROOM_COMMAND = "headroom";
 
+// `headroom wrap claude` 自身のオプション（`--` より **前** に置く。`--` の後ろは
+// すべて claude へ素通しされるため、ここへ置くと headroom に解釈されず無視される）。
+//
+// - `--1m`: プロキシ経由でも 1M コンテキストウィンドウを維持する。付けないと headroom は
+//   1M window を有効化せず（proxy が既定の window にフォールバックする）、ワーカーが扱う
+//   大きめのコンテキストで挙動が変わる。**これが未指定だと context サイズが意図せず膨らむ**。
+// - `--memory`: セッション横断の永続メモリを有効化する。
+// - `--code-graph`: tokensave のコードグラフインデックスを即時構築する（headroom 既定の
+//   圧縮バックエンド）。
+export const HEADROOM_WRAP_OPTIONS = ["--1m", "--memory", "--code-graph"] as const;
+
 // claude の起動引数を組み立てる。モードによる差は `-p`（非対話 print モード）の有無だけで、
 // ツール制限・システムプロンプト・モデル指定は両モードで共通にする。
 export function buildClaudeArgs({ mode, prompt, model, effort }: ClaudeInvocation): string[] {
@@ -131,15 +142,19 @@ export interface ClaudeExecution {
 /**
  * タスクを起動する実行可能ファイルと引数を組み立てる。
  *
- * `headroom` が有効な場合は `headroom wrap claude -- <claude の引数>` になる
+ * `headroom` が有効な場合は
+ * `headroom wrap claude <HEADROOM_WRAP_OPTIONS> -- <claude の引数>` になる
  * （Headroom がプロキシを起動し、`ANTHROPIC_BASE_URL` を差し替えて claude を起動する）。
  *
  * **`--` の区切りは必須**。`headroom wrap claude` は自前のオプション
- * （`--port` / `--memory` / `--no-mcp` 等）を持ち、`-p` のように headroom 側の解釈と
- * 衝突しうるフラグは `--` の後ろに置かないと claude まで届かない
+ * （`--port` / `--memory` / `--no-mcp` / `--1m` 等）を持ち、`-p` のように headroom 側の
+ * 解釈と衝突しうるフラグは `--` の後ろに置かないと claude まで届かない
  * （headroom のヘルプも `headroom wrap claude -- -p` を print モードの例として挙げている）。
  * 未知フラグのパススルーに頼らず全引数を `--` の後ろへ置くことで、将来 headroom 側に
  * 追加されたオプションと `buildClaudeArgs()` のフラグが衝突する事故も防ぐ。
+ *
+ * 逆に headroom 自身へ渡すオプション（`HEADROOM_WRAP_OPTIONS`）は `--` の **前** に置く。
+ * `--1m`（1M window 維持）が無いと proxy 経由で context サイズが膨らむため必須。
  *
  * 実行形態（default / herdr）とは直交する。default モードでは spawn の command に、
  * herdr モードでは `agent start ... -- <argv>` の argv 先頭になる。どちらも
@@ -150,7 +165,10 @@ export function buildClaudeExecution(invocation: ClaudeInvocation & { headroom?:
   if (!invocation.headroom) {
     return { command: CLAUDE_COMMAND, args };
   }
-  return { command: HEADROOM_COMMAND, args: ["wrap", CLAUDE_COMMAND, "--", ...args] };
+  return {
+    command: HEADROOM_COMMAND,
+    args: ["wrap", CLAUDE_COMMAND, ...HEADROOM_WRAP_OPTIONS, "--", ...args],
+  };
 }
 
 // claude へ渡す環境変数を組み立てる。


### PR DESCRIPTION
## 概要

`headroom: true` でタスクを起動すると context サイズが異常肥大する問題を修正する。

## 原因

`headroom wrap claude` に `--1m` を渡していなかった。付けないと headroom proxy が 1M コンテキストウィンドウを有効化せず（既定 window にフォールバック）、ワーカーが扱う大きめの context で挙動が変わり肥大していた。

## 変更

- `HEADROOM_WRAP_OPTIONS = ["--1m", "--memory", "--code-graph"]` を新設
  - `--1m`: proxy 経由でも 1M window を維持（肥大の元凶）
  - `--memory`: セッション横断の永続メモリ
  - `--code-graph`: tokensave コードグラフインデックスの即時構築（headroom 既定の圧縮バックエンド）
- `buildClaudeExecution()` で `--` の **前** に配置 → `headroom wrap claude --1m --memory --code-graph -- <claude args>`。`--` の後ろは claude へ素通しされ headroom に解釈されないため、headroom 自身のオプションは前に置く必要がある
- CLAUDE.md の headroom 節を追記

## テスト

- `npm run build` clean
- `npm test` 236 pass（`buildClaudeExecution` 系テストを区切り位置・wrap オプション検証・mode 直交性で更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)