### PR TITLE
タスク実行履歴を直近20件に絞りライブログテーブルを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ UI実装Issueについて、実装の前に Pencil（`.pen`）でデザインを
 
 ## Conventions
 
-- ESM (`NodeNext` module) — importは `.js` 拡張子付き
+- ESM（tsconfig は `module: ESNext` / `moduleResolution: Bundler`）— **相対 import は拡張子を付けない**（`import { x } from "./foo"`）。`.js` も `.ts` も付けない。esbuild バンドルと `tsc`（Bundler 解決）は拡張子なしをそのまま解決するが、`node --experimental-strip-types --test` の ESM リゾルバは拡張子なし・`.js`→`.ts` のどちらも解決できないため、テスト実行時のみ `scripts/test-resolver.mjs`（`register()` で `scripts/test-resolver.hooks.mjs` の resolve フックを登録）が実ファイル（`.ts` 等）へ橋渡しする。`package.json` の `test` スクリプトが `--import ./scripts/test-resolver.mjs` で読み込む。テストでソースを値として読む場合は `import type * as M from "./foo"`（型は拡張子なしで erase される）＋ `const m = (await import("./foo")) as typeof M` の既存パターンに従う
 - ログは `[worker-name]` プレフィックス付き
 - エラーはtry-catchでログ出力し、ワーカーはクラッシュせず継続
 - SIGTERM/SIGINT で全子プロセスを graceful shutdown

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "tsc --noEmit --watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --experimental-strip-types --test \"src/**/*.test.ts\" \"plugin/scripts/**/*.test.mjs\"",
+    "test": "node --experimental-strip-types --import ./scripts/test-resolver.mjs --test \"src/**/*.test.ts\" \"plugin/scripts/**/*.test.mjs\"",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "version": "node scripts/sync-plugin-version.mjs && git add plugin/.claude-plugin/plugin.json",

--- a/scripts/test-resolver.hooks.mjs
+++ b/scripts/test-resolver.hooks.mjs
@@ -1,0 +1,30 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+// node --experimental-strip-types の ESM リゾルバは拡張子なし相対 import も
+// `.js`→`.ts` の読み替えも行わないため、拡張子なしで書かれたソースを
+// node --test で解決できるよう補完する resolve フック。
+// esbuild / tsc(moduleResolution: Bundler) は元から拡張子なしを解決するので、
+// テスト実行時のみこのフックで実ファイルへ橋渡しする。
+const EXTS = [".ts", ".mts", ".mjs", ".js"];
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+    const parent = context.parentURL ? fileURLToPath(context.parentURL) : `${process.cwd()}/`;
+    const base = path.resolve(path.dirname(parent), specifier);
+    if (!existsSync(base)) {
+      const stripped = base.replace(/\.(js|mjs|ts|mts)$/, "");
+      const candidates = [];
+      for (const ext of EXTS) candidates.push(stripped + ext);
+      for (const ext of EXTS) candidates.push(base + ext);
+      for (const ext of EXTS) candidates.push(path.join(base, `index${ext}`));
+      for (const candidate of candidates) {
+        if (existsSync(candidate)) {
+          return nextResolve(pathToFileURL(candidate).href, context);
+        }
+      }
+    }
+  }
+  return nextResolve(specifier, context);
+}

--- a/scripts/test-resolver.mjs
+++ b/scripts/test-resolver.mjs
@@ -1,0 +1,5 @@
+import { register } from "node:module";
+
+// resolve フックを登録するエントリ。package.json の test スクリプトが
+// `node --import ./scripts/test-resolver.mjs` で読み込む。
+register("./test-resolver.hooks.mjs", import.meta.url);

--- a/src/claude-args.test.ts
+++ b/src/claude-args.test.ts
@@ -14,7 +14,7 @@ const {
   buildClaudeEnv,
   buildClaudeExecution,
   systemPromptFilePath,
-} = (await import("./claude-args.ts")) as typeof ClaudeArgsModule;
+} = (await import("./claude-args")) as typeof ClaudeArgsModule;
 
 test("DISALLOWED_TOOLS covers the tools with no autonomous use", () => {
   assert.deepEqual(

--- a/src/claude-args.ts
+++ b/src/claude-args.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { RunMode } from "./user-config.js";
+import type { RunMode } from "./user-config";
 
 // ワーカーは各スキルを自律実行モードで起動する（default モードは `claude -p`、
 // herdr モードは herdr タブ内の TUI セッション。どちらも応答するユーザーは常駐しない）。

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,7 +2,7 @@ import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import type * as ConfigModule from "./config";
 
-const { parseUiDesignEntry, DEFAULT_UI_DESIGN_CONFIG } = (await import("./config.ts")) as typeof ConfigModule;
+const { parseUiDesignEntry, DEFAULT_UI_DESIGN_CONFIG } = (await import("./config")) as typeof ConfigModule;
 
 // 不正値は console.warn を出して既定値へ倒す仕様なので、テスト出力を汚さないよう黙らせる。
 function silenceWarn(t: TestContext): void {

--- a/src/dispatch-args.test.ts
+++ b/src/dispatch-args.test.ts
@@ -5,7 +5,7 @@ import type * as DispatchArgsModule from "./dispatch-args";
 // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求するため、
 // .ts 拡張子付きのリテラル文字列で動的importする。
 // allowImportingTsExtensions により tsc --noEmit もこの指定子を許容する。
-const { buildForwardedCommand, shellQuote } = (await import("./dispatch-args.ts")) as typeof DispatchArgsModule;
+const { buildForwardedCommand, shellQuote } = (await import("./dispatch-args")) as typeof DispatchArgsModule;
 
 test("buildForwardedCommand strips --project and its value from argv.slice(2)-shaped input", () => {
   const argv = ["all", "--project", "foo"];

--- a/src/dispatcher.test.ts
+++ b/src/dispatcher.test.ts
@@ -21,8 +21,8 @@ const {
   waitForPaneReady,
   waitForWorkerStartup,
   startWorkerInPane,
-} = (await import("./dispatcher.ts")) as typeof DispatcherModule;
-const { HerdrError } = (await import("./herdr.ts")) as typeof HerdrModule;
+} = (await import("./dispatcher")) as typeof DispatcherModule;
+const { HerdrError } = (await import("./herdr")) as typeof HerdrModule;
 
 type ExecFileCallback = (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void;
 
@@ -397,7 +397,7 @@ test("waits for the pane prompt before sending the command so a shell still init
     },
   );
 
-  const herdr = (await import("./herdr.ts")) as typeof HerdrModule;
+  const herdr = (await import("./herdr")) as typeof HerdrModule;
   const started = await startWorkerInPane("pane-my-app", "claude-task-worker all", herdr, FAST_TIMING);
 
   assert.equal(started, true);
@@ -439,7 +439,7 @@ test("resends the command when the worker process never appears, then gives up a
   );
   t.mock.method(console, "warn", () => {});
 
-  const herdr = (await import("./herdr.ts")) as typeof HerdrModule;
+  const herdr = (await import("./herdr")) as typeof HerdrModule;
   const started = await startWorkerInPane("pane-my-app", "claude-task-worker all", herdr, {
     ...FAST_TIMING,
     sendMaxAttempts: 3,
@@ -475,7 +475,7 @@ test("waitForPaneReady returns false when the pane stays empty until the timeout
     callback(null, "", "");
   });
 
-  const herdr = (await import("./herdr.ts")) as typeof HerdrModule;
+  const herdr = (await import("./herdr")) as typeof HerdrModule;
   const ready = await waitForPaneReady("pane-my-app", herdr, { timeoutMs: 20, pollIntervalMs: 1 });
 
   assert.equal(ready, false);
@@ -492,7 +492,7 @@ test("waitForWorkerStartup returns true once a claude-task-worker process appear
     callback(null, JSON.stringify({ result: { process_info: { foreground_processes: [foreground] } } }), "");
   });
 
-  const herdr = (await import("./herdr.ts")) as typeof HerdrModule;
+  const herdr = (await import("./herdr")) as typeof HerdrModule;
   const started = await waitForWorkerStartup("pane-my-app", herdr, { timeoutMs: 500, pollIntervalMs: 1 });
 
   assert.equal(started, "started");
@@ -514,7 +514,7 @@ test("waitForWorkerStartup returns other when the foreground process is neither 
     );
   });
 
-  const herdr = (await import("./herdr.ts")) as typeof HerdrModule;
+  const herdr = (await import("./herdr")) as typeof HerdrModule;
   const result = await waitForWorkerStartup("pane-my-app", herdr, { timeoutMs: 500, pollIntervalMs: 1 });
 
   assert.equal(result, "other");
@@ -554,7 +554,7 @@ test("gives up immediately without resending when the foreground process is neit
   );
   t.mock.method(console, "warn", () => {});
 
-  const herdr = (await import("./herdr.ts")) as typeof HerdrModule;
+  const herdr = (await import("./herdr")) as typeof HerdrModule;
   const started = await startWorkerInPane("pane-my-app", "claude-task-worker all", herdr, {
     ...FAST_TIMING,
     sendMaxAttempts: 3,

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -8,11 +8,11 @@ import type { ResolvedProject } from "./user-config";
 // allowImportingTsExtensions により tsc --noEmit もこの指定子を許容し、
 // リテラル文字列のため esbuild も単一ファイルバンドルにインライン化できる。
 async function loadHerdr(): Promise<typeof HerdrModule> {
-  return (await import("./herdr.ts")) as typeof HerdrModule;
+  return (await import("./herdr")) as typeof HerdrModule;
 }
 
 async function loadTable(): Promise<typeof TableModule> {
-  return (await import("./table.ts")) as typeof TableModule;
+  return (await import("./table")) as typeof TableModule;
 }
 
 const { getDisplayWidth, truncateToWidth, padToWidth } = await loadTable();

--- a/src/gh.test.ts
+++ b/src/gh.test.ts
@@ -6,7 +6,7 @@ import type * as GhModule from "./gh";
 
 const childProcess = createRequire(import.meta.url)("node:child_process") as typeof ChildProcess;
 
-const { hasLabel, findPrNumberClosingIssue } = (await import("./gh.ts")) as typeof GhModule;
+const { hasLabel, findPrNumberClosingIssue } = (await import("./gh")) as typeof GhModule;
 
 const REPO_INFO_STDOUT = JSON.stringify({
   owner: { login: "getty104" },

--- a/src/herdr-runner.test.ts
+++ b/src/herdr-runner.test.ts
@@ -6,7 +6,7 @@ import type * as HerdrRunnerModule from "./herdr-runner";
 
 // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求するため、
 // .ts 拡張子付きのリテラル文字列で動的importする。
-const { HerdrError } = (await import("./herdr.ts")) as typeof HerdrModule;
+const { HerdrError } = (await import("./herdr")) as typeof HerdrModule;
 const {
   taskTabLabel,
   toAgentName,
@@ -16,7 +16,7 @@ const {
   waitForHerdrTask,
   startHerdrTask,
   stopHerdrTask,
-} = (await import("./herdr-runner.ts")) as typeof HerdrRunnerModule;
+} = (await import("./herdr-runner")) as typeof HerdrRunnerModule;
 
 test("taskTabLabel formats the tab label as ctw:<project>:#<number>", () => {
   assert.equal(taskTabLabel("my-app", 123), "ctw:my-app:#123");

--- a/src/herdr-runner.ts
+++ b/src/herdr-runner.ts
@@ -3,13 +3,13 @@ import type { AgentStatus } from "./herdr";
 import type { TaskResult } from "./task-result";
 // node --experimental-strip-types は実ファイル解決を要求するため、値のimportは
 // .ts 拡張子付きにする（herdr-runner.ts はテストから直接 .ts で読み込まれる）。
-import { readFinalReport } from "./transcript.ts";
+import { readFinalReport } from "./transcript";
 
 // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求するため、
 // .ts 拡張子付きのリテラル文字列で動的importする（dispatcher.ts と同様）。
 // herdr.ts は herdr モードでのみ必要なため、静的importにはしない。
 async function loadHerdr(): Promise<typeof HerdrModule> {
-  return (await import("./herdr.ts")) as typeof HerdrModule;
+  return (await import("./herdr")) as typeof HerdrModule;
 }
 
 // agent ステータスのポーリング間隔。TUI セッションは完了後もプロセスが生き続けるため、

--- a/src/herdr.test.ts
+++ b/src/herdr.test.ts
@@ -18,7 +18,7 @@ const {
   AGENT_START_READY_TIMEOUT_MS,
   workspaceCreate,
   HerdrError,
-} = (await import("./herdr.ts")) as typeof HerdrModule;
+} = (await import("./herdr")) as typeof HerdrModule;
 
 type ExecFileCallback = (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void;
 
@@ -189,7 +189,7 @@ test("propagates a timeout error via execError when herdr hangs", async (t) => {
 // （実測）。ここで code を取り出せないと stopHerdrTask の「tab_not_found は正常系」
 // 判定が効かず、claude がグレースフルに終了するたびに偽のエラーログが出る。
 test("surfaces a HerdrError with its code when herdr writes the error envelope to stderr and exits non-zero", async (t) => {
-  const { tabClose } = (await import("./herdr.ts")) as typeof HerdrModule;
+  const { tabClose } = (await import("./herdr")) as typeof HerdrModule;
   mockExecFileError(
     t,
     new Error("Command failed: herdr tab close w1:t2") as NodeJS.ErrnoException,

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ process.on("unhandledRejection", (err) => {
 async function assertRunModeAvailable(): Promise<void> {
   if (getRunMode() !== "herdr") return;
   // herdr.ts は herdr モード（と --project）でのみ必要なため動的importで遅延読込する。
-  const herdr = (await import("./herdr.ts")) as typeof HerdrModule;
+  const herdr = (await import("./herdr")) as typeof HerdrModule;
   try {
     await herdr.checkHerdrAvailable();
   } catch (err) {
@@ -222,8 +222,8 @@ if (hasProjectFilter()) {
     // .ts 拡張子付きのリテラル文字列で動的importする（dispatcher.ts と同様）。
     // allowImportingTsExtensions により tsc --noEmit もこの指定子を許容する。
     // dispatcher.ts / herdr.ts は --project 使用時にのみ必要なモジュールで、この分岐内で読込む。
-    const herdr = (await import("./herdr.ts")) as typeof HerdrModule;
-    const dispatcher = (await import("./dispatcher.ts")) as typeof DispatcherModule;
+    const herdr = (await import("./herdr")) as typeof HerdrModule;
+    const dispatcher = (await import("./dispatcher")) as typeof DispatcherModule;
 
     // 起動処理（runDispatcher/monitorSessions）が完了する前にシグナルを受けても
     // タブ・セッションが放置されないよう、起動処理より前にハンドラを登録する。

--- a/src/process-manager.test.ts
+++ b/src/process-manager.test.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type * as ProcessManagerModule from "./process-manager";
+
+// node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求するため、
+// .ts 拡張子付きのリテラル文字列で動的importする。
+// allowImportingTsExtensions により tsc --noEmit もこの指定子を許容する。
+const { makeLogFeeder, logLines } = (await import("./process-manager")) as typeof ProcessManagerModule;
+
+test("makeLogFeeder: 1バイトずつfeedしてもマルチバイト文字が文字化けしない", () => {
+  const startLength = logLines.length;
+  const feeder = makeLogFeeder(1, "stdout");
+  const line = "日本語テスト";
+  const bytes = Buffer.from(`${line}\n`, "utf-8");
+  for (const byte of bytes) feeder.feed(Buffer.from([byte]));
+  feeder.flush();
+
+  const pushed = logLines.slice(startLength);
+  assert.equal(pushed.length, 1);
+  assert.equal(pushed[0].text, line);
+  assert.ok(!pushed[0].text.includes("�"));
+});
+
+test("makeLogFeeder: 複数chunkにまたがる1行が正しく1行として結合される", () => {
+  const startLength = logLines.length;
+  const feeder = makeLogFeeder(2, "stdout");
+  const line = "日本語テスト行です";
+  const bytes = Buffer.from(`${line}\n`, "utf-8");
+  const mid = Math.floor(bytes.length / 2);
+  feeder.feed(bytes.subarray(0, mid));
+  feeder.feed(bytes.subarray(mid));
+  feeder.flush();
+
+  const pushed = logLines.slice(startLength);
+  assert.equal(pushed.length, 1);
+  assert.equal(pushed[0].text, line);
+});

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -1,13 +1,21 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { basename } from "node:path";
-import { getWorkerConfig } from "./config.js";
-import type { AgentStatus } from "./herdr.js";
-import type { HerdrTask } from "./herdr-runner.js";
-import { buildTaskTableLines } from "./table.js";
-import { STDERR_TAIL_LIMIT, buildTaskResult } from "./task-result.js";
-import type { TaskResult } from "./task-result.js";
-import { findProjectNameByPath, getRunMode } from "./user-config.js";
+import { StringDecoder } from "node:string_decoder";
+import { getWorkerConfig } from "./config";
+import type { AgentStatus } from "./herdr";
+import type { HerdrTask } from "./herdr-runner";
+import {
+  LOG_DISPLAY_LIMIT,
+  TASK_DISPLAY_LIMIT,
+  buildLogTableLines,
+  buildTaskTableLines,
+  selectRecentTasks,
+} from "./table";
+import type { LogTableEntry } from "./table";
+import { STDERR_TAIL_LIMIT, buildTaskResult } from "./task-result";
+import type { TaskResult } from "./task-result";
+import { findProjectNameByPath, getRunMode } from "./user-config";
 
 type TaskStatus = "running" | "completed" | "failed";
 
@@ -32,6 +40,52 @@ export interface TaskEntry {
 }
 
 const tasks = new Map<number, TaskEntry>();
+
+// 実行中タスクの標準出力/エラー出力の直近ログ（全タスク横断のローリングバッファ）。
+// default モードの子プロセスの stdout/stderr を行単位で溜め、直近 LOG_DISPLAY_LIMIT 行だけ残す。
+// herdr モードは TUI 起動で stdout をストリームしないため、ここには載らない。
+export const logLines: LogTableEntry[] = [];
+
+function pushLogLine(id: number, stream: "stdout" | "stderr", text: string): void {
+  const trimmed = text.replace(/\r$/, "");
+  if (trimmed.trim().length === 0) return;
+  logLines.push({ id, stream, text: trimmed, time: new Date() });
+  if (logLines.length > LOG_DISPLAY_LIMIT) {
+    logLines.splice(0, logLines.length - LOG_DISPLAY_LIMIT);
+  }
+}
+
+// chunk 境界が行の途中で割れても正しく1行ずつ拾えるよう、未確定の末尾を持ち越す。
+// マルチバイト文字が chunk 境界で分断される場合に備え、バイト単位ではなく StringDecoder で
+// デコードする（chunk.toString("utf-8") だと分断されたバイト列が U+FFFD に化ける）。
+export function makeLogFeeder(id: number, stream: "stdout" | "stderr") {
+  let partial = "";
+  const decoder = new StringDecoder("utf-8");
+  return {
+    feed(chunk: Buffer): void {
+      partial += decoder.write(chunk);
+      const parts = partial.split("\n");
+      partial = parts.pop() ?? "";
+      for (const part of parts) pushLogLine(id, stream, part);
+    },
+    flush(): void {
+      partial += decoder.end();
+      if (partial.length > 0) {
+        pushLogLine(id, stream, partial);
+        partial = "";
+      }
+    },
+  };
+}
+
+// 完了タスクの台帳を直近 TASK_DISPLAY_LIMIT 件に刈り込む（実行中タスクは常に保持）。
+// 表示は selectRecentTasks が別途上限を課すが、長時間稼働で Map が無制限に膨らむのを防ぐ。
+function pruneTaskHistory(): void {
+  const finished = [...tasks.values()]
+    .filter((t) => t.status !== "running")
+    .sort((a, b) => (b.finishedAt ?? b.startedAt).getTime() - (a.finishedAt ?? a.startedAt).getTime());
+  for (const t of finished.slice(TASK_DISPLAY_LIMIT)) tasks.delete(t.id);
+}
 
 let shuttingDown = false;
 
@@ -68,8 +122,15 @@ export function isWorkerAtCapacity(workerName: string): boolean {
 }
 
 function renderTable(): void {
-  const lines = buildTaskTableLines([...tasks.values()]);
-  if (lines.length === 0) return;
+  const taskLines = buildTaskTableLines(selectRecentTasks([...tasks.values()]));
+  const logTableLines = buildLogTableLines(logLines);
+  if (taskLines.length === 0 && logTableLines.length === 0) return;
+
+  const lines = [...taskLines];
+  if (logTableLines.length > 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push("Logs", ...logTableLines);
+  }
 
   console.clear();
   console.log(lines.join("\n"));
@@ -104,6 +165,7 @@ async function finishTask(id: number, result: TaskResult, onComplete?: OnComplet
     task.finishedAt = new Date();
     task.agentStatus = undefined;
   }
+  pruneTaskHistory();
   renderTable();
 }
 
@@ -125,8 +187,8 @@ async function runViaHerdr(
   cwd?: string,
   env?: Record<string, string>,
 ): Promise<void> {
-  const { startHerdrTask, stopHerdrTask, taskTabLabel, waitForHerdrTask } = await import("./herdr-runner.ts");
-  const { getCurrentWorkspaceId } = await import("./herdr.ts");
+  const { startHerdrTask, stopHerdrTask, taskTabLabel, waitForHerdrTask } = await import("./herdr-runner");
+  const { getCurrentWorkspaceId } = await import("./herdr");
 
   const label = taskTabLabel(resolveProjectName(), id);
   let task: HerdrTask | undefined;
@@ -182,6 +244,9 @@ export function run(
   cwd?: string,
   env?: Record<string, string>,
 ): void {
+  // 同じ Issue/PR を再実行したときは古いエントリを削除してから入れ直し、
+  // Map の挿入順で「最新に繰り上げる」（selectRecentTasks の直近順表示と揃える）。
+  tasks.delete(id);
   tasks.set(id, {
     id,
     title,
@@ -209,9 +274,14 @@ export function run(
   });
   childProcesses.set(id, child);
 
+  // 標準出力/エラー出力の直近ログをステータステーブル下に表示するための行フィーダー。
+  const stdoutFeeder = makeLogFeeder(id, "stdout");
+  const stderrFeeder = makeLogFeeder(id, "stderr");
+
   const outputChunks: Buffer[] = [];
   child.stdout?.on("data", (chunk: Buffer) => {
     outputChunks.push(chunk);
+    stdoutFeeder.feed(chunk);
   });
 
   // stderr は末尾 STDERR_TAIL_LIMIT 分だけ保持する（失敗時の通知に含める）
@@ -224,9 +294,12 @@ export function run(
       stderrLen -= stderrChunks[0].length;
       stderrChunks.shift();
     }
+    stderrFeeder.feed(chunk);
   });
 
   child.on("close", async (code) => {
+    stdoutFeeder.flush();
+    stderrFeeder.flush();
     const result = buildTaskResult(
       code,
       Buffer.concat(outputChunks).toString("utf-8"),

--- a/src/runcat.test.ts
+++ b/src/runcat.test.ts
@@ -7,7 +7,7 @@ import type * as RuncatModule from "./runcat";
 import type { UsageInfo } from "./slack";
 
 const { buildRuncatSnapshot, resetStamp, resetHour, writeRuncatUsage } =
-  (await import("./runcat.ts")) as typeof RuncatModule;
+  (await import("./runcat")) as typeof RuncatModule;
 
 // 2026-07-19 21:00 JST
 const NOW = new Date("2026-07-19T12:00:00Z");

--- a/src/table.test.ts
+++ b/src/table.test.ts
@@ -5,8 +5,8 @@ import type * as TableModule from "./table";
 // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求するため、
 // .ts 拡張子付きのリテラル文字列で動的importする。
 // allowImportingTsExtensions により tsc --noEmit もこの指定子を許容する。
-const { getDisplayWidth, truncateToWidth, padToWidth, buildTaskTableLines } =
-  (await import("./table.ts")) as typeof TableModule;
+const { getDisplayWidth, truncateToWidth, padToWidth, buildTaskTableLines, selectRecentTasks, buildLogTableLines } =
+  (await import("./table")) as typeof TableModule;
 
 test("getDisplayWidth returns 0 for empty string", () => {
   assert.equal(getDisplayWidth(""), 0);
@@ -293,8 +293,130 @@ test("buildTaskTableLines shows the worktree column only when some task has a pa
   assert.doesNotMatch(withoutPath.join("\n"), /Worktree/);
 });
 
+test("buildTaskTableLines truncates a full-width path by display width, not JS string length", () => {
+  // 全角文字を22個 + ASCII前置き "a/" で JS 文字列長は24（40以下）だが、
+  // 表示幅は 2 + 22*2 = 46 で maxPathWidth(40) を超える。
+  const path = "a/" + "日".repeat(22);
+  assert.ok(path.length <= 40);
+  assert.ok(getDisplayWidth(path) > 40);
+
+  const lines = buildTaskTableLines([task({ id: 1, status: "running", path })], NOW);
+
+  const widths = new Set(lines.map((l) => getDisplayWidth(l)));
+  assert.equal(widths.size, 1);
+});
+
 test("buildTaskTableLines measures elapsed time against the supplied clock", () => {
   const lines = buildTaskTableLines([task({ id: 1, status: "running" })], NOW);
 
   assert.match(dataRows(lines)[0], /0m 30s/);
+});
+
+// --- selectRecentTasks ---
+
+function at(iso: string): Date {
+  return new Date(iso);
+}
+
+test("selectRecentTasks caps the list at the given limit", () => {
+  const entries = Array.from({ length: 30 }, (_, i) =>
+    task({ id: i, status: "completed", finishedAt: at(`2026-07-20T12:00:${String(i).padStart(2, "0")}`) }),
+  );
+
+  assert.equal(selectRecentTasks(entries, 20).length, 20);
+});
+
+test("selectRecentTasks dedupes by id, keeping the last (most recent) entry", () => {
+  const selected = selectRecentTasks([
+    task({ id: 5, status: "completed", finishedAt: at("2026-07-20T12:00:00") }),
+    task({ id: 5, status: "running", startedAt: at("2026-07-20T12:05:00") }),
+  ]);
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].status, "running");
+});
+
+test("selectRecentTasks lists running tasks ahead of finished ones", () => {
+  const selected = selectRecentTasks([
+    task({ id: 1, status: "completed", finishedAt: at("2026-07-20T12:10:00") }),
+    task({ id: 2, status: "running", startedAt: at("2026-07-20T12:00:00") }),
+  ]);
+
+  assert.deepEqual(
+    selected.map((t) => t.id),
+    [2, 1],
+  );
+});
+
+test("selectRecentTasks orders finished tasks newest-first by finish time", () => {
+  const selected = selectRecentTasks([
+    task({ id: 1, status: "completed", finishedAt: at("2026-07-20T12:00:00") }),
+    task({ id: 2, status: "completed", finishedAt: at("2026-07-20T12:05:00") }),
+    task({ id: 3, status: "failed", finishedAt: at("2026-07-20T12:02:00") }),
+  ]);
+
+  assert.deepEqual(
+    selected.map((t) => t.id),
+    [2, 3, 1],
+  );
+});
+
+test("selectRecentTasks keeps the most recent 20 finished tasks when over the limit", () => {
+  const entries = Array.from({ length: 25 }, (_, i) =>
+    task({ id: i, status: "completed", finishedAt: at(`2026-07-20T12:${String(i).padStart(2, "0")}:00`) }),
+  );
+
+  const selectedIds = selectRecentTasks(entries, 20).map((t) => t.id);
+  // 最も古い #0..#4 が落ち、直近の #24 が先頭に来る
+  assert.equal(selectedIds[0], 24);
+  assert.ok(!selectedIds.includes(0));
+  assert.ok(!selectedIds.includes(4));
+});
+
+// --- buildLogTableLines ---
+
+type LogTableEntry = TableModule.LogTableEntry;
+
+function log(overrides: Partial<LogTableEntry> & Pick<LogTableEntry, "id" | "text">): LogTableEntry {
+  return {
+    stream: "stdout",
+    time: at("2026-07-20T12:00:05"),
+    ...overrides,
+  };
+}
+
+test("buildLogTableLines returns no lines when there are no logs", () => {
+  assert.deepEqual(buildLogTableLines([]), []);
+});
+
+test("buildLogTableLines renders a header with the log columns", () => {
+  const lines = buildLogTableLines([log({ id: 1, text: "hello" })]);
+
+  assert.match(lines.join("\n"), /Time.*#.*Stream.*Log/);
+});
+
+test("buildLogTableLines renders the id, stream and text of each entry", () => {
+  const lines = buildLogTableLines([log({ id: 42, stream: "stderr", text: "boom happened" })]).join("\n");
+
+  assert.match(lines, /#42/);
+  assert.match(lines, /stderr/);
+  assert.match(lines, /boom happened/);
+});
+
+test("buildLogTableLines strips ANSI/control chars so the table stays aligned", () => {
+  const lines = buildLogTableLines([log({ id: 1, text: "\x1b[31mred\x1b[0m\ttab" })]);
+
+  const joined = lines.join("\n");
+  assert.ok(!joined.includes("\x1b"));
+  assert.match(joined, /red/);
+  // 全行の表示幅が揃っている（制御文字が幅計算を狂わせていない）
+  const widths = new Set(lines.map((l) => getDisplayWidth(l)));
+  assert.equal(widths.size, 1);
+});
+
+test("buildLogTableLines keeps every row the same display width with wide characters", () => {
+  const lines = buildLogTableLines([log({ id: 1, text: "ascii line" }), log({ id: 2, text: "日本語のログ行" })]);
+
+  const widths = new Set(lines.map((l) => getDisplayWidth(l)));
+  assert.equal(widths.size, 1);
 });

--- a/src/table.ts
+++ b/src/table.ts
@@ -73,6 +73,62 @@ function formatTime(date: Date): string {
   return `${h}:${m}:${s}`;
 }
 
+/**
+ * 罫線付きテーブルを組み立てる汎用ヘルパー。列幅はヘッダーと全行の表示幅から算出し、
+ * 全角を幅2として桁揃えする。`groups` は行グループの配列で、空でないグループの境目に
+ * 区切り罫線を引く（タスクテーブルの実行中/完了セクションの区切りに使う）。
+ */
+function renderBoxTable(headers: string[], groups: string[][][]): string[] {
+  const allRows = groups.flat();
+  const widths = headers.map((h, i) =>
+    Math.max(1, getDisplayWidth(h), ...allRows.map((r) => getDisplayWidth(r[i] ?? ""))),
+  );
+
+  const border = (l: string, m: string, r: string) => `${l}${widths.map((w) => "─".repeat(w + 2)).join(m)}${r}`;
+  const row = (cells: string[]) => `│ ${cells.map((c, i) => padToWidth(c ?? "", widths[i])).join(" │ ")} │`;
+
+  const lines: string[] = [];
+  lines.push(border("┌", "┬", "┐"));
+  lines.push(row(headers));
+  lines.push(border("├", "┼", "┤"));
+
+  const nonEmpty = groups.filter((g) => g.length > 0);
+  nonEmpty.forEach((group, gi) => {
+    if (gi > 0) lines.push(border("├", "┼", "┤"));
+    for (const r of group) lines.push(row(r));
+  });
+
+  lines.push(border("└", "┴", "┘"));
+  return lines;
+}
+
+/** タスクテーブル/ログテーブルで表示する既定の最大件数。 */
+export const TASK_DISPLAY_LIMIT = 20;
+export const LOG_DISPLAY_LIMIT = 20;
+
+/** タスクの「直近さ」の基準時刻。完了は finishedAt、実行中は startedAt。 */
+function taskRecency(t: TaskTableEntry): number {
+  return (t.finishedAt ?? t.startedAt).getTime();
+}
+
+/**
+ * 表示するタスクを「直近 limit 件」に絞り込む純粋関数。同じ Issue/PR（id）は
+ * 呼び出し元の Map で既に一意化されている前提だが、二重登録に備えて id で重複排除し
+ * 最新のものだけを残す。実行中タスクを先頭に、その下を直近順（新しい順）に並べ、
+ * 合計 limit 件で打ち切る。
+ */
+export function selectRecentTasks(entries: TaskTableEntry[], limit: number = TASK_DISPLAY_LIMIT): TaskTableEntry[] {
+  // id で重複排除（後勝ち＝最新を残す）
+  const byId = new Map<number, TaskTableEntry>();
+  for (const e of entries) byId.set(e.id, e);
+  const unique = [...byId.values()];
+
+  const running = unique.filter((t) => t.status === "running").sort((a, b) => taskRecency(b) - taskRecency(a));
+  const finished = unique.filter((t) => t.status !== "running").sort((a, b) => taskRecency(b) - taskRecency(a));
+
+  return [...running, ...finished].slice(0, limit);
+}
+
 /** ステータステーブルの各行を組み立てる。副作用を持たないのでそのままテストできる。 */
 export function buildTaskTableLines(entries: TaskTableEntry[], now: Date = new Date()): string[] {
   if (entries.length === 0) return [];
@@ -83,91 +139,88 @@ export function buildTaskTableLines(entries: TaskTableEntry[], now: Date = new D
   const maxTitleWidth = 40;
   const maxPathWidth = 40;
 
-  const runningRows = runningTasks.map((t) => ({
-    id: `#${t.id}`,
-    title: getDisplayWidth(t.title) > maxTitleWidth ? truncateToWidth(t.title, maxTitleWidth) : t.title,
-    worker: t.workerName,
-    path: t.path ? (t.path.length > maxPathWidth ? truncateToWidth(t.path, maxPathWidth) : t.path) : "",
-    // herdr モードでは agent ステータス（working / blocked 等）を併記し、
-    // 人の介入が必要な blocked にも気づけるようにする。
-    status: t.agentStatus ? `${t.status}:${t.agentStatus}` : t.status,
-    time: formatTime(t.startedAt),
-    duration: formatDuration(t.startedAt, now),
-  }));
+  const truncTitle = (s: string) => (getDisplayWidth(s) > maxTitleWidth ? truncateToWidth(s, maxTitleWidth) : s);
+  const truncPath = (p?: string) =>
+    p ? (getDisplayWidth(p) > maxPathWidth ? truncateToWidth(p, maxPathWidth) : p) : "";
 
-  const finishedRows = finishedTasks.map((t) => ({
-    id: `#${t.id}`,
-    title: getDisplayWidth(t.title) > maxTitleWidth ? truncateToWidth(t.title, maxTitleWidth) : t.title,
-    worker: t.workerName,
-    path: t.path ? (t.path.length > maxPathWidth ? truncateToWidth(t.path, maxPathWidth) : t.path) : "",
-    status: t.status,
-    time: formatTime(t.finishedAt ?? t.startedAt),
-    duration: formatDuration(t.startedAt, t.finishedAt ?? now),
-  }));
+  const hasPath = entries.some((t) => truncPath(t.path) !== "");
 
-  // 列幅の算出は全行を対象にするが、セクションの振り分けには使わない。
   // status 文字列は herdr モードで `running:working` のように装飾されるため、
-  // 表示値で running か否かを判定すると実行中タスクが完了セクションへ紛れ込む。
-  const allRows = [...runningRows, ...finishedRows];
+  // 表示値ではなく status フィールドで実行中/完了のセクション振り分けを行う。
+  const runningRows = runningTasks.map((t) =>
+    taskRow(
+      t,
+      truncTitle(t.title),
+      truncPath(t.path),
+      hasPath,
+      t.agentStatus ? `${t.status}:${t.agentStatus}` : t.status,
+      formatTime(t.startedAt),
+      formatDuration(t.startedAt, now),
+    ),
+  );
+  const finishedRows = finishedTasks.map((t) =>
+    taskRow(
+      t,
+      truncTitle(t.title),
+      truncPath(t.path),
+      hasPath,
+      t.status,
+      formatTime(t.finishedAt ?? t.startedAt),
+      formatDuration(t.startedAt, t.finishedAt ?? now),
+    ),
+  );
 
-  const hasPath = allRows.some((r) => r.path !== "");
+  const headers = hasPath
+    ? ["#", "Title", "Worker", "Worktree", "Status", "Time", "Duration"]
+    : ["#", "Title", "Worker", "Status", "Time", "Duration"];
 
-  const colWidths = {
-    id: Math.max(3, ...allRows.map((r) => r.id.length)),
-    title: Math.max(5, ...allRows.map((r) => getDisplayWidth(r.title))),
-    worker: Math.max(6, ...allRows.map((r) => r.worker.length)),
-    ...(hasPath ? { path: Math.max(8, ...allRows.map((r) => r.path.length)) } : {}),
-    status: Math.max(6, ...allRows.map((r) => r.status.length)),
-    time: Math.max(4, ...allRows.map((r) => r.time.length)),
-    duration: Math.max(8, ...allRows.map((r) => r.duration.length)),
-  };
+  return renderBoxTable(headers, [runningRows, finishedRows]);
+}
 
-  const pad = (s: string, w: number, useDisplayWidth = false) =>
-    useDisplayWidth ? padToWidth(s, w) : s + " ".repeat(w - s.length);
-  const cols = hasPath
-    ? [
-        colWidths.id,
-        colWidths.title,
-        colWidths.worker,
-        colWidths.path!,
-        colWidths.status,
-        colWidths.time,
-        colWidths.duration,
-      ]
-    : [colWidths.id, colWidths.title, colWidths.worker, colWidths.status, colWidths.time, colWidths.duration];
-  const line = (l: string, m: string, r: string, f: string) => `${l}${cols.map((w) => f.repeat(w + 2)).join(m)}${r}`;
+function taskRow(
+  t: TaskTableEntry,
+  title: string,
+  path: string,
+  hasPath: boolean,
+  status: string,
+  time: string,
+  duration: string,
+): string[] {
+  return hasPath
+    ? [`#${t.id}`, title, t.workerName, path, status, time, duration]
+    : [`#${t.id}`, title, t.workerName, status, time, duration];
+}
 
-  const row = (
-    id: string,
-    title: string,
-    worker: string,
-    path: string,
-    status: string,
-    time: string,
-    duration: string,
-  ) =>
-    hasPath
-      ? `│ ${pad(id, colWidths.id)} │ ${pad(title, colWidths.title, true)} │ ${pad(worker, colWidths.worker)} │ ${pad(path, colWidths.path!)} │ ${pad(status, colWidths.status)} │ ${pad(time, colWidths.time)} │ ${pad(duration, colWidths.duration)} │`
-      : `│ ${pad(id, colWidths.id)} │ ${pad(title, colWidths.title, true)} │ ${pad(worker, colWidths.worker)} │ ${pad(status, colWidths.status)} │ ${pad(time, colWidths.time)} │ ${pad(duration, colWidths.duration)} │`;
+/** ログテーブル1行分。実行中タスクの標準出力/エラー出力の1行に対応する。 */
+export interface LogTableEntry {
+  id: number;
+  stream: string;
+  text: string;
+  time: Date;
+}
 
-  const lines: string[] = [];
-  lines.push(line("┌", "┬", "┐", "─"));
-  lines.push(row("#", "Title", "Worker", "Worktree", "Status", "Time", "Duration"));
-  lines.push(line("├", "┼", "┤", "─"));
+// ANSI エスケープ・制御文字はテーブルの桁揃えを壊すため除去する。
+// eslint-disable-next-line no-control-regex -- ANSI/制御文字を意図的に対象にする
+const CONTROL_CHARS = /\x1b\[[0-9;?]*[ -/]*[@-~]|[\x00-\x08\x0b-\x1f\x7f]/g;
 
-  for (const r of runningRows) {
-    lines.push(row(r.id, r.title, r.worker, r.path, r.status, r.time, r.duration));
-  }
+function sanitizeLogText(text: string): string {
+  return text.replace(CONTROL_CHARS, " ").replace(/\t/g, " ");
+}
 
-  if (runningRows.length > 0 && finishedRows.length > 0) {
-    lines.push(line("├", "┼", "┤", "─"));
-  }
+/** 実行中タスクの標準出力/エラー出力のログをテーブルに組み立てる純粋関数。 */
+export function buildLogTableLines(entries: LogTableEntry[]): string[] {
+  if (entries.length === 0) return [];
 
-  for (const r of finishedRows) {
-    lines.push(row(r.id, r.title, r.worker, r.path, r.status, r.time, r.duration));
-  }
+  const maxTextWidth = 100;
+  const rows = entries.map((e) => {
+    const text = sanitizeLogText(e.text);
+    return [
+      formatTime(e.time),
+      `#${e.id}`,
+      e.stream,
+      getDisplayWidth(text) > maxTextWidth ? truncateToWidth(text, maxTextWidth) : text,
+    ];
+  });
 
-  lines.push(line("└", "┴", "┘", "─"));
-
-  return lines;
+  return renderBoxTable(["Time", "#", "Stream", "Log"], [rows]);
 }

--- a/src/task-result.test.ts
+++ b/src/task-result.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import type * as TaskResultModule from "./task-result";
 
-const { buildTaskResult } = (await import("./task-result.ts")) as typeof TaskResultModule;
+const { buildTaskResult } = (await import("./task-result")) as typeof TaskResultModule;
 
 test("exit 0 with output is completed and keeps stdout as-is", () => {
   const result = buildTaskResult(0, "判定: パターンB-通常（マージ済み）\n", "");

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -7,7 +7,7 @@ import type * as TranscriptModule from "./transcript";
 
 // node --experimental-strip-types は .ts 拡張子付きの実ファイル解決を要求する。
 const { extractFinalAssistantText, findTranscriptPath, readFinalReport } =
-  (await import("./transcript.ts")) as typeof TranscriptModule;
+  (await import("./transcript")) as typeof TranscriptModule;
 
 function assistantLine(text: string, extra: Record<string, unknown> = {}): string {
   return JSON.stringify({

--- a/src/user-config.test.ts
+++ b/src/user-config.test.ts
@@ -19,7 +19,7 @@ const {
   getRunMode,
   resetRunModeCache,
   findProjectNameByPath,
-} = (await import("./user-config.ts")) as typeof UserConfigModule;
+} = (await import("./user-config")) as typeof UserConfigModule;
 
 const configDir = join(configHome, "claude-task-worker");
 


### PR DESCRIPTION
## 概要

ワーカーのステータステーブル表示を刷新する。

## 変更点

### タスク実行履歴を直近20件に絞る
- `selectRecentTasks()`（純粋関数）を追加。id で重複排除（同じ Issue/PR は最新のみ）、実行中タスクを先頭・以降を直近順（新しい順）に並べ、合計20件で打ち切る。
- `run()` の冒頭で `tasks.delete(id)` してから set し、同一 Issue/PR の再実行を Map 挿入順で「最新に繰り上げる」。
- `pruneTaskHistory()` で完了台帳を直近20件に刈り込み、長時間稼働での Map 無制限膨張を防ぐ（実行中タスクは常に保持）。

### ライブログテーブルを追加
- タスクテーブルの下に、実行中タスクの標準出力/エラー出力の直近ログを同じテーブル形式で表示（`Time` / `#` / `Stream` / `Log`、最大20行）。
- 子プロセスの stdout/stderr を `makeLogFeeder()` で行単位に拾い、chunk 境界で行が割れても正しく1行ずつ溜める。`node:string_decoder` の `StringDecoder` を保持し、マルチバイト文字（日本語等）が chunk 境界で分断されても文字化け（`U+FFFD`）しないようデコードする。ローリングバッファで直近20行だけ保持。
- ANSI エスケープ・制御文字はテーブルの桁揃えを壊すため `sanitizeLogText()` で除去。
- herdr モードは TUI 起動で stdout をストリームしないためログテーブルは空になる。

### リファクタ
- 罫線テーブルの組み立てを `renderBoxTable()` に共通化し、タスクテーブル/ログテーブルで共有。`buildTaskTableLines()` の出力挙動は据え置き。

### import を拡張子なしに統一
- 相対 import の拡張子（`.js` / `.ts`）を全廃し、拡張子なしに統一（`import { x } from "./foo"`）。`tsconfig`（`moduleResolution: Bundler`）と esbuild は拡張子なしをそのまま解決するが、`node --experimental-strip-types --test` の ESM リゾルバは拡張子なし・`.js`→`.ts` のどちらも解決できないため、テスト実行時のみ `scripts/test-resolver.mjs`（`register()` で `scripts/test-resolver.hooks.mjs` の resolve フックを登録）が実ファイルへ橋渡しする。`package.json` の `test` スクリプトを `--import ./scripts/test-resolver.mjs` 付きに変更。
- CLAUDE.md の規約も「相対 import は拡張子を付けない」に更新。

## テスト
- `selectRecentTasks` 5件・`buildLogTableLines` 5件に加え、`makeLogFeeder` のマルチバイト境界デコード（1バイト分割・複数 chunk 跨ぎ）と `truncPath` の表示幅切り詰め（全角パス）を検証するテストを追加。268 tests pass、lint・format・build いずれもクリーン。

## 修正履歴

### 2026-07-24: レビュー指摘対応（2件）
- `makeLogFeeder` の UTF-8 デコードを chunk ごとの独立 `toString("utf-8")` から `node:string_decoder` の `StringDecoder` に変更し、マルチバイト文字が chunk 境界で分断されても文字化けしないよう修正。`makeLogFeeder` / `logLines` をテスト観測用に export し、1バイト分割 feed でも正しく復元されることを検証するテストを追加（対応コミット: 21fbd08）
- `truncPath` の切り詰め判定を JS 文字列長 `p.length` から表示幅 `getDisplayWidth(p)` に変更し、`truncTitle` と判定基準を揃えて全角パスでの列幅崩れを解消。全角パスの切り詰めを検証するテストを追加（対応コミット: 21fbd08）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 実行中タスクの stdout/stderr ログを、最新行から確認できる「Logs」セクションを追加。
  * タスクとログを罫線付きテーブルで見やすく表示。
  * 同じタスクを再実行すると、一覧の先頭に表示。

* **改善**
  * 完了済みタスクとログの表示件数を制限し、最新の情報を優先して表示。
  * ANSI・制御文字や全角文字を含むログでも、表示の整列を維持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
