### PR TITLE
chore: package.json と plugin.json のバージョンを同期

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # npm version の `version` ライフサイクルフック (package.json の scripts.version)
+      # が plugin/.claude-plugin/plugin.json のバージョンも package.json に揃えて上げる。
+      # 続く `git commit -am` が両ファイルを一緒にコミットする。
       - name: Bump version
         id: version
         run: |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,8 +20,8 @@ export default [
     },
   },
   {
-    // Plugin runtime scripts run under Node (hook commands), not part of the TS build.
-    files: ["plugin/scripts/**/*.mjs"],
+    // Node scripts run under Node (hook commands / release tooling), not part of the TS build.
+    files: ["plugin/scripts/**/*.mjs", "scripts/**/*.mjs"],
     languageOptions: {
       globals: { process: "readonly", console: "readonly" },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "prettier": "^3.8.3",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.59.1"
+      },
+      "engines": {
+        "node": ">=22.6.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -734,7 +737,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -926,7 +928,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1085,7 +1086,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1568,7 +1568,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1697,7 +1696,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "node --experimental-strip-types --test \"src/**/*.test.ts\" \"plugin/scripts/**/*.test.mjs\"",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "version": "node scripts/sync-plugin-version.mjs && git add plugin/.claude-plugin/plugin.json",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-task-worker",
-  "version": "0.2.21",
+  "version": "0.35.0",
   "description": "claude-task-worker と組み合わせて使う getty104's base tool set (skills/agents/hooks)",
   "author": {
     "name": "getty104"

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// package.json の version を Claude Code プラグイン (plugin/.claude-plugin/plugin.json) の
+// version へ同期する。npm version の `version` ライフサイクルフックから呼ばれるため、
+// npm でバージョンを上げる (npm run publish 相当・publish.yml) たびにプラグイン側も
+// 一緒に上がり、両者のバージョンが常に一致する。
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const packageJsonPath = join(repoRoot, "package.json");
+const pluginJsonPath = join(repoRoot, "plugin", ".claude-plugin", "plugin.json");
+
+const version = JSON.parse(readFileSync(packageJsonPath, "utf8")).version;
+if (typeof version !== "string" || version.length === 0) {
+  throw new Error(`package.json に有効な version がありません: ${version}`);
+}
+
+const plugin = JSON.parse(readFileSync(pluginJsonPath, "utf8"));
+if (plugin.version === version) {
+  console.log(`[sync-plugin-version] plugin.json は既に ${version} です`);
+  process.exit(0);
+}
+
+const previous = plugin.version;
+plugin.version = version;
+writeFileSync(pluginJsonPath, `${JSON.stringify(plugin, null, 2)}\n`);
+console.log(`[sync-plugin-version] plugin.json を ${previous} から ${version} へ更新しました`);


### PR DESCRIPTION
## 概要

package.json のバージョンと Claude Code プラグイン (`plugin/.claude-plugin/plugin.json`) のバージョンを一致させ、npm publish のたびに両者を一緒に上げるようにする。

これまで package.json (`0.35.0`) と plugin.json (`0.2.21`) が別々に管理され乖離していた。

## 仕組み

`npm version` の `version` ライフサイクルフックで自動同期する:

1. **`scripts/sync-plugin-version.mjs`**（新規）— package.json の version を plugin.json へ書き込む。
2. **package.json** — `scripts.version` で上記スクリプトを起動し、更新した plugin.json を `git add` する。`npm version` がバージョンを上げた直後（コミット前）に発火。
3. **publish.yml** — `npm version ... --no-git-tag-version` がフックを起動し、続く `git commit -am` が package.json と plugin.json を一緒にコミットする（ワークフロー本体の変更はコメント追記のみ）。
4. **eslint.config.js** — `scripts/**/*.mjs` に Node globals（console/process）を付与。

これで npm へ push（＝ publish.yml の `npm version`）のたびに plugin.json も同じ番号へ自動追従する。ローカルの `npm version` でも同じ。

## 検証

- 実際に `npm version patch` を実行し、plugin.json が `0.35.1` へ追従＋ステージされることを確認（その後 `0.35.0` へ戻した）。
- 既存の不一致を解消し、package.json・plugin.json・package-lock すべて `0.35.0` に揃えた。
- `npm run lint` / `npm run format:check` / `npm test`（277 pass, 0 fail）緑。

補足: `marketplace.json` の `metadata.version` はマーケットプレイス自体のバージョンで別物のため対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)