### PR TITLE
fix(headroom): 1M window を --model の [1m] サフィックスで解放する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,10 +135,16 @@ TUI起動時の引数は `buildClaudeArgs()` が組み立て、`-p` の有無以
 コマンドの組み立ては `src/claude-args.ts` の `buildClaudeExecution()`（`{ command, args }` を返す）。`mode` とは直交し、default モードでは `spawn` の command に、herdr モードでは `agentStart` の argv 先頭になる。どちらもシェルを経由せず argv を直接実行するためクォートの考慮は不要。
 
 - **claude の引数はすべて `--` の後ろに置く**。`headroom wrap claude` は自前のオプション（`--port` / `--memory` / `--no-mcp` / `--1m` 等）を持ち、`-p` のように衝突しうるフラグは `--` の後ろでないと claude へ届かない（headroom 側は click の `ignore_unknown_options` + `UNPROCESSED` で `--` を消費し、残りを `subprocess.run([claude_bin, *claude_args])` へそのまま渡す）。未知フラグのパススルーに頼らず全引数を後ろへ回すことで、将来 headroom にオプションが増えたときの衝突も防ぐ
-- **headroom 自身へ渡すオプション（`HEADROOM_WRAP_OPTIONS`）は逆に `--` の前に置く**。`--` の後ろは claude へ素通しされ headroom には解釈されないため。現在渡しているのは `--1m` / `--memory` / `--code-graph` の3つ:
-  - `--1m`: proxy 経由でも 1M コンテキストウィンドウを維持する。**未指定だと headroom が 1M window を有効化せず context サイズが意図せず膨らむ**（headroom オプションを付けたら context が異常肥大した実測の原因がこれ）
+- **headroom 自身へ渡すオプション（`HEADROOM_WRAP_OPTIONS`）は逆に `--` の前に置く**。`--` の後ろは claude へ素通しされ headroom には解釈されないため。現在渡しているのは `--1m` / `--memory` / `--no-tokensave` / `--no-serena` の4つ:
+  - `--1m`: 1M コンテキストウィンドウを要求させる。ただし**このフラグ単体ではワーカーに効かない**（下記「1M window の解放は `--model` 側で行う」参照）。`--model` を渡さなくなった場合の保険として残している
   - `--memory`: セッション横断の永続メモリを有効化する
-  - `--code-graph`: tokensave のコードグラフインデックスを即時構築する（headroom 既定の圧縮バックエンド）
+  - `--no-tokensave` / `--no-serena`: 重いコードグラフ MCP の自動登録を止める（下記参照）
+- **1M window の解放は `--model` へ付ける `[1m]` サフィックスが担う**（`withContext1mSuffix()`）。Claude Code は model id が `[1m]` で終わるときだけ `context-1m` beta ヘッダを送るが、headroom の `--1m` は **`ANTHROPIC_MODEL=<model>[1m]` をセットするだけ**の実装（`wrap.py` の `_resolve_1m_model()`）で、CLI の `--model` が環境変数に勝つため、`--model sonnet` を明示するワーカー起動では素通しされていた。proxy のリクエストログで `anthropic-beta` から `context-1m` が欠落することを実測で確認済み。headroom は `ANTHROPIC_MODEL=claude-opus-4-8[1m] (1M context window)` と成功したかのように表示するため、ログを見ても気づけない。サフィックスはエイリアスへ直接連結してよい（`--model 'sonnet[1m]'` でヘッダが送出されることを実測確認済み。エイリアス→フルモデルIDの変換表は新モデル追加のたびに陳腐化するため持たない）
+- **tokensave MCP は `--no-tokensave` で明示的に切る**。ただし**コンテキスト削減が目的ではない**。狙いは (1) headroom がタスク起動のたびに走らせる再登録＋再インデックス（`_setup_tokensave_mcp(..., force=True)` → `_index_tokensave_project()`）を止めること、(2) ワーカーの都合で `~/.claude.json` の**トップレベル** `mcpServers`（＝ユーザーの対話セッション）が書き換わるのを止めること。コード探索は codegraph MCP（`plugin/.mcp.json`）が担い、`--append-system-prompt` の探索方針もそちらを指しているため機能面の損失はない
+  - **`--code-graph` を外すだけでは止まらない**。同フラグは「今すぐ index を張れ」の意味しかなく、tokensave の登録自体は `_setup_coding_compressor()` が**既定で**行う
+  - **`--no-serena` を併せて渡す必要がある**。`_setup_coding_compressor()` は tokensave が無効だと Serena MCP をバックアップとして登録するため、`--no-tokensave` 単体では別の MCP に置き換わるだけになる
+  - 既存の登録は、ledger（`~/.headroom/mcp_installs.json`）が headroom によるインストールを証明する場合に限り `--no-tokensave` が削除する（ユーザーが自分で入れたエントリは残す）
+  - **MCP のツール数はコンテキスト肥大の主因ではない**。tokensave はツール81個・schema 約 15.7k tokens 相当だが、headroom が `ENABLE_TOOL_SEARCH=true` を立てて Claude Code のオンデマンドツール読み込みを有効にするため、MCP のツールスキーマはリクエストに載らず名前だけが遅延解決される。同一条件の A/B 実測差は **11 bytes / 3 tokens**（有り: content-length 114,638・tok_before 13,029 → 無し: 114,627・13,026）。ベースラインを占めているのは遅延できない組み込みツールの schema（proxy ログの `tool_search_deferral:15tools:12663tok`）であり、MCP を減らしても縮まない
 - exit code は headroom が claude のものを `SystemExit(result.returncode)` で伝播するため、default モードの成否判定はそのまま使える
 - **`headroom wrap claude` は claude 起動前に起動バナーを無条件で stdout へ出す**（`--verbose` と無関係で、抑止するオプションも無い）。これをそのまま数えると「exit 0 かつ stdout が空＝空振りセッション」の検知が永久に効かなくなるため、`buildTaskResult()` / `buildHerdrTaskResult()` は `headroom` が有効なとき `stripHeadroomBanner()`（先頭から続く空行 / 2スペース始まりの行を落とす）を通してから空判定する。バナーは claude 起動前にすべて出力され各行が空行か2スペース始まりなので、この形で claude 本体の出力に触れずに除去できる。通知に載せる `output` は元の stdout のままにしてあり、判定を誤っても失敗側（ラベルを進めない安全側）に倒れる
 - `headroom: true` で headroom コマンドが PATH に無い場合は `assertHeadroomAvailable()`（`src/index.ts`）がワーカー起動時にエラー終了させる（直接起動へのサイレントフォールバックはしない）

--- a/src/claude-args.test.ts
+++ b/src/claude-args.test.ts
@@ -13,6 +13,7 @@ const {
   buildClaudeEnv,
   buildClaudeExecution,
   HEADROOM_WRAP_OPTIONS,
+  withContext1mSuffix,
 } = (await import("./claude-args.ts")) as typeof ClaudeArgsModule;
 
 test("DISALLOWED_TOOLS covers the tools with no autonomous use", () => {
@@ -133,14 +134,20 @@ test("buildClaudeExecution runs claude directly when headroom is off", () => {
 });
 
 test("buildClaudeExecution wraps claude with headroom when enabled", () => {
-  const invocation = { mode: "default", prompt: "/skill 123", model: "sonnet", effort: "high" } as const;
-  const execution = buildClaudeExecution({ ...invocation, headroom: true });
+  const invocation = {
+    mode: "default",
+    prompt: "/skill 123",
+    model: "sonnet",
+    effort: "high",
+    headroom: true,
+  } as const;
+  const execution = buildClaudeExecution(invocation);
 
   assert.equal(execution.command, HEADROOM_COMMAND);
   assert.deepEqual(execution.args, ["wrap", "claude", ...HEADROOM_WRAP_OPTIONS, "--", ...buildClaudeArgs(invocation)]);
 });
 
-test("buildClaudeExecution enables the 1M window and memory / code-graph backends", () => {
+test("buildClaudeExecution passes headroom's own options before the -- separator", () => {
   const execution = buildClaudeExecution({
     mode: "default",
     prompt: "/skill 1",
@@ -150,10 +157,49 @@ test("buildClaudeExecution enables the 1M window and memory / code-graph backend
   });
   const separator = execution.args.indexOf("--");
   // Every headroom-own option must sit before the -- separator so headroom parses them.
-  for (const flag of ["--1m", "--memory", "--code-graph"]) {
+  for (const flag of ["--1m", "--memory", "--no-tokensave", "--no-serena"]) {
     const index = execution.args.indexOf(flag);
     assert.ok(index > 1 && index < separator, `${flag} must be a headroom wrap option before --`);
   }
+});
+
+test("buildClaudeExecution opts out of tokensave and its Serena fallback", () => {
+  // Not a context-size optimisation: with ENABLE_TOOL_SEARCH on, MCP tool schemas stay out
+  // of the request (measured A/B difference: 11 bytes). The point is to stop headroom
+  // re-registering + re-indexing tokensave on every task launch, and to stop it mutating the
+  // user's global ~/.claude.json. --code-graph would contradict the opt-out, and
+  // --no-tokensave alone just swaps in Serena.
+  const execution = buildClaudeExecution({
+    mode: "default",
+    prompt: "/skill 1",
+    model: "opus",
+    effort: "high",
+    headroom: true,
+  });
+  assert.ok(!execution.args.includes("--code-graph"));
+  assert.ok(execution.args.includes("--no-tokensave"));
+  assert.ok(execution.args.includes("--no-serena"));
+});
+
+test("buildClaudeArgs appends the [1m] suffix to --model only under headroom", () => {
+  const common = { mode: "default", prompt: "/skill 1", effort: "high" } as const;
+
+  // headroom's --1m only sets ANTHROPIC_MODEL, which the CLI's --model overrides, so the
+  // suffix has to ride on --model itself for Claude Code to send the context-1m beta header.
+  const wrapped = buildClaudeArgs({ ...common, model: "sonnet", headroom: true });
+  assert.equal(wrapped[wrapped.indexOf("--model") + 1], "sonnet[1m]");
+
+  // Without headroom there is no proxy stripping the model picker, so leave the model alone.
+  for (const headroom of [undefined, false]) {
+    const direct = buildClaudeArgs({ ...common, model: "sonnet", headroom });
+    assert.equal(direct[direct.indexOf("--model") + 1], "sonnet");
+  }
+});
+
+test("withContext1mSuffix is idempotent", () => {
+  assert.equal(withContext1mSuffix("opus"), "opus[1m]");
+  assert.equal(withContext1mSuffix("opus[1m]"), "opus[1m]");
+  assert.equal(withContext1mSuffix("claude-sonnet-5[1m]"), "claude-sonnet-5[1m]");
 });
 
 test("buildClaudeExecution puts every claude flag after the -- separator", () => {

--- a/src/claude-args.ts
+++ b/src/claude-args.ts
@@ -99,6 +99,9 @@ export interface ClaudeInvocation {
   prompt: string;
   model: string;
   effort: string;
+  // Headroom 経由で起動するか（`--model` への `[1m]` 付与を左右する。後述の
+  // `withContext1mSuffix()` 参照）。
+  headroom?: boolean;
 }
 
 export const CLAUDE_COMMAND = "claude";
@@ -107,17 +110,59 @@ export const HEADROOM_COMMAND = "headroom";
 // `headroom wrap claude` 自身のオプション（`--` より **前** に置く。`--` の後ろは
 // すべて claude へ素通しされるため、ここへ置くと headroom に解釈されず無視される）。
 //
-// - `--1m`: プロキシ経由でも 1M コンテキストウィンドウを維持する。付けないと headroom は
-//   1M window を有効化せず（proxy が既定の window にフォールバックする）、ワーカーが扱う
-//   大きめのコンテキストで挙動が変わる。**これが未指定だと context サイズが意図せず膨らむ**。
+// - `--1m`: 1M コンテキストウィンドウを要求させる。ただし headroom 側の実装は
+//   **`ANTHROPIC_MODEL=<model>[1m]` を起動プロセスへセットするだけ**で、claude CLI の
+//   `--model` は環境変数より優先されるため、ワーカーのように `--model` を明示指定する
+//   起動ではこのフラグ単体では効かない（`withContext1mSuffix()` 参照）。実際に効かせて
+//   いるのは `--model` 側のサフィックスで、このフラグは `--model` を渡さなくなった場合の
+//   保険として残してある。
 // - `--memory`: セッション横断の永続メモリを有効化する。
-// - `--code-graph`: tokensave のコードグラフインデックスを即時構築する（headroom 既定の
-//   圧縮バックエンド）。
-export const HEADROOM_WRAP_OPTIONS = ["--1m", "--memory", "--code-graph"] as const;
+// - `--no-tokensave`: tokensave MCP の登録を止める。**コンテキスト削減が目的ではない**
+//   （後述）。狙いは次の2つ:
+//     1. headroom はタスク起動のたびに `_setup_tokensave_mcp(..., force=True)` で再登録＋
+//        プロジェクトの再インデックス（`_index_tokensave_project()`）を走らせる。ワーカーは
+//        Issue ごとにプロセスを立ち上げるため、この往復がタスク数だけ積み上がる
+//     2. 登録先が `~/.claude.json` の**トップレベル** `mcpServers` なので、ワーカーの都合で
+//        ユーザーのグローバル設定（＝対話セッション）まで書き換わる
+//   コード探索はプラグインの codegraph MCP（`plugin/.mcp.json`）が担い、`SYSTEM_PROMPT` の
+//   探索方針もそちらを指しているため、機能面の損失もない。
+//   **tokensave は headroom の既定で登録される**ため、`--code-graph`（＝「今すぐ index を
+//   張れ」）を外すだけでは止まらず、この明示的なオプトアウトが要る。ledger
+//   （`~/.headroom/mcp_installs.json`）が headroom によるインストールを証明する場合は、
+//   既存エントリの削除も headroom 側が行う。
+//
+//   なお tokensave はツールを81個公開しており schema は約 15.7k tokens 相当だが、これが
+//   そのままコンテキストに載るわけではない。headroom は `ENABLE_TOOL_SEARCH=true` を立てて
+//   Claude Code のオンデマンドツール読み込みを有効にするため、MCP のツールスキーマは
+//   リクエストに載らず名前だけが遅延解決される。**同一条件の A/B で実測した差は
+//   11 bytes / 3 tokens**（tokensave 有り: content-length 114,638・tok_before 13,029 →
+//   無し: 114,627・13,026）。コンテキスト肥大の主因は MCP ではなく、遅延できない組み込み
+//   ツールの schema（proxy ログの `tool_search_deferral:15tools:12663tok`）である。
+// - `--no-serena`: Serena MCP のバックアップ登録を止める。headroom の
+//   `_setup_coding_compressor()` は tokensave が無効だと Serena を代替として登録するため、
+//   `--no-tokensave` だけでは別の MCP に置き換わり、上記2つの狙いがどちらも達成できない。
+//
+// `--code-graph` は渡さない（`--no-tokensave` と矛盾する。上記参照）。
+export const HEADROOM_WRAP_OPTIONS = ["--1m", "--memory", "--no-tokensave", "--no-serena"] as const;
+
+// Claude Code は model id が `[1m]` で終わる場合にのみ `context-1m` beta ヘッダを送り、
+// 1M コンテキストウィンドウを解放する。headroom の `--1m` は ANTHROPIC_MODEL 経由でしか
+// これを行わず、CLI の `--model` が環境変数に勝つため、ワーカー起動では素通しされていた
+// （proxy のリクエストログで `context-1m` ヘッダが欠落していることを実測で確認済み）。
+// 付ける側を `--model` の値へ移すことで、`--model` を明示していても 1M window が効く。
+//
+// エイリアス（`sonnet` / `opus`）にそのまま連結してよい。`--model 'sonnet[1m]'` でも
+// `context-1m-2025-08-07` ヘッダが送出されることを実測で確認しており、エイリアスから
+// フルモデルIDへの変換表を持つ必要はない（持つと新モデル追加のたびに陳腐化する）。
+const CONTEXT_1M_SUFFIX = "[1m]";
+
+export function withContext1mSuffix(model: string): string {
+  return model.endsWith(CONTEXT_1M_SUFFIX) ? model : `${model}${CONTEXT_1M_SUFFIX}`;
+}
 
 // claude の起動引数を組み立てる。モードによる差は `-p`（非対話 print モード）の有無だけで、
 // ツール制限・システムプロンプト・モデル指定は両モードで共通にする。
-export function buildClaudeArgs({ mode, prompt, model, effort }: ClaudeInvocation): string[] {
+export function buildClaudeArgs({ mode, prompt, model, effort, headroom }: ClaudeInvocation): string[] {
   return [
     ...(mode === "herdr" ? [] : ["-p"]),
     prompt,
@@ -128,7 +173,7 @@ export function buildClaudeArgs({ mode, prompt, model, effort }: ClaudeInvocatio
     "--append-system-prompt",
     SYSTEM_PROMPT,
     "--model",
-    model,
+    headroom ? withContext1mSuffix(model) : model,
     "--effort",
     effort,
   ];
@@ -154,13 +199,16 @@ export interface ClaudeExecution {
  * 追加されたオプションと `buildClaudeArgs()` のフラグが衝突する事故も防ぐ。
  *
  * 逆に headroom 自身へ渡すオプション（`HEADROOM_WRAP_OPTIONS`）は `--` の **前** に置く。
- * `--1m`（1M window 維持）が無いと proxy 経由で context サイズが膨らむため必須。
+ *
+ * 1M コンテキストウィンドウの解放は headroom の `--1m` ではなく `--model` へ付ける
+ * `[1m]` サフィックスが担う（`withContext1mSuffix()` 参照）。`--1m` は
+ * ANTHROPIC_MODEL しか触らず、CLI の `--model` に負けるため単体では効かない。
  *
  * 実行形態（default / herdr）とは直交する。default モードでは spawn の command に、
  * herdr モードでは `agent start ... -- <argv>` の argv 先頭になる。どちらも
  * シェルを経由せず argv を直接実行するため、クォートの考慮は不要。
  */
-export function buildClaudeExecution(invocation: ClaudeInvocation & { headroom?: boolean }): ClaudeExecution {
+export function buildClaudeExecution(invocation: ClaudeInvocation): ClaudeExecution {
   const args = buildClaudeArgs(invocation);
   if (!invocation.headroom) {
     return { command: CLAUDE_COMMAND, args };


### PR DESCRIPTION
## 背景

`headroom: true` のワーカー起動でコンテキストサイズが異常に膨らむ、という報告の調査結果。

PR #130 で `--1m` を `headroom wrap` へ渡すようにしたが、**ワーカーに対しては no-op だった**。headroom の `--1m` は `ANTHROPIC_MODEL=<model>[1m]` を起動プロセスへセットするだけの実装（`wrap.py` の `_resolve_1m_model()`）で、claude CLI の `--model` が環境変数より優先される。ワーカーは常に `--model sonnet` を明示するため `[1m]` サフィックスが失われ、Claude Code が `context-1m` beta ヘッダを送らず 1M window が解放されていなかった。

headroom 自身は `ANTHROPIC_MODEL=claude-opus-4-8[1m] (1M context window; issue #1158)` と成功したかのように表示するため、ログを見ても気づけない。

## 実測

proxy のリクエストログ（`~/.headroom/logs/proxy.log`）の `anthropic-beta` ヘッダ:

| 起動 | `context-1m` |
|---|---|
| `--1m -- -p ... --model sonnet` | **無し** |
| `--1m -- -p ... --model 'sonnet[1m]'` | **`context-1m-2025-08-07` 有り** |

## 変更

- `withContext1mSuffix()` を追加。headroom 有効時のみ `--model` の値へ `[1m]` を付ける
  - エイリアスへの直接連結（`sonnet[1m]`）でヘッダが送出されることを実測で確認したため、エイリアス→フルモデルIDの変換表は持たない（持つと新モデル追加のたびに陳腐化する）
  - `--1m` は `--model` を渡さなくなった場合の保険として残す
- `ClaudeInvocation` に `headroom?: boolean` を移動（`buildClaudeExecution` の交差型を廃止）
- `HEADROOM_WRAP_OPTIONS`: `--code-graph` を外し `--no-tokensave` / `--no-serena` を追加

## `--no-tokensave` / `--no-serena` について

**コンテキスト削減が目的ではない。** 狙いは2つ:

1. headroom がタスク起動のたびに走らせる tokensave の再登録＋再インデックス（`_setup_tokensave_mcp(..., force=True)`）を止める
2. ワーカーの都合で `~/.claude.json` のトップレベル `mcpServers`（＝ユーザーの対話セッション）が書き換わるのを止める

tokensave の登録は headroom の既定動作なので `--code-graph`（＝「今すぐ index を張れ」）を外すだけでは止まらず、`--no-tokensave` 単体では `_setup_coding_compressor()` が Serena を代替登録するため `--no-serena` も要る。

コンテキストへの影響は**ほぼゼロ**であることを同一条件の A/B で確認済み:

| | content-length | tok_before |
|---|---:|---:|
| tokensave 有り | 114,638 | 13,029 |
| tokensave 無し | 114,627 | 13,026 |

`ENABLE_TOOL_SEARCH=true`（headroom が既定で立てる）により MCP のツールスキーマはリクエストに載らず名前だけが遅延解決されるため。ベースラインを占めているのは遅延できない組み込みツールの schema（proxy ログの `tool_search_deferral:15tools:12663tok`）で、MCP を減らしても縮まない。この点は誤解しやすいのでコード・CLAUDE.md 双方にコメントとして残した。

## テスト

`npm run build` / `npm test` ともに通過（239 tests pass）。`[1m]` 付与の headroom 有無による分岐・冪等性・tokensave オプトアウトのテストを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 修正履歴

### 2026-07-20: レビュー指摘対応（1件）
- CI build ワークフローの Format check 失敗（`src/claude-args.test.ts` の prettier フォーマット崩れ、長い1行オブジェクトリテラルを複数行へ整形）を修正（対応コミット: 32f41f5）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * headroom 有効時の起動オプション処理を見直し、各オプションが適切に Claude へ渡されるようになりました。
  * headroom 使用時は tokensave と Serena の自動処理を無効化します。
  * 1M コンテキスト対応モデルを正しく指定できるようになりました。
  * 既に 1M サフィックスが付いたモデル名への重複付与を防止します。

* **テスト**
  * headroom の引数処理、オプション配置、モデル指定の検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
