### PR TITLE
fix: herdrモードのagent名サニタイズでinvalid_agent_nameを解消

### DIFF
--- a/src/herdr-runner.test.ts
+++ b/src/herdr-runner.test.ts
@@ -9,6 +9,7 @@ import type * as HerdrRunnerModule from "./herdr-runner";
 const { HerdrError } = (await import("./herdr.ts")) as typeof HerdrModule;
 const {
   taskTabLabel,
+  toAgentName,
   createCompletionTracker,
   observeAgentStatus,
   buildHerdrTaskResult,
@@ -19,6 +20,29 @@ const {
 
 test("taskTabLabel formats the tab label as ctw:<project>:#<number>", () => {
   assert.equal(taskTabLabel("my-app", 123), "ctw:my-app:#123");
+});
+
+const AGENT_NAME_RE = /^[a-z][a-z0-9_-]{0,31}$/;
+
+test("toAgentName converts a task tab label into a valid herdr agent name", () => {
+  // `:` と `#` を含むラベルは agent 名規則に違反するため潰されること。
+  assert.equal(toAgentName(taskTabLabel("my-app", 123)), "ctw-my-app-123");
+  assert.match(toAgentName(taskTabLabel("my-app", 123)), AGENT_NAME_RE);
+});
+
+test("toAgentName satisfies the herdr agent name rules for tricky inputs", () => {
+  // 大文字・全角・記号を含む、数字始まり、先頭記号、超長文字列でも規則を満たす。
+  const cases = [
+    taskTabLabel("Dementia_App", 12),
+    taskTabLabel("プロジェクト", 7),
+    taskTabLabel("123numeric", 9),
+    taskTabLabel("a".repeat(60), 999999),
+    "###",
+  ];
+  for (const label of cases) {
+    const name = toAgentName(label);
+    assert.match(name, AGENT_NAME_RE, `"${label}" -> "${name}" should be a valid agent name`);
+  }
 });
 
 test("observeAgentStatus only completes after a working status has been seen", () => {
@@ -253,7 +277,7 @@ test("startHerdrTask launches claude into the task tab's root shell pane via age
   // ルートペインがそのまま claude のペインになる（余剰シェルペインの paneClose は不要）。
   assert.deepEqual(task, { paneId: "pane-root", tabId: "tab-task" });
   // タブ作成 → ルートペインで agent start、の順。args には実行ファイル claude は含めない。
-  assert.deepEqual(calls, ["tabCreate:ctw:my-app:#12:/tmp/worktree", "agentStart:pane-root:ctw:my-app:#12:/skill 12"]);
+  assert.deepEqual(calls, ["tabCreate:ctw:my-app:#12:/tmp/worktree", "agentStart:pane-root:ctw-my-app-12:/skill 12"]);
 });
 
 // agent start は検出できなければ herdr がエラーを返す（起動失敗・プリアンブル失敗など）。
@@ -265,7 +289,7 @@ test("startHerdrTask closes the task tab when agent start fails", async () => {
   // シェルだけのタブを残さない。
   assert.deepEqual(calls, [
     "tabCreate:ctw:my-app:#12:/tmp/worktree",
-    "agentStart:pane-root:ctw:my-app:#12:",
+    "agentStart:pane-root:ctw-my-app-12:",
     "tabClose:tab-task",
   ]);
 });

--- a/src/herdr-runner.ts
+++ b/src/herdr-runner.ts
@@ -25,6 +25,21 @@ export function taskTabLabel(projectName: string, number: number): string {
   return `ctw:${projectName}:#${number}`;
 }
 
+// `herdr agent start <name>` の agent 名は「小文字始まり・小文字/数字/'-'/'_' のみ・1〜32文字」に
+// 制限される（違反すると invalid_agent_name で起動が失敗する）。タブラベル（`ctw:<project>:#<n>`）は
+// `:` や `#` を含むためそのままでは使えないので、無効文字を `-` へ潰して規則に合う名前へ変換する。
+// 純粋関数として export し、ユニットテストで規則違反を検証できるようにする。
+export function toAgentName(label: string): string {
+  const sanitized = label
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-") // 無効文字（`:` `#` 全角など）を `-` へ
+    .replace(/-+/g, "-") // 連続する `-` を1つに畳む
+    .replace(/^[-_]+/, ""); // 先頭の `-`/`_` を除去（小文字始まりを保証する下ごしらえ）
+  // 先頭が小文字英字でなければ（数字始まり・空になった場合含む）接頭辞を足して規則を満たす。
+  const withLeadingLetter = /^[a-z]/.test(sanitized) ? sanitized : `ctw-${sanitized}`;
+  return withLeadingLetter.slice(0, 32).replace(/[-_]+$/, "");
+}
+
 // 完了判定の状態。TUI は起動直後 unknown / idle を経てから working になるため、
 // 「一度 working を観測してから idle になった」ことを完了条件にする。
 // idle 単独を完了とみなすと、起動直後のプロンプト表示前に完了と誤判定してしまう。
@@ -121,7 +136,8 @@ export interface StartTiming {
  * herdr のタスク専用タブで claude を TUI 起動する（1タスク=1タブ）。
  *
  * `--no-focus` でタスク専用タブを作り、その**ルートペイン（シェル）で** `herdr agent start`
- * を使って claude を起動する。`agent start <label> --kind claude --pane <id> -- <args>` は、
+ * を使って claude を起動する。`agent start <name> --kind claude --pane <id> -- <args>` は（name は
+ * ラベルを agent 名規則へ変換した `toAgentName(label)`）、
  * ペインのシェルで claude を起動し、agent として検出され入力待ちになるまで同期的にブロックする
  * （旧 send-text 方式の「起動コマンド送信 → 自動検出待ちポーリング」を1コマンドで担う）。
  * `--kind claude` が実行ファイルを供給するため、`args` には claude のフラグだけを渡す
@@ -167,7 +183,8 @@ export async function startHerdrTask({
     if (!ready) {
       console.warn(`[herdr-runner] pane ${paneId} produced no prompt before the timeout, launching anyway`);
     }
-    await mod.agentStart(paneId, { name: label, args, readyTimeoutMs: timing?.agentStartReadyTimeoutMs });
+    // agent 名はラベルと違い文字種が厳しく制限されるため、ラベルから規則に合う名前へ変換して渡す。
+    await mod.agentStart(paneId, { name: toAgentName(label), args, readyTimeoutMs: timing?.agentStartReadyTimeoutMs });
   } catch (err) {
     // 起動できなかった場合、シェルだけのタブが残り続けるため閉じてから失敗させる。
     await mod.tabClose(tabId).catch(() => {});


### PR DESCRIPTION
## 概要

herdrモードでタスクを起動すると `[invalid_agent_name]` エラーで失敗する問題を修正。

```
[invalid_agent_name] agent name must start with a lowercase letter and contain only lowercase letters, digits, '-' or '_' (1-32 characters)
```

## 原因

`startHerdrTask` がタブラベル `ctw:<project>:#<n>`（例 `ctw:my-app:#12`）を**そのまま** `herdr agent start <name>` の agent 名として渡していた。`:` と `#` が agent 名規則（小文字始まり・小文字/数字/`-`/`_` のみ・1〜32文字）に違反するため起動が失敗していた。

## 修正

- `toAgentName(label)` を追加（純粋関数・export）。無効文字を `-` へ潰す → 連続 `-` を畳む → 先頭 `-`/`_` 除去 → 小文字始まりでなければ `ctw-` を前置 → 32文字へ切り詰め。`ctw:my-app:#12` は `ctw-my-app-12` になる。
- `startHerdrTask` は `agentStart` へ `toAgentName(label)` を渡す。**タブラベル自体は従来どおり `ctw:...` のまま表示**。

## テスト

- 新規: ラベル変換の期待値、大文字/全角/記号/数字始まり/超長文字列/先頭記号での規則充足を正規表現で検証。
- 既存2件の agentStart 呼び出し期待値をサニタイズ後の名前へ更新。
- `tsc --noEmit` クリーン、全248テストパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)