### PR TITLE
chore: triage-pr の修正判断から create-review-fix-plan を外す

### DIFF
--- a/plugin/skills/create-review-fix-plan/SKILL.md
+++ b/plugin/skills/create-review-fix-plan/SKILL.md
@@ -31,6 +31,8 @@ GitHub PRの未解決レビューコメントとCI失敗を分析し、後続ス
 bash ${CLAUDE_SKILL_DIR}/scripts/fetch-unresolved-comments.sh
 ```
 
+> `scripts/fetch-unresolved-comments.sh` は `triage-pr` スキルからも `${CLAUDE_SKILL_DIR}/../create-review-fix-plan/scripts/fetch-unresolved-comments.sh` として参照される共有スクリプト。パス・ファイル名を変更する場合は `triage-pr` 側の参照も合わせて直すこと。
+
 返却されるJSONから2系統のフィードバックを抽出する。
 
 - **`unresolved_threads[]`**: コード行に紐づく未解決のインラインレビューコメント。各スレッドの `path` / `line` / `body` / `author` / `is_outdated` を保持する。`is_outdated: true` のスレッドは差分が変わっている可能性があるため、対応方針の判断時に注記する。

--- a/plugin/skills/triage-pr/SKILL.md
+++ b/plugin/skills/triage-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-pr
-description: Triage a single GitHub PR by PR number. Check out the PR's branch, detect conflicts with the target branch via `gh pr status` (and label the PR with `cc-resolve-conflict` if any are found), generate and evaluate a fix plan via create-review-fix-plan, then take action (add cc-fix-onetime label if fixes are needed; if release-ready, add cc-release-ready label for an Epic PR marked `cc-epic-issue` instead of merging, otherwise merge the PR).
+description: Triage a single GitHub PR by PR number. Check out the PR's branch, detect conflicts with the target branch via `gh pr status` (and label the PR with `cc-resolve-conflict` if any are found), collect unresolved review comments and CI status and judge only whether each item must be fixed, then take action (add cc-fix-onetime label if fixes are needed; if release-ready, add cc-release-ready label for an Epic PR marked `cc-epic-issue` instead of merging, otherwise merge the PR).
 argument-hint: "[pr-number]"
 hooks:
   Stop:
@@ -12,19 +12,19 @@ hooks:
 
 # Triage PR
 
-指定されたPR番号のPRに対して、コンフリクト検知から修正プランの評価、最終アクション（ラベル付与またはマージ）までを一貫して実行するスキルです。Instructionsに従って、PRの状態を確認し、適切なアクションを実行してください。
+指定されたPR番号のPRに対して、コンフリクト検知から修正要否の判定、最終アクション（ラベル付与またはマージ）までを一貫して実行するスキルです。Instructionsに従って、PRの状態を確認し、適切なアクションを実行してください。
 
 ## このスキルがやること・やらないこと
 
 **やること**:
 - ステップ1のコンフリクト検知（`gh pr status`で確認し、コンフリクトがあれば`cc-resolve-conflict`ラベル付与のみで終了）
-- ステップ2の修正プラン生成と評価（プランの分析・判定のみ）
+- ステップ2の未解決レビューコメント・CIステータスの収集と、各項目が「修正すべきか」の二分判定のみ
 - ステップ3のアクション: 修正が必要なら`cc-fix-onetime`ラベル付与 / マージ可能な場合は、Epic PR（`cc-epic-issue`付き）なら`cc-release-ready`ラベル付与（マージはしない）、通常PRならマージ
 
 **絶対にやらないこと**:
-- **PRのコード修正・実装**: 修正プランで「対応すべき」と判定された項目があっても、このスキル内では一切コードを変更しない。修正の実行は`cc-fix-onetime`ラベル付与後に別スキル（`fix-review-point`など）の責務
+- **PRのコード修正・実装**: 「対応すべき」と判定された項目があっても、このスキル内では一切コードを変更しない。修正の実行は`cc-fix-onetime`ラベル付与後に別スキル（`fix-review-point`など）の責務
 - **コンフリクト解消の直接実行**: rebase・コンフリクトファイルの編集・force-pushは行わない。検知したら`cc-resolve-conflict`ラベルを付けて終了し、実際の解消は同ラベルをトリガーに別スキル（`resolve-pr-conflict`等）が担当する
-- **`create-review-fix-plan`が返したプランの実行**: プランは判定材料として読むだけで、ファイルを変更してはならない
+- **修正プランの作成**: `create-review-fix-plan` スキルを呼び出してはならない。修正方針・タスク分解・影響範囲の見積もりは `cc-fix-onetime` を拾う `fix-review-point` 側の責務であり、ここで作ると同じ分析をPRごとに二重に行いトークンを無駄に消費する。本スキルは「修正すべきコメントが1件でもあるか」だけを判定する
 - **新規コミットの作成**: コミット・push・commit amendを行わない
 - **テスト追加・Lint修正・リファクタリング**: 評価対象であっても、実行せずラベル付与にとどめる
 
@@ -66,33 +66,84 @@ gh pr status
 gh pr view $ARGUMENTS --json mergeable -q .mergeable
 ```
 
-返却値 `MERGEABLE` / `CONFLICTING` / `UNKNOWN` のうち `CONFLICTING` のときコンフリクトありと判定する。`UNKNOWN` の場合はGitHub側で判定中のため、数秒のスリープ後に1回だけリトライし、それでも `UNKNOWN` ならコンフリクトなし扱いで先に進む。
+返却値 `MERGEABLE` / `CONFLICTING` / `UNKNOWN` のうち `CONFLICTING` のときコンフリクトありと判定する。`UNKNOWN` の場合はGitHub側で判定中のため、数秒のスリープ後に1回だけリトライする。
 
 判定に応じて分岐する。
 
-- **コンフリクトあり（`CONFLICTING`）**: `cc-resolve-conflict` ラベルを付与してこのスキルを終了する。ステップ2・ステップ3には進まない（コンフリクト解消前に修正プラン評価やマージを行っても意味がないため）
+- **マージ可能（`MERGEABLE`）**: ステップ2に進む
+- **コンフリクトあり（`CONFLICTING`）**: `cc-resolve-conflict` ラベルを付与してこのスキルを終了する。ステップ2・ステップ3には進まない（コンフリクト解消前に修正要否の判定やマージを行っても意味がないため）
 
   ```bash
   gh pr edit $ARGUMENTS --add-label "cc-resolve-conflict"
   ```
 
-- **コンフリクトなし（`MERGEABLE` または `UNKNOWN` のリトライ後も判定不能）**: ステップ2に進む
+- **判定不能（`UNKNOWN` のままリトライ後も継続する場合）**: マージ可能性が未確定のまま修正要否判定・マージへ進むのは危険なため、**後続のステップに進まず**、ラベル操作は一切行わずに「判定: エラー」で結果報告を行い終了する（ステップ0の`gh pr checkout`失敗時と同様の扱い）。自前のリトライはこの1回のみとし、それ以上は繰り返さない（ブロッカー解消後のポーリングで自動的に再実行される）
 
-### ステップ2: 修正プランの生成と評価（**判定のみ・実行禁止**）
+### ステップ2: 修正要否の判定（**判定のみ・実行禁止**）
 
-`create-review-fix-plan` skillを用いてPRの修正プランを生成する。
+**修正プラン（`create-review-fix-plan`）は生成しない。** 本スキルが必要とするのは「修正すべき項目が1件でもあるか」という真偽値だけであり、修正方針・タスク分解・依存関係・影響範囲の見積もりは `cc-fix-onetime` を拾った `fix-review-point` が改めて行う。ここでプランを作ると同じ分析（サブエージェントのfan-out探索とタスク定義の生成）をPRごとに二重に走らせることになるため、判定に必要な最小限の情報だけを集める。
 
-**重要**: プランは「PRをマージ可能か」を判定する材料に過ぎない。プランに含まれるタスクをこのスキル内で実装してはならない。対応すべき項目があると判断したら **コードに手を加えず** ステップ3のパターンA（ラベル付与）へ進むこと。判定は内部的な思考にとどめ、ファイルの編集・コマンドの実行は行わない（参照のための`Read`/`Grep`は許容）。
+**重要**: 判定は内部的な思考にとどめ、ファイルの編集・コミット・pushは行わない。対応すべき項目があると判断したら **コードに手を加えず** ステップ3のパターンA（ラベル付与）へ進むこと。裏取りのための`Read`/`Grep`/codegraph参照は許容するが、判定が変わらない範囲では省略する。
 
-修正プランの各項目を以下の評価基準で分析し、対応要否を判定する。
+#### 2-1. 判定材料の収集
+
+以下を **同一メッセージ内で並列に実行** する。
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../create-review-fix-plan/scripts/fetch-unresolved-comments.sh"
+```
+
+```bash
+CHECKS_JSON=$(gh pr checks $ARGUMENTS --json state,name,link,workflow 2>&1)
+CHECKS_EXIT=$?
+```
+
+```bash
+gh pr view $ARGUMENTS --json title,body,labels
+```
+
+- 1つ目のスクリプトは未解決のインラインレビューコメント（`unresolved_threads[]`）とConversationタブの一般コメント（`conversation_comments[]`）を返す。インラインだけを見ると行外の指摘を取りこぼすため両方を対象にする。カレントブランチのPRを対象とするため、ステップ0の `gh pr checkout` 済みであることが前提
+- `gh pr checks` は失敗チェックがあると終了コードが非0になるが、これは「失敗チェックが存在する」という正常系の結果であり、認証失敗・通信障害・不正なPR番号等の実行時エラーと区別する必要がある。区別は終了コードではなく **出力がJSONとしてパース可能かどうか** で行う。
+
+  ```bash
+  echo "$CHECKS_JSON" | jq -e . >/dev/null 2>&1
+  ```
+
+  パースに成功した場合のみ、その内容を「失敗チェックの有無」の判定材料として使う（`CHECKS_EXIT` が非0でもJSONとしてパースできていれば、それは失敗チェックの存在を表す正常系として扱う）。パースに失敗した場合（＝実行時エラーで `gh pr checks` 自体が意味のある出力を返せなかった場合）は、**後続のステップに進まず**、ラベル操作は一切行わずに出力内容をそのまま含めて「判定: エラー」で結果報告を行い終了する（「CI失敗なし」には倒さない。ステップ0の`gh pr checkout`失敗時と同様の扱い）
+  - `state` が `FAILURE` / `STARTUP_FAILURE` のチェックについてのみ、`link` から `run-id` を抽出して `gh run view <run-id> --log-failed` で失敗内容を確認する。**全Passなら追加のログ取得は行わない**
+- `gh pr view` の結果は「デザインPRか（`cc-ui-design`）」「Epic PRか（`cc-epic-issue`）」「`Refs #<N>` の有無」の確認に使う。ステップ3で同じ情報を再取得しないよう、ここで取得したラベル一覧を使い回す
+- デザインPR（`cc-ui-design`）と判定した場合のみ、差分ファイル一覧を追加で取得する（実装コードの混入・スナップショットの有無の確認用）
+
+  ```bash
+  gh pr diff $ARGUMENTS --name-only
+  ```
+
+#### 2-2. ノイズの除外
+
+会話コメントには対応不要なノイズが混ざるため、次を判定対象から除外する。
+
+- `is_minimized: true` のコメント（折りたたみ済み＝outdated/resolved/spam等として処理済み）
+- `/gemini review` のようなボット起動コマンドや、CIステータスの自動投稿
+- PR作成者自身の単なる進捗報告・補足など、対応を求めていないチャット
+
+判断に迷う場合は「このコメントは未対応の修正要求か？」を基準にする。
+
+#### 2-3. 各項目の二分判定
+
+残った各コメント・各CI失敗を、下記の評価基準に照らして **「対応すべき」／「対応不要」の二値** に振り分ける。修正方針・修正手順・対象ファイルの列挙は書かない（`fix-review-point` が行う）。
+
+**「対応すべき」が1件見つかった時点で残りの項目の精査を打ち切り、ステップ3のパターンAへ進んでよい**（以降の項目をいくら精査しても付与するラベルは変わらないため）。ただしデザインPRでCI失敗の切り分けが必要な場合（パターンC判定）は、その切り分けを終えてから分岐する。
+
+**ステップ3のパターンB（マージ可能）へ進めるのは、2-1で取得した全チェックが `SUCCESS` 等の明示的な成功状態であることを確認できた場合に限る。** `PENDING` や実行中など未完了のチェックが1件でも残っている場合は、CIが失敗しているわけではなくても「対応不要」の暗黙扱いにせず、パターンBへは進まない。
+
+未完了チェックが残っている場合の分岐は「対応すべき」項目の有無で決まる。
+
+- **「対応すべき」が1件以上ある場合**: CIの完了を待たずステップ3のパターンA（またはデザインPRならパターンC）へ進む。CI結果に関わらず修正は必要であり、待っても付与するラベルは変わらないため
+- **「対応すべき」が1件もない場合**: 判定を確定させず、ステップ3に進まずに「判定: 保留（CI未完了）」として結果報告のみ行い終了する（次回ポーリングで再評価させる。ラベル操作は行わない）
 
 #### デザインPR（`cc-ui-design` ラベル付き）の場合の評価基準
 
-対象PRに `cc-ui-design` ラベルが付いている場合、そのPRは `.pen`（Pencilデザインファイル）とスナップショットPNGのみを変更するデザインPRであり、コードレビューの観点（型安全性・テスト・Lint等）をそのまま適用しても意味がない。以下の観点に差し替えて評価する。
-
-```bash
-gh pr view $ARGUMENTS --json labels -q '.labels[].name'
-```
+2-1で取得したラベル一覧に `cc-ui-design` が含まれる場合、そのPRは `.pen`（Pencilデザインファイル）とスナップショットPNGのみを変更するデザインPRであり、コードレビューの観点（型安全性・テスト・Lint等）をそのまま適用しても意味がない。以下の観点に差し替えて評価する。
 
 - **差分が `.pen` とスナップショットPNGに限定されているか**（実装コードが混入していないか）。混入していれば「対応すべき」
 - **スナップショットが差分に含まれ、デザイン意図がPR bodyから読み取れるか**。スナップショットが無くレビューできない場合は「対応すべき」
@@ -144,15 +195,11 @@ gh pr edit $ARGUMENTS --add-label "cc-need-human-check"
 
 #### パターンB: マージ可能な場合
 
-すべての項目が「対応不要」、または修正プランに項目がない場合、マージ可能（リリース問題なし）と判定する。
+すべての項目が「対応不要」、または対象となるコメント・CI失敗が1件もない場合、マージ可能（リリース問題なし）と判定する。
 
-**まず対象PRが Epic PR（`cc-epic-issue` ラベル付き）かどうかを確認する。**
+**まず対象PRが Epic PR（`cc-epic-issue` ラベル付き）かどうかを、2-1で取得したラベル一覧で確認する**（再取得はしない）。
 
-```bash
-gh pr view $ARGUMENTS --json labels -q '.labels[].name'
-```
-
-- **Epic PR の場合（出力に `cc-epic-issue` を含む）**: このPRをマージするとデフォルトブランチへの集約反映（＝リリース）になるため、**このスキルではマージせず** `cc-release-ready` ラベルのみを付与して終了する。実際のリリース（マージ）は人間の判断に委ねるゲートとして扱う。以降のマージ手順・関連Issueクローズには進まない。
+- **Epic PR の場合（ラベル一覧に `cc-epic-issue` を含む）**: このPRをマージするとデフォルトブランチへの集約反映（＝リリース）になるため、**このスキルではマージせず** `cc-release-ready` ラベルのみを付与して終了する。実際のリリース（マージ）は人間の判断に委ねるゲートとして扱う。以降のマージ手順・関連Issueクローズには進まない。
 
   ```bash
   gh pr edit $ARGUMENTS --add-label "cc-release-ready"
@@ -237,5 +284,5 @@ gh issue close <issue番号> --reason "not planned"
 
 処理結果として以下を報告する：
 
-- **判定**: コンフリクト検知（`cc-resolve-conflict`ラベル付与） / パターンA（修正が必要・`cc-fix-onetime`ラベル付与） / パターンB-Epic（Epic PRのリリースゲート・`cc-release-ready`ラベル付与、マージせず終了） / パターンB-通常（マージ済み。非デフォルトブランチへのマージ時は連動Closeした関連Issue番号も明記） / PRクローズ（関連IssueもClose） / エラー
-- **理由**: 判定の根拠（コンフリクト検知時はターゲットブランチ名、対応すべき項目の要約、マージ可能と判断した理由、Epic PRで`cc-release-ready`を付与した旨、非デフォルトブランチへのマージで`--reason completed`により連動Closeした関連Issue番号、またはクローズ理由と連動Closeした関連Issue番号）
+- **判定**: コンフリクト検知（`cc-resolve-conflict`ラベル付与） / パターンA（修正が必要・`cc-fix-onetime`ラベル付与） / パターンB-Epic（Epic PRのリリースゲート・`cc-release-ready`ラベル付与、マージせず終了） / パターンB-通常（マージ済み。非デフォルトブランチへのマージ時は連動Closeした関連Issue番号も明記） / パターンC（デザインPRのCI失敗が解消不能・`cc-need-human-check`ラベル付与） / 保留（CI未完了・ラベル操作なし） / PRクローズ（関連IssueもClose） / エラー
+- **理由**: 判定の根拠（コンフリクト検知時はターゲットブランチ名、対応すべき項目の要約、マージ可能と判断した理由、Epic PRで`cc-release-ready`を付与した旨、非デフォルトブランチへのマージで`--reason completed`により連動Closeした関連Issue番号、CI未完了で保留した場合は未完了チェック名、エラー時は`gh pr view`のmergeable判定不能または`gh pr checks`出力のパース失敗など発生箇所、またはクローズ理由と連動Closeした関連Issue番号）


### PR DESCRIPTION
## 概要

`triage-pr` スキルの修正判断（ステップ2）から `create-review-fix-plan` の呼び出しを外し、スキル内の軽量な二値判定に差し替えてトークン消費を削減する。

`triage-pr` が必要とするのは「修正すべき項目が1件でもあるか」の真偽値だけだが、`create-review-fix-plan` は `context: fork` の別セッションで `explore-agent` を並列 fan-out させ、修正方針・タスク分解・依存関係まで生成する。それらは `cc-fix-onetime` を拾った `fix-review-point` が改めて行うため、同じ分析を PR ごとに二重に走らせていた。

## 変更内容

### `plugin/skills/triage-pr/SKILL.md`

ステップ2を以下に差し替え。

- **2-1 判定材料の収集**: `fetch-unresolved-comments.sh`（未解決インラインコメント + Conversation コメント）／`gh pr checks --json state,name,link,workflow`／`gh pr view --json title,body,labels` を並列取得。CI失敗ログ（`gh run view --log-failed`）は `FAILURE` / `STARTUP_FAILURE` のときだけ、`gh pr diff --name-only` はデザインPR（`cc-ui-design`）のときだけ取得する
- **2-2 ノイズの除外**: `is_minimized` / ボット起動コマンド / CI自動投稿 / 作者の進捗報告
- **2-3 各項目の二分判定**: 「対応すべき」／「対応不要」の二値のみに振り分け、修正方針・修正手順・対象ファイルの列挙は書かない。**「対応すべき」1件目で残りの精査を打ち切りパターンAへ進んでよい**（付与するラベルは変わらないため）。ただしデザインPRのCI失敗切り分け（パターンC判定）は完了させてから分岐する
- 「やらないこと」に **`create-review-fix-plan` を呼び出さない** を明示追加
- 2-1 で取得したラベル一覧を使い回し、ステップ2（デザインPR判定）・ステップ3パターンB（Epic PR判定）にあった `gh pr view --json labels` の再取得2箇所を削除
- 評価基準（デザインPR観点／対応すべき／対応不要の可能性あり）と意思決定の原則はそのまま維持

あわせて、判定を確定できない状態でステップ3（ラベル付与・マージ）へ進まないための安全化を実施（詳細は「修正履歴」参照）。

- ステップ1のマージ可能性判定を `MERGEABLE` / `CONFLICTING` / `UNKNOWN` の3分岐に整理
- ステップ2-1 の `gh pr checks` で、実行時エラーと「失敗チェックによる非0終了」をJSONパース可否で区別
- ステップ2-3 に、全チェックが明示的な成功状態のときだけパターンB（マージ）へ進める旨を明記

### `plugin/skills/create-review-fix-plan/SKILL.md`

- `scripts/fetch-unresolved-comments.sh` が `triage-pr` からも参照される共有スクリプトになったため、パス変更時に `triage-pr` 側も直す旨の注意書きを追加

### `src/config.test.ts`

本PRの変更に起因しない既存のテスト破損の修正（デフォルトブランチでも同様に失敗していた）。過去のコミット `83d007a` が `exec-issue` の `model` を `sonnet` → `opus` へ変更した結果、advisorModel の既定値ロジック（`model === "opus" ? "" : "opus"`）により `exec-issue` の既定 advisorModel が `""` になったが、2つのテストの固定期待値だけが `"opus"` のまま取り残されていた。テストの検証意図（sonnet tier ワーカーの既定 advisorModel が `"opus"` であること）を保つため、対象ワーカーを sonnet tier の `update-issue` へ差し替えた。

## テスト観点

- `npm test`: 283件すべてパス（修正前は `parseWorkerEntry` 系2件が失敗）
- `npm run build`（`tsc --noEmit` 含む）: 成功
- `npm run lint` / `prettier --check`: エラーなし
- スキル本文（Markdown）の変更はユニットテスト対象外のため、記述の一貫性（エラー終了パスでラベル操作を行わないこと・報告フォーマットとの整合）を目視で確認

## 影響範囲

- `create-review-fix-plan` スキル自体は `fix-review-point` が引き続き使うため残置（動作変更なし）
- `triage-pr` のラベルフロー（`cc-resolve-conflict` / `cc-fix-onetime` / `cc-need-human-check` / `cc-release-ready` / マージ）自体は変更なし。ただし判定不能・CI未完了のケースで**ラベルを付けずに終了する**経路が新設された（次回ポーリングで再評価される）
- TypeScript 側の変更はテストのみ（プロダクションコードの変更なし）

## 修正履歴

### 2026-07-25: レビュー指摘対応（3件）

- **`UNKNOWN`（マージ可能性判定不能）をコンフリクトなし扱いにしていた問題**: リトライ後も `UNKNOWN` のままなら、マージ可能性が未確定のまま修正要否判定・マージへ進むのは危険なため、ステップ1を `MERGEABLE` / `CONFLICTING` / `UNKNOWN` の3分岐に変更。`UNKNOWN` はラベル操作を一切行わず「判定: エラー」で報告して終了する（対応コミット: `780ba52`）
- **`gh pr checks ... || true` が実行時エラーを握りつぶしていた問題**: 認証失敗・通信障害・不正なPR番号等でコマンド自体が失敗しても「CI失敗なし」と誤判定してマージへ進む恐れがあったため、出力を変数に受けて `jq -e .` でJSONパース可否を検証する手順へ変更。パース成功時のみ「失敗チェックの存在」を表す正常系として扱い、パース不能時はラベル操作なしでエラー終了する（対応コミット: `780ba52`）
- **`PENDING` 等の未完了CIチェックを暗黙に「失敗なし」扱いしていた問題**: チェック完了前にマージへ進むリスクがあったため、パターンB（マージ可能）へ進めるのは全チェックが `SUCCESS` 等の明示的な成功状態を確認できた場合に限る旨をステップ2-3に明記。未完了チェックが残る場合は、「対応すべき」項目があればパターンA（`cc-fix-onetime` 付与）へ進み、なければラベル操作なしで「判定: 保留（CI未完了）」として終了し次回ポーリングで再評価させる（対応コミット: `780ba52`）

あわせて、本PRとは無関係にデフォルトブランチでも失敗していたCI（`build` ジョブ / `src/config.test.ts` の advisorModel 既定値テスト2件）を修正し、CIをグリーンにした（対応コミット: `38fa9d4`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - トリアージ手順を更新し、未解決レビューコメントとCIステータスから「修正要否」を二分判定する流れに整理しました。
  - デザインPRの評価基準（デザイン/スナップショット観点）と、人手確認へ振り分ける条件を明確化しました。
  - Epic PRは所定のラベル前提で判定し、マージせず終了する手順を整理しました。
  - 共有スクリプトの参照関係に関する注意書きを追加しました。
- **テスト**
  - 設定解析のテスト対象を更新し、既定値の維持・フォールバック挙動を確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
