### PR TITLE
fix(ci): publishのBump versionでnpm stdout解析をやめる

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,11 +46,16 @@ jobs:
       # npm version の `version` ライフサイクルフック (package.json の scripts.version)
       # が plugin/.claude-plugin/plugin.json のバージョンも package.json に揃えて上げる。
       # 続く `git commit -am` が両ファイルを一緒にコミットする。
+      #
+      # バージョンは npm version の stdout ではなく package.json から読む。
+      # `version` フックがあると npm の run-script バナー (`> version` 等) や
+      # フック内の console.log が stdout に混じり、それを $GITHUB_OUTPUT へ書くと
+      # `Invalid format '> version'` で失敗するため。
       - name: Bump version
         id: version
         run: |
-          new_version=$(npm version "${{ inputs.semver }}" --no-git-tag-version)
-          echo "version=$new_version" >> "$GITHUB_OUTPUT"
+          npm version "${{ inputs.semver }}" --no-git-tag-version
+          echo "version=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push
         run: |


### PR DESCRIPTION
## 問題

`Publish to npm` ワークフローの **Bump version** ステップが失敗（[run 30002968662](../../actions/runs/30002968662)）。

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '> version'
```

## 原因

PR #140 で `package.json` に `version` ライフサイクルフックを追加した:

```json
"version": "node scripts/sync-plugin-version.mjs && git add plugin/.claude-plugin/plugin.json"
```

このフックがあると `npm version` の **stdout** に

- npm の run-script バナー（`> version` / `> node scripts/...`）
- `sync-plugin-version.mjs` の `console.log`

が混じる。従来は `new_version=$(npm version ...)` でこの stdout をそのまま `$GITHUB_OUTPUT` へ書いていたため、`> version` 行が `key=value` 形式でなく `Invalid format '> version'` で失敗していた。フック追加前は stdout がバージョン1行だけだったので通っていた。

## 修正

npm の stdout を解析せず、bump 後の `package.json` から version を直接読む:

```yaml
npm version "${{ inputs.semver }}" --no-git-tag-version
echo "version=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
```

フックが stdout に何を出しても影響を受けない。`v` プレフィックス付きで、下流の commit メッセージ・`gh release create` のタグ形式（既存の `v0.35.0` 等）と一致する。

ローカルでフック込みの再現環境を作り、修正前は `Invalid format '> version'` を再現、修正後は `version=v0.36.0` が出ることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)