### PR TITLE
feat: advisorオプションを追加しタスク実行時に--advisorを渡せるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ claude-task-worker all             # Run all workers concurrently
   - herdr は大半のコマンドで「終了コード0＋stdoutにJSON」を返すが、一部（実測では存在しないタブへの `tab close`）は「終了コード非0＋**stderr**にJSON」を返す。`runHerdr()` は stdout から error を取れなかった場合のみ stderr も解析し、どちらの形でも `HerdrError`（`code` 付き）にする。取り出せないと `stopHerdrTask()` の「`tab_not_found` は正常系」判定が効かず、claudeがグレースフル終了するたびに偽のエラーログが出る。ただし `result`（成功値）の取得元は stdout のみ
 - **`src/transcript.ts`** - Claude Code のセッション transcript（`~/.claude/projects/*/<sessionId>.jsonl`）から最終レポートを取り出す。`findTranscriptPath()`（セッションIDでディレクトリを総なめ）、`extractFinalAssistantText()`（末尾から最初に見つかる非 sidechain のアシスタントテキスト。純粋関数）、`readFinalReport()`。herdr モードで `claude -p` の stdout の代わりに Slack 通知本文を作るために使う
 - **`src/herdr-runner.ts`** - herdrモードのタスク実行。`startHerdrTask()`（`tabCreate`（`--no-focus`）→ `waitForPaneReady`（シェルプロンプト描画待ち）→ `agentStart`（ルートペインで `herdr agent start --kind claude` を使って claude を起動し、検出＋入力待ちになるまで同期ブロック）。`agent start` が検出できなければ herdr がエラーを返し `agentStart` が throw するので、シェルだけのタブを残さないよう閉じてから失敗させる。ルートペインがそのまま claude のペインになるため余剰シェルペインの `paneClose` は不要。**渡す `args` は claude のフラグのみで実行ファイル `claude` は含めない**（`--kind` が供給））、`waitForHerdrTask()`（agentステータスのポーリング。`done` または `working`→`idle` で完了、`pane_not_found`/`agent_not_found` で失敗、`blocked` は待機継続）、`buildHerdrTaskResult()`（ペイン出力が空なら空振りとして失敗扱い）、`stopHerdrTask()`（ctrl-c送信 → `waitForAgentGone` → タブクローズ）、`taskTabLabel()`（`ctw:<project>:#<n>`）
-- **`src/user-config.ts`** - `config.json`（`~/.config/claude-task-worker/config.json` または `$XDG_CONFIG_HOME` 配下）のロード・検証・対象プロジェクト解決。`UserConfig`（`mode`/`projects`/`projectGroups`）、`loadUserConfig()`（読み込み・検証）、`resolveTargetProjects()`（プロジェクト名/グループ名/予約語 `all` の展開）、`getRunMode()`（`mode` の解決。設定ファイル不在・projects破損でも `"default"` を返し、プロセス内でキャッシュする）、`findProjectNameByPath()`（herdrモードのタブラベル用にパスからプロジェクト名を逆引き）。リポジトリ直下の `claude-task-worker.json` を扱う `src/config.ts` とは別物
+- **`src/user-config.ts`** - `config.json`（`~/.config/claude-task-worker/config.json` または `$XDG_CONFIG_HOME` 配下）のロード・検証・対象プロジェクト解決。`UserConfig`（`mode`/`advisor`/`projects`/`projectGroups`）、`loadUserConfig()`（読み込み・検証）、`resolveTargetProjects()`（プロジェクト名/グループ名/予約語 `all` の展開）、`getRunMode()`（`mode` の解決。設定ファイル不在・projects破損でも `"default"` を返し、プロセス内でキャッシュする）、`isAdvisorEnabled()`（`advisor` の解決。`getRunMode()` と同じく設定ファイル不在・破損でも既定＝無効を返し、プロセス内でキャッシュする。後述の「`advisor`（アドバイザーモデル）」参照）、`findProjectNameByPath()`（herdrモードのタブラベル用にパスからプロジェクト名を逆引き）。リポジトリ直下の `claude-task-worker.json` を扱う `src/config.ts` とは別物
 - **`src/dispatch-args.ts`** - `--project` ディスパッチ用CLI引数ヘルパー。`PROJECT_INCOMPATIBLE_COMMANDS`（`--project` と併用不可なコマンド一覧: `init`/`install`/`update`/`usage`/`version`）、`parseProjectFilters()`/`hasProjectFilter()`（`--project` の抽出・検出）、`buildForwardedCommand()`（`--project` とその値を除去し他プロジェクトへ転送するコマンド文字列を構築）
 
 ### Worker共通ライフサイクル
@@ -100,6 +100,17 @@ SKILL.md のプリアンブル（`!` インライン実行）のコマンドが�
 2. **worktree配下を作業ディレクトリに持つ残留プロセスへ `SIGTERM`**: 実行cwd（worktree、`.claude/worktrees/<adj-noun-NNNN>` で一意）を cwd に持つプロセスだけを対象にする。切り離されたプロセスも起動時の cwd を保持し、worktree名はこの実行に固有なため、「この実行が起動したプロセス」だけを、ユーザー自身や別実行のプロセスに触れずに特定できる。ただし本フック自身の祖先チェーン（node フック・そのシェル・`claude` プロセスはいずれもworktreeをcwdに持つ）は除外し、自プロセスの巻き添え停止を防ぐ。プロセス列挙は Linux では `/proc/<pid>/cwd`、macOS 等では `lsof` を用いる。
 
 判定ロジック（`selectPidsToKill` / `parseLsofCwds` / `isUnder` / `resolveTargetDir`）は純粋関数として export し、`plugin/scripts/stop-servers.test.mjs` でユニットテストする。対象スキルは同期実行ガードと同じ12スキル（`exec-issue` / `fix-review-point` / `answer-issue-questions` / `create-issue-from-issue-number` / `update-issue` / `triage-created-issue` / `triage-pr` / `resolve-pr-conflict` / `check-dependabot` / `create-epic-pr` / `create-ui-design` / `apply-ui-design`）。
+
+### `advisor`（アドバイザーモデル）
+
+`config.json` のトップレベル `advisor`（boolean、既定 `false`）で、タスク起動時に claude CLI へ `--advisor <model>` を渡すかを切り替える。`mode` と同じくトップレベル一括（プロジェクト単位・ワーカー単位のオン/オフはできない）で、`isAdvisorEnabled()` がプロセス起動時に一度だけ解決してキャッシュするため、実行中に設定ファイルが書き換わってもワーカー間・タスク間で `--advisor` の有無が揺れない。
+
+渡すモデルはリポジトリ直下の `claude-task-worker.json` の `workers.<name>.advisorModel`（`WorkerRuntimeConfig.advisorModel`）で指定する。ゲートは2段:
+
+1. `advisor: false`（既定）なら `advisorModel` の指定に関わらず渡さない。判定はワーカー側（`issue-worker.ts` / `pr-worker.ts`）で行い、無効時は `buildClaudeExecution()` へ空文字を渡す
+2. `advisorModel` が空文字（または未指定でその既定が空文字）なら `buildClaudeArgs()` が `--advisor` ごと省く。**値なしの `--advisor` を渡すと後続フラグを値として食われる**ため、必ずモデル名とセットでのみ付ける
+
+`advisorModel` のパースは `parseWorkerEntry()` の他フィールドと違い**空文字を有効値として受け付ける**（「advisor を使わない」の明示指定）。既定値は claude 側の制約（advisor は main モデル以上の能力が必要）に合わせ、`model` が `sonnet` のワーカーは `"opus"`、`model` が `opus` のワーカー（`answer-issue-questions`）は `""` にしてある。
 
 ### `mode`（タスクの実行形態）
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 ```json
 {
   "mode": "default",
+  "advisor": false,
   "projects": {
     "app-a": "/Users/me/repos/app-a",
     "app-b": "/Users/me/repos/app-b",
@@ -346,7 +347,7 @@ claude-task-worker yolo --epic 100 --epic 200 --label priority-high
 }
 ```
 
-`mode` については [`mode`（タスクの実行形態）](#modeタスクの実行形態) を参照。
+`mode` については [`mode`（タスクの実行形態）](#modeタスクの実行形態)、`advisor` については [`advisor`（アドバイザーモデル）](#advisorアドバイザーモデル) を参照。
 
 `--project` は繰り返し指定可能で、複数指定した場合は解決後のプロジェクト集合の和集合が対象になる（重複は一意化される）。`--epic` / `--label` と併用でき、ディスパッチ先の各プロジェクトで実行されるコマンドにそのまま引き継がれる。
 
@@ -404,6 +405,24 @@ claude-task-worker exec-issue --project app-a --epic 100 --label priority-high
   ```
 
   適用は `herdr server reload-config`。この設定は herdr サーバー全体に効くため、ワーカー以外の対話セッションの完了音も鳴らなくなる（`[ui.sound.agents] claude = "off"` でも実質同じ範囲）。ワーカーだけを無音にしたい場合は、`HERDR_DISABLE_SOUND=1 herdr --session <name>` で別セッションを起動し、その中でディスパッチャーを動かす
+
+### `advisor`（アドバイザーモデル）
+
+`config.json` のトップレベルに `advisor: true` を書くと、ワーカーがタスクを起動する際、Claude CLI へ `--advisor <model>` を渡すようになる。渡すモデルはリポジトリ直下の `claude-task-worker.json` の `workers.<ワーカー名>.advisorModel`（[ワーカーごとの設定](#ワーカーごとの設定)）で指定する。`mode` と同じくトップレベル一括で、プロジェクト単位・ワーカー単位のオン/オフはできない。
+
+| `advisor` | 挙動 |
+|---|---|
+| `false`（既定） | `advisorModel` の指定に関わらず `--advisor` を渡さない |
+| `true` | 各ワーカーの `advisorModel`（未指定時はワーカー既定値）を `--advisor` に渡す。空文字のワーカーには渡さない |
+
+```json
+{
+  "advisor": true,
+  "projects": { "app-a": "/Users/me/repos/app-a" }
+}
+```
+
+advisor は main モデル以上の能力を持つモデルである必要がある（Claude CLI 側の制約）。そのため `advisorModel` の既定値は、`model` が `sonnet` のワーカーは `opus`、`model` が `opus` のワーカー（`answer-issue-questions`）は空文字（＝advisor なし）にしてある。
 
 ### exec-issue
 
@@ -562,26 +581,26 @@ claude-task-worker -v
 |---|---|---|---|
 | `fixReviewPointCallbackCommentMessage` | string | - | fix-review-point 完了時にPRへ投稿するコメント（未設定の場合は投稿しない） |
 | `uiDesign` | object | `{ "enabled": false, "designDir": "designs" }` | UIデザイン先行ワークフローの設定（詳細は「[UIデザイン先行ワークフロー](#uiデザイン先行ワークフロー)」） |
-| `workers` | object | `{}` | ワーカーごとに Claude CLI に渡すスキル、`--model` / `--effort`、ポーリング間隔、クールダウン時間、最大同時実行数を上書きする設定（詳細は下記） |
+| `workers` | object | `{}` | ワーカーごとに Claude CLI に渡すスキル、`--model` / `--advisor` / `--effort`、ポーリング間隔、クールダウン時間、最大同時実行数を上書きする設定（詳細は下記） |
 
 ### ワーカーごとの設定
 
-`workers` キーにワーカー名ごとの設定オブジェクトを指定することで、Claude CLI の `-p` に渡すスキル（スラッシュコマンド）、`--model` / `--effort`、ポーリング間隔、タスク完了後のクールダウン時間、最大同時実行数を個別に上書きできる。未指定のワーカー・フィールドは下記のワーカー別デフォルト値が使用される。
+`workers` キーにワーカー名ごとの設定オブジェクトを指定することで、Claude CLI の `-p` に渡すスキル（スラッシュコマンド）、`--model` / `--advisor` / `--effort`、ポーリング間隔、タスク完了後のクールダウン時間、最大同時実行数を個別に上書きできる。未指定のワーカー・フィールドは下記のワーカー別デフォルト値が使用される。
 
-| ワーカー名 | デフォルト `skill` | デフォルト `model` | デフォルト `effort` | デフォルト `pollingIntervalSeconds` | デフォルト `cooldownSeconds` | デフォルト `maxConcurrentTasks` |
-|---|---|---|---|---|---|---|
-| `answer-issue-questions` | `/claude-task-worker:answer-issue-questions` | `opus` | `xhigh` | 60 | 0 | 1 |
-| `create-issue` | `/claude-task-worker:create-issue-from-issue-number` | `sonnet` | `xhigh` | 60 | 0 | 1 |
-| `update-issue` | `/claude-task-worker:update-issue` | `sonnet` | `high` | 60 | 0 | 1 |
-| `exec-issue` | `/claude-task-worker:exec-issue` | `sonnet` | `high` | 60 | 0 | 1 |
-| `fix-review-point` | `/claude-task-worker:fix-review-point` | `sonnet` | `high` | 60 | 0 | 1 |
-| `triage-created-issue` | `/claude-task-worker:triage-created-issue` | `sonnet` | `high` | 60 | 0 | 1 |
-| `triage-pr` | `/claude-task-worker:triage-pr` | `sonnet` | `high` | 60 | 0 | 1 |
-| `resolve-conflict` | `/claude-task-worker:resolve-pr-conflict` | `sonnet` | `high` | 60 | 0 | 1 |
-| `check-dependabot` | `/claude-task-worker:check-dependabot` | `sonnet` | `high` | 3600 | 0 | 1 |
-| `epic-issue` | `/claude-task-worker:create-epic-pr` | `sonnet` | `high` | 300 | 0 | 1 |
-| `create-ui-design` | `/claude-task-worker:create-ui-design` | `sonnet` | `high` | 60 | 0 | 1 |
-| `apply-ui-design` | `/claude-task-worker:apply-ui-design` | `sonnet` | `high` | 60 | 0 | 1 |
+| ワーカー名 | デフォルト `skill` | デフォルト `model` | デフォルト `advisorModel` | デフォルト `effort` | デフォルト `pollingIntervalSeconds` | デフォルト `cooldownSeconds` | デフォルト `maxConcurrentTasks` |
+|---|---|---|---|---|---|---|---|
+| `answer-issue-questions` | `/claude-task-worker:answer-issue-questions` | `opus` | (なし) | `xhigh` | 60 | 0 | 1 |
+| `create-issue` | `/claude-task-worker:create-issue-from-issue-number` | `sonnet` | `opus` | `xhigh` | 60 | 0 | 1 |
+| `update-issue` | `/claude-task-worker:update-issue` | `sonnet` | `opus` | `high` | 60 | 0 | 1 |
+| `exec-issue` | `/claude-task-worker:exec-issue` | `sonnet` | `opus` | `high` | 60 | 0 | 1 |
+| `fix-review-point` | `/claude-task-worker:fix-review-point` | `sonnet` | `opus` | `high` | 60 | 0 | 1 |
+| `triage-created-issue` | `/claude-task-worker:triage-created-issue` | `sonnet` | `opus` | `high` | 60 | 0 | 1 |
+| `triage-pr` | `/claude-task-worker:triage-pr` | `sonnet` | `opus` | `high` | 60 | 0 | 1 |
+| `resolve-conflict` | `/claude-task-worker:resolve-pr-conflict` | `sonnet` | `opus` | `high` | 60 | 0 | 1 |
+| `check-dependabot` | `/claude-task-worker:check-dependabot` | `sonnet` | `opus` | `high` | 3600 | 0 | 1 |
+| `epic-issue` | `/claude-task-worker:create-epic-pr` | `sonnet` | `opus` | `high` | 300 | 0 | 1 |
+| `create-ui-design` | `/claude-task-worker:create-ui-design` | `sonnet` | `opus` | `high` | 60 | 0 | 1 |
+| `apply-ui-design` | `/claude-task-worker:apply-ui-design` | `sonnet` | `opus` | `high` | 60 | 0 | 1 |
 
 各フィールドの値:
 
@@ -589,6 +608,7 @@ claude-task-worker -v
 |---|---|---|
 | `skill` | string | Claude CLI の `-p` に渡すスラッシュコマンド（例: `/claude-task-worker:exec-issue`, `/my-plugin:my-skill`）。ワーカーは `"<skill> <issue-or-pr-number>"` の形で Claude を起動する |
 | `model` | string | Claude CLI の `--model` に渡す値（例: `sonnet`, `opus`, `haiku`） |
+| `advisorModel` | string | Claude CLI の `--advisor` に渡す値（例: `opus`）。空文字を指定するとそのワーカーでは advisor を使わない。`config.json` の `advisor` が `true` のときだけ参照される（詳細は「[`advisor`（アドバイザーモデル）](#advisorアドバイザーモデル)」） |
 | `effort` | string | Claude CLI の `--effort` に渡す値（例: `high`, `medium`, `low`） |
 | `pollingIntervalSeconds` | number | GitHub をポーリングする間隔（秒）。正の数を指定する |
 | `cooldownSeconds` | number | タスク完了後に次のポーリングを停止する時間（秒）。`0` でクールダウンなし |
@@ -599,8 +619,8 @@ claude-task-worker -v
 ```json
 {
   "workers": {
-    "exec-issue":        { "skill": "/my-plugin:exec-issue", "model": "opus", "effort": "high", "pollingIntervalSeconds": 60, "cooldownSeconds": 600, "maxConcurrentTasks": 3 },
-    "fix-review-point":  { "skill": "/claude-task-worker:fix-review-point", "model": "sonnet", "effort": "high", "maxConcurrentTasks": 2 },
+    "exec-issue":        { "skill": "/my-plugin:exec-issue", "model": "opus", "advisorModel": "", "effort": "high", "pollingIntervalSeconds": 60, "cooldownSeconds": 600, "maxConcurrentTasks": 3 },
+    "fix-review-point":  { "skill": "/claude-task-worker:fix-review-point", "model": "sonnet", "advisorModel": "opus", "effort": "high", "maxConcurrentTasks": 2 },
     "triage-pr":         { "effort": "medium", "pollingIntervalSeconds": 120 },
     "check-dependabot":  { "model": "haiku", "pollingIntervalSeconds": 7200 }
   }

--- a/src/claude-args.test.ts
+++ b/src/claude-args.test.ts
@@ -128,6 +128,22 @@ test("buildClaudeArgs passes the system prompt via a file so no arg carries a ne
   }
 });
 
+test("buildClaudeArgs omits --advisor unless an advisor model is given", () => {
+  for (const advisorModel of [undefined, "", "   "]) {
+    const args = buildClaudeArgs({ mode: "default", prompt: "/skill 1", model: "opus", effort: "high", advisorModel });
+    assert.ok(!args.includes("--advisor"), `--advisor must be omitted for ${JSON.stringify(advisorModel)}`);
+  }
+});
+
+test("buildClaudeArgs passes --advisor with the model in both modes", () => {
+  for (const mode of ["default", "herdr"] as const) {
+    const args = buildClaudeArgs({ mode, prompt: "/skill 1", model: "sonnet", effort: "high", advisorModel: "opus" });
+    assert.equal(args[args.indexOf("--advisor") + 1], "opus");
+    // 値なしの --advisor は後続フラグを値として食うため、必ず末尾に値が続くこと。
+    assert.ok(args.indexOf("--advisor") < args.length - 1);
+  }
+});
+
 test("buildClaudeEnv drops the print-only ceiling in herdr mode", () => {
   assert.deepEqual(buildClaudeEnv("default"), { ...CLAUDE_SPAWN_ENV });
   assert.deepEqual(buildClaudeEnv("herdr"), {

--- a/src/claude-args.ts
+++ b/src/claude-args.ts
@@ -104,6 +104,10 @@ export interface ClaudeInvocation {
   prompt: string;
   model: string;
   effort: string;
+  // `--advisor` に渡すモデル。空文字・未指定ならフラグ自体を渡さない。
+  // config.json の `advisor` が false のときは呼び出し側が空文字を渡す
+  // （ワーカー側でゲートする。`buildClaudeArgs` は渡された値をそのまま反映するだけ）。
+  advisorModel?: string;
 }
 
 export const CLAUDE_COMMAND = "claude";
@@ -140,7 +144,8 @@ export function systemPromptFilePath(): string {
 // ツール制限・システムプロンプト・モデル指定は両モードで共通にする。
 // システムプロンプトはファイル経由（`--append-system-prompt-file`）で渡す（理由は
 // `systemPromptFilePath()` を参照）。
-export function buildClaudeArgs({ mode, prompt, model, effort }: ClaudeInvocation): string[] {
+export function buildClaudeArgs({ mode, prompt, model, effort, advisorModel }: ClaudeInvocation): string[] {
+  const advisor = advisorModel?.trim() ?? "";
   return [
     ...(mode === "herdr" ? [] : ["-p"]),
     prompt,
@@ -154,6 +159,9 @@ export function buildClaudeArgs({ mode, prompt, model, effort }: ClaudeInvocatio
     model,
     "--effort",
     effort,
+    // advisor 未指定（空文字）ならフラグごと省く。値なしの `--advisor` を渡すと
+    // 後続フラグを値として食われるため、必ずモデル名とセットでのみ付ける。
+    ...(advisor === "" ? [] : ["--advisor", advisor]),
   ];
 }
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,7 +2,8 @@ import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import type * as ConfigModule from "./config";
 
-const { parseUiDesignEntry, DEFAULT_UI_DESIGN_CONFIG } = (await import("./config")) as typeof ConfigModule;
+const { parseUiDesignEntry, parseWorkerEntry, DEFAULT_UI_DESIGN_CONFIG, DEFAULT_WORKER_CONFIG, WORKER_DEFAULTS } =
+  (await import("./config")) as typeof ConfigModule;
 
 // 不正値は console.warn を出して既定値へ倒す仕様なので、テスト出力を汚さないよう黙らせる。
 function silenceWarn(t: TestContext): void {
@@ -61,4 +62,34 @@ test("parseUiDesignEntry warns once per invalid key", (t) => {
   const warn = t.mock.method(console, "warn", () => {});
   parseUiDesignEntry({ enabled: 1, designDir: 2 });
   assert.equal(warn.mock.callCount(), 2);
+});
+
+test("advisorModel defaults to opus for sonnet workers and to none for opus workers", () => {
+  // claude 側の制約: advisor は main モデル以上の能力が必要。opus のワーカーに
+  // opus advisor を付けても意味がないため既定は空文字（＝渡さない）。
+  assert.equal(DEFAULT_WORKER_CONFIG.model, "sonnet");
+  assert.equal(DEFAULT_WORKER_CONFIG.advisorModel, "opus");
+  for (const [name, config] of Object.entries(WORKER_DEFAULTS)) {
+    const expected = config.model === "opus" ? "" : "opus";
+    assert.equal(config.advisorModel, expected, `WORKER_DEFAULTS.${name}.advisorModel`);
+  }
+});
+
+test("parseWorkerEntry keeps the worker default advisorModel when unspecified", (t) => {
+  silenceWarn(t);
+  assert.equal(parseWorkerEntry("exec-issue", {})?.advisorModel, "opus");
+  assert.equal(parseWorkerEntry("answer-issue-questions", {})?.advisorModel, "");
+});
+
+test("parseWorkerEntry accepts an empty advisorModel as an explicit opt-out", (t) => {
+  silenceWarn(t);
+  // 他フィールドと違い空文字は不正値ではなく「advisor を使わない」の明示指定。
+  assert.equal(parseWorkerEntry("exec-issue", { advisorModel: "" })?.advisorModel, "");
+  assert.equal(parseWorkerEntry("exec-issue", { advisorModel: "fable" })?.advisorModel, "fable");
+});
+
+test("parseWorkerEntry falls back to the default for a non-string advisorModel", (t) => {
+  silenceWarn(t);
+  assert.equal(parseWorkerEntry("exec-issue", { advisorModel: 1 })?.advisorModel, "opus");
+  assert.equal(parseWorkerEntry("exec-issue", { advisorModel: null })?.advisorModel, "opus");
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,11 @@ export type WorkerName =
 export interface WorkerRuntimeConfig {
   skill: string;
   model: string;
+  // claude CLI の `--advisor <model>` に渡すモデル。空文字は「advisor を使わない」を意味する
+  // （config.json の `advisor: true` でも `--advisor` を渡さない）。claude 側の制約で
+  // advisor は main モデル以上の能力が必要なため、既定は model が sonnet のワーカーは
+  // "opus"、model が opus のワーカーは ""（＝無効）にしてある。
+  advisorModel: string;
   effort: string;
   pollingIntervalSeconds: number;
   cooldownSeconds: number;
@@ -45,6 +50,7 @@ export const DEFAULT_UI_DESIGN_CONFIG: UiDesignConfig = {
 export const DEFAULT_WORKER_CONFIG: WorkerRuntimeConfig = {
   skill: "",
   model: "sonnet",
+  advisorModel: "opus",
   effort: "high",
   pollingIntervalSeconds: 60,
   cooldownSeconds: 0,
@@ -55,6 +61,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "answer-issue-questions": {
     skill: "/claude-task-worker:answer-issue-questions",
     model: "opus",
+    advisorModel: "",
     effort: "xhigh",
     pollingIntervalSeconds: 60,
     cooldownSeconds: 0,
@@ -63,6 +70,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "create-issue": {
     skill: "/claude-task-worker:create-issue-from-issue-number",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "xhigh",
     pollingIntervalSeconds: 60,
     cooldownSeconds: 0,
@@ -71,6 +79,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "update-issue": {
     skill: "/claude-task-worker:update-issue",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 60,
     cooldownSeconds: 0,
@@ -79,6 +88,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "exec-issue": {
     skill: "/claude-task-worker:exec-issue",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 60,
     cooldownSeconds: 0,
@@ -87,6 +97,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "fix-review-point": {
     skill: "/claude-task-worker:fix-review-point",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 60,
     cooldownSeconds: 0,
@@ -95,6 +106,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "triage-created-issue": {
     skill: "/claude-task-worker:triage-created-issue",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 60,
     cooldownSeconds: 0,
@@ -103,6 +115,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "triage-pr": {
     skill: "/claude-task-worker:triage-pr",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 60,
     cooldownSeconds: 0,
@@ -111,6 +124,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "resolve-conflict": {
     skill: "/claude-task-worker:resolve-pr-conflict",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 60,
     cooldownSeconds: 0,
@@ -119,6 +133,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "check-dependabot": {
     skill: "/claude-task-worker:check-dependabot",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 3600,
     cooldownSeconds: 0,
@@ -127,6 +142,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "epic-issue": {
     skill: "/claude-task-worker:create-epic-pr",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 300,
     cooldownSeconds: 0,
@@ -135,6 +151,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "create-ui-design": {
     skill: "/claude-task-worker:create-ui-design",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 60,
     cooldownSeconds: 0,
@@ -143,6 +160,7 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
   "apply-ui-design": {
     skill: "/claude-task-worker:apply-ui-design",
     model: "sonnet",
+    advisorModel: "opus",
     effort: "high",
     pollingIntervalSeconds: 300,
     cooldownSeconds: 0,
@@ -162,7 +180,8 @@ function defaultsFor(name: string): WorkerRuntimeConfig {
   return WORKER_DEFAULTS[name] ?? DEFAULT_WORKER_CONFIG;
 }
 
-function parseWorkerEntry(name: string, val: unknown): WorkerRuntimeConfig | null {
+// parseUiDesignEntry と同じくテスト可能にするため export する（純粋関数）。
+export function parseWorkerEntry(name: string, val: unknown): WorkerRuntimeConfig | null {
   const base = defaultsFor(name);
   if (typeof val !== "object" || val === null || Array.isArray(val)) {
     console.warn(`[config] invalid workers.${name}: expected object, using defaults`);
@@ -182,6 +201,16 @@ function parseWorkerEntry(name: string, val: unknown): WorkerRuntimeConfig | nul
       result.model = entry.model;
     } else {
       console.warn(`[config] invalid workers.${name}.model: ${String(entry.model)}, using default ${base.model}`);
+    }
+  }
+  // 他のフィールドと違い空文字を有効値として受け付ける（「advisor を使わない」の明示指定）。
+  if ("advisorModel" in entry) {
+    if (typeof entry.advisorModel === "string") {
+      result.advisorModel = entry.advisorModel;
+    } else {
+      console.warn(
+        `[config] invalid workers.${name}.advisorModel: ${String(entry.advisorModel)}, using default ${JSON.stringify(base.advisorModel)}`,
+      );
     }
   }
   if ("effort" in entry) {

--- a/src/user-config.test.ts
+++ b/src/user-config.test.ts
@@ -18,6 +18,8 @@ const {
   getUserConfigPath,
   getRunMode,
   resetRunModeCache,
+  isAdvisorEnabled,
+  resetAdvisorCache,
   findProjectNameByPath,
 } = (await import("./user-config")) as typeof UserConfigModule;
 
@@ -82,6 +84,7 @@ test("loadUserConfig loads a valid config.json normally", () => {
 test("resolveTargetProjects throws UserConfigError for constructor/toString requests", () => {
   const config = {
     mode: "default" as const,
+    advisor: false,
     projects: { alpha: "/tmp/alpha" },
     projectGroups: { mygroup: ["alpha"] },
   };
@@ -93,6 +96,7 @@ test("resolveTargetProjects throws UserConfigError for constructor/toString requ
 test("resolveTargetProjects resolves known projects and groups normally", () => {
   const config = {
     mode: "default" as const,
+    advisor: false,
     projects: { alpha: "/tmp/alpha", beta: "/tmp/beta" },
     projectGroups: { mygroup: ["alpha", "beta"] },
   };
@@ -138,6 +142,7 @@ test("loadUserConfig throws UserConfigError when projects contains a __proto__ k
 test("resolveTargetProjects throws UserConfigError when resolution yields no projects", () => {
   const config = {
     mode: "default" as const,
+    advisor: false,
     projects: {},
     projectGroups: { empty: [] },
   };
@@ -147,6 +152,7 @@ test("resolveTargetProjects throws UserConfigError when resolution yields no pro
 function removeConfigFile(): void {
   rmSync(getUserConfigPath(), { force: true });
   resetRunModeCache();
+  resetAdvisorCache();
 }
 
 test("loadUserConfig defaults mode to default when it is not specified", () => {
@@ -198,6 +204,48 @@ test("getRunMode caches the mode resolved on first call", () => {
   assert.equal(getRunMode(), "herdr");
   resetRunModeCache();
   assert.equal(getRunMode(), "default");
+});
+
+test("loadUserConfig defaults advisor to false when it is not specified", () => {
+  removeConfigFile();
+  writeConfigFile(JSON.stringify({ projects: { alpha: process.cwd() } }));
+  assert.equal(loadUserConfig().advisor, false);
+});
+
+test("loadUserConfig reads advisor true", () => {
+  removeConfigFile();
+  writeConfigFile(JSON.stringify({ advisor: true, projects: { alpha: process.cwd() } }));
+  assert.equal(loadUserConfig().advisor, true);
+});
+
+test("loadUserConfig falls back to disabled for a non-boolean advisor", (t) => {
+  t.mock.method(console, "warn", () => {});
+  removeConfigFile();
+  // "true" のような文字列を有効扱いすると、意図せず全ワーカーに --advisor が付く。
+  writeConfigFile(JSON.stringify({ advisor: "true", projects: { alpha: process.cwd() } }));
+  assert.equal(loadUserConfig().advisor, false);
+});
+
+test("isAdvisorEnabled returns false when no config file exists", () => {
+  removeConfigFile();
+  assert.equal(isAdvisorEnabled(), false);
+});
+
+test("isAdvisorEnabled does not fail when the projects section is broken", () => {
+  removeConfigFile();
+  writeConfigFile(JSON.stringify({ advisor: true, projects: [] }));
+  assert.equal(isAdvisorEnabled(), true);
+});
+
+test("isAdvisorEnabled caches the value resolved on first call", () => {
+  removeConfigFile();
+  writeConfigFile(JSON.stringify({ advisor: true, projects: {} }));
+  assert.equal(isAdvisorEnabled(), true);
+  // 実行中に設定ファイルが書き換わっても、同一プロセス内では最初の解決結果を保つ。
+  writeConfigFile(JSON.stringify({ advisor: false, projects: {} }));
+  assert.equal(isAdvisorEnabled(), true);
+  resetAdvisorCache();
+  assert.equal(isAdvisorEnabled(), false);
 });
 
 test("findProjectNameByPath resolves a project name from its path", () => {

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -10,8 +10,14 @@ export type RunMode = "default" | "herdr";
 
 export const DEFAULT_RUN_MODE: RunMode = "default";
 
+// advisor（claude CLI の `--advisor <model>`）を有効にするか。有効時のみ、
+// claude-task-worker.json の workers.<name>.advisorModel を `--advisor` に渡す。
+// 未指定・不正値は「渡さない」側（false）へ倒す。
+export const DEFAULT_ADVISOR_ENABLED = false;
+
 export interface UserConfig {
   mode: RunMode;
+  advisor: boolean;
   projects: Record<string, string>;
   projectGroups: Record<string, string[]>;
 }
@@ -80,6 +86,14 @@ function parseMode(raw: Record<string, unknown>, path: string): RunMode {
   return DEFAULT_RUN_MODE;
 }
 
+function parseAdvisor(raw: Record<string, unknown>, path: string): boolean {
+  if (!("advisor" in raw)) return DEFAULT_ADVISOR_ENABLED;
+  const value = raw["advisor"];
+  if (typeof value === "boolean") return value;
+  console.warn(`[config] invalid advisor: ${JSON.stringify(value)} in ${path}, using ${DEFAULT_ADVISOR_ENABLED}`);
+  return DEFAULT_ADVISOR_ENABLED;
+}
+
 export function loadUserConfig(): UserConfig {
   const path = getUserConfigPath();
   const raw = readRawConfig();
@@ -108,6 +122,7 @@ export function loadUserConfig(): UserConfig {
   }
 
   const mode = parseMode(raw, path);
+  const advisor = parseAdvisor(raw, path);
   const rawProjects = raw["projects"] as Record<string, unknown>;
   const rawProjectGroups = ("projectGroups" in raw ? raw["projectGroups"] : {}) as Record<string, unknown>;
 
@@ -164,7 +179,7 @@ export function loadUserConfig(): UserConfig {
     projectGroups[groupName] = members;
   }
 
-  return { mode, projects, projectGroups };
+  return { mode, advisor, projects, projectGroups };
 }
 
 // mode はプロセス起動時に確定させる。実行中に設定ファイルが書き換わっても、
@@ -182,6 +197,39 @@ export function getRunMode(): RunMode {
 // テスト用。設定ファイルを差し替えて再解決させる。
 export function resetRunModeCache(): void {
   cachedRunMode = undefined;
+}
+
+// advisor も mode と同じくプロセス起動時に確定させる。実行中に設定ファイルが
+// 書き換わっても、同一ワーカーのタスク間で `--advisor` の有無が揺れないようにする。
+let cachedAdvisorEnabled: boolean | undefined;
+
+export function isAdvisorEnabled(): boolean {
+  if (cachedAdvisorEnabled === undefined) {
+    cachedAdvisorEnabled = readAdvisorEnabled();
+  }
+  return cachedAdvisorEnabled;
+}
+
+// テスト用。設定ファイルを差し替えて再解決させる。
+export function resetAdvisorCache(): void {
+  cachedAdvisorEnabled = undefined;
+}
+
+// getRunMode と同様、ワーカーは `--project` 無しでも起動されるため、設定ファイル不在・
+// projects セクション破損で advisor の判定を失敗させない。判定できない場合は既定（無効）。
+function readAdvisorEnabled(): boolean {
+  let raw: Record<string, unknown> | undefined;
+  try {
+    raw = readRawConfig();
+  } catch (err) {
+    console.warn(`[config] failed to read config file, advisor disabled: ${err}`);
+    return DEFAULT_ADVISOR_ENABLED;
+  }
+  if (raw === undefined) return DEFAULT_ADVISOR_ENABLED;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return DEFAULT_ADVISOR_ENABLED;
+  }
+  return parseAdvisor(raw, getUserConfigPath());
 }
 
 // ワーカーは `--project` 無しでも起動されるため、設定ファイルが無い・projects セクションが

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -6,7 +6,7 @@ import { syncDefaultBranch, ensureEpicBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isShuttingDown, run } from "../process-manager";
 import { generateWorktreeName } from "../random-name";
 import { notifyTaskCompleted, notifyTaskFailed, notifyError } from "../slack";
-import { getRunMode } from "../user-config";
+import { getRunMode, isAdvisorEnabled } from "../user-config";
 import { removeWorktree, createWorktreeFromBranch, getWorktreePath } from "../worktree";
 
 const LABEL_TRIAGE_SCOPE = "cc-triage-scope";
@@ -87,7 +87,7 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
           try {
             const issueUrl = `https://github.com/${owner}/${name}/issues/${issue.number}`;
             syncDefaultBranch(defaultBranch);
-            const { model, effort, skill } = getWorkerConfig(config.name);
+            const { model, effort, skill, advisorModel } = getWorkerConfig(config.name);
             const command = skill || config.command;
 
             const parentNumber = issue.parent?.number;
@@ -97,6 +97,8 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
               prompt: `${command} ${issue.number}`,
               model,
               effort,
+              // config.json の advisor が false なら advisorModel の指定に関わらず渡さない。
+              advisorModel: isAdvisorEnabled() ? advisorModel : "",
             });
 
             // claude CLI の --worktree は locked な worktree を作り、異常終了時に

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -12,7 +12,7 @@ import { syncDefaultBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isShuttingDown, run } from "../process-manager";
 import { generateWorktreeName } from "../random-name";
 import { notifyTaskCompleted, notifyTaskFailed, notifyError } from "../slack";
-import { getRunMode } from "../user-config";
+import { getRunMode, isAdvisorEnabled } from "../user-config";
 import {
   createWorktreeFromBranch,
   deleteLocalBranch,
@@ -86,7 +86,7 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
             // 削除不能な残骸を残すため使わない。ワーカー自身が worktree を生成して cwd として渡す。
             await createWorktreeFromBranch(worktreeId, defaultBranch);
             const cwd = getWorktreePath(worktreeId);
-            const { model, effort, skill } = getWorkerConfig(config.name);
+            const { model, effort, skill, advisorModel } = getWorkerConfig(config.name);
             const command = skill || config.command;
             const mode = getRunMode();
             const execution = buildClaudeExecution({
@@ -94,6 +94,8 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
               prompt: `${command} ${pr.number}`,
               model,
               effort,
+              // config.json の advisor が false なら advisorModel の指定に関わらず渡さない。
+              advisorModel: isAdvisorEnabled() ? advisorModel : "",
             });
             run(
               execution.command,


### PR DESCRIPTION
## 概要

タスク実行時に claude CLI の `--advisor <model>` を渡せるようにした。

- `config.json`（`~/.config/claude-task-worker/config.json`）にトップレベル `advisor`（boolean、既定 `false`）を追加
- `claude-task-worker.json` の `workers.<name>` に `advisorModel` を追加
- `advisor: true` のときだけ、各ワーカーの `advisorModel` を `--advisor` に渡す
- `advisorModel` が空文字ならフラグごと渡さない（未指定時はワーカー既定値へ解決される）

## デフォルト値

claude 側の制約（advisor は main モデル以上の能力が必要）に合わせている。

| model | デフォルト advisorModel |
|---|---|
| `sonnet`（`answer-issue-questions` 以外の全ワーカー） | `opus` |
| `opus`（`answer-issue-questions`） | `""`（advisor なし） |

## 実装

### ゲート2段

1. `advisor: false`（既定）なら `advisorModel` の指定に関わらず渡さない。判定はワーカー側（`issue-worker.ts` / `pr-worker.ts`）で行い、無効時は `buildClaudeExecution()` へ空文字を渡す
2. `advisorModel` が空文字なら `buildClaudeArgs()` が `--advisor` ごと省く。**値なしの `--advisor` は後続フラグを値として食う**ため、必ずモデル名とセットでのみ付ける

### 主な変更

- `src/user-config.ts`: `UserConfig.advisor`、`parseAdvisor()`、`isAdvisorEnabled()`（`getRunMode()` と同じくプロセス内キャッシュ・設定ファイル不在/破損は既定＝無効へ倒す）、`resetAdvisorCache()`
- `src/config.ts`: `WorkerRuntimeConfig.advisorModel`、各ワーカーの既定値、`parseWorkerEntry()` を export（テスト可能な純粋関数）。**他フィールドと違い空文字を有効値として受け付ける**（「advisor を使わない」の明示指定）
- `src/claude-args.ts`: `ClaudeInvocation.advisorModel`、`buildClaudeArgs()` での `--advisor` 付与
- `src/workers/issue-worker.ts` / `src/workers/pr-worker.ts`: `isAdvisorEnabled()` によるゲート
- README.md / CLAUDE.md: `advisor` 節の追加、workers 表への `advisorModel` 列追加

## 補足

`--advisor` は `claude --help` に出ない隠しフラグだが、バイナリ内に `--advisor <model>` が実在することを確認済み（Claude Code 2.1.220）。

## テスト

`npm run build`（tsc --noEmit + esbuild）と `npm test` がパス（283件）。追加したテスト:

- `buildClaudeArgs` が undefined / 空文字 / 空白のみで `--advisor` を省くこと、モデル指定時に両モードで値とセットで付くこと
- `advisorModel` の既定値が model に応じて `opus` / `""` になること
- `parseWorkerEntry` が空文字を明示的なオプトアウトとして受け付け、非 string は既定へ倒すこと
- `loadUserConfig` / `isAdvisorEnabled` の既定値・真偽値パース・非 boolean のフォールバック・キャッシュ挙動

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 修正履歴

### 2026-07-25: レビュー指摘対応（1件）
- README.md の advisor 設定表で「未指定・空文字は渡さない」としていた記述を、実装の挙動（未指定時はワーカー既定値へ解決、空文字のみ渡さない）に一致させた（対応コミット: 15db981）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Claude CLIでアドバイザーモデルを利用できる設定を追加しました。
  - 全体設定で有効・無効を切り替え、ワーカーごとに使用モデルを指定できます。
  - 未指定または空のモデル名の場合は、アドバイザーを実行しません。

- **ドキュメント**
  - アドバイザー設定の項目、既定値、ワーカー別設定についてREADMEと設定ガイドを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
