### PR TITLE
ci: OpenCodeReview による PR 自動レビューワークフローを追加

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,560 @@
+# OpenCodeReview - PR Auto-Review Workflow
+#
+# Reviews pull requests using OpenCodeReview and posts review comments
+# directly on the PR.
+#
+# Required secrets:
+#   OCR_LLM_URL        - LLM API endpoint (e.g., https://api.openai.com/v1/chat/completions)
+#   OCR_LLM_AUTH_TOKEN - Authentication token for the LLM API
+#
+# Optional secrets:
+#   OCR_LLM_MODEL          - Model name (default: gpt-4o)
+#   OCR_LLM_USE_ANTHROPIC  - Use Anthropic-compatible API ('true' / 'false')
+#
+# Note: GITHUB_TOKEN is automatically provided by GitHub Actions.
+#
+# This repository is public, so the job guards are stricter than a private-repo setup:
+#   - `pull_request` runs only for same-repo branches (fork PRs get no secrets).
+#   - `issue_comment` triggers only for OWNER / MEMBER / COLLABORATOR comments,
+#     so drive-by comments cannot spend LLM credits.
+
+name: OpenCodeReview PR Review
+
+on:
+  pull_request:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # Secrets cannot be referenced in a job-level `if:`, so the enablement check lives
+  # in its own job. Without the LLM secrets the review is skipped (not failed), so
+  # repositories that have not configured OCR yet do not get a red check on every PR.
+  preflight:
+    runs-on: ubuntu-latest
+    # Run on same-repo PR events, or on comments starting with trigger keywords
+    # posted by someone with write access.
+    if: |
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+        (startsWith(github.event.comment.body, '/open-code-review') ||
+         startsWith(github.event.comment.body, '@open-code-review')))
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Check OCR secrets
+        id: check
+        env:
+          OCR_LLM_URL: ${{ secrets.OCR_LLM_URL }}
+          OCR_LLM_AUTH_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+        run: |
+          if [ -n "$OCR_LLM_URL" ] && [ -n "$OCR_LLM_AUTH_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::OCR_LLM_URL / OCR_LLM_AUTH_TOKEN are not configured. Skipping OpenCodeReview."
+          fi
+
+  code-review:
+    runs-on: ubuntu-latest
+    needs: preflight
+    if: needs.preflight.outputs.enabled == 'true'
+    steps:
+      - name: Get PR context
+        id: pr-context
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // For issue_comment events, get PR info
+            const prNumber = context.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            core.setOutput('base_ref', pullRequest.base.ref);
+            core.setOutput('head_ref', pullRequest.head.ref);
+            core.setOutput('head_sha', pullRequest.head.sha);
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history needed for merge-base diff
+          ref: ${{ github.event.pull_request.head.sha || steps.pr-context.outputs.head_sha }}
+
+      - name: Fetch PR head ref (ensures fork commits are available)
+        run: git fetch origin pull/${{ github.event.pull_request.number || github.event.issue.number }}/head
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install OpenCodeReview
+        run: npm install -g @alibaba-group/open-code-review
+
+      - name: Configure OCR
+        env:
+          OCR_LLM_URL: ${{ secrets.OCR_LLM_URL }}
+          OCR_LLM_AUTH_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          OCR_LLM_MODEL: ${{ secrets.OCR_LLM_MODEL }}
+          OCR_LLM_USE_ANTHROPIC: ${{ secrets.OCR_LLM_USE_ANTHROPIC }}
+        run: |
+          ocr config set llm.url "$OCR_LLM_URL"
+          ocr config set llm.auth_token "$OCR_LLM_AUTH_TOKEN"
+          if [ -n "$OCR_LLM_MODEL" ]; then
+            ocr config set llm.model "$OCR_LLM_MODEL"
+          fi
+          if [ -n "$OCR_LLM_USE_ANTHROPIC" ]; then
+            ocr config set llm.use_anthropic "$OCR_LLM_USE_ANTHROPIC"
+          fi
+          ocr config set language Japanese
+
+      - name: Collect review background context
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const prNumber = context.payload.pull_request?.number || context.issue.number;
+
+            // Fetch PR details for title and description
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            // Extract linked issue numbers from the PR body
+            // Pick up both GitHub "closing" keywords (close/fix/resolve [#N]) and bare #N references
+            const prBody = pr.body || '';
+            const issueNumbers = new Set();
+            const closingPattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+            const refPattern = /(?:^|[^&\w])#(\d+)\b/g;
+            for (const re of [closingPattern, refPattern]) {
+              let m;
+              while ((m = re.exec(prBody)) !== null) {
+                issueNumbers.add(Number(m[1]));
+              }
+            }
+            issueNumbers.delete(prNumber);
+
+            // Fetch each referenced issue (skip PR references and anything we can't read)
+            const linkedIssues = [];
+            for (const n of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: n,
+                });
+                if (issue.pull_request) continue;
+                linkedIssues.push(issue);
+              } catch (e) {
+                console.log(`Skipping #${n}: ${e.message}`);
+              }
+            }
+
+            // Fetch all existing inline review comments across pages
+            const comments = await github.paginate(
+              github.rest.pulls.listReviewComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              }
+            );
+
+            // NOTE: This block is injected under OCR's `### Requirement Background (Optional)`
+            // heading, so top-level sections start at h4 (####) and sub-entries at h5 (#####).
+            const sections = [
+              'Below is contextual information for this code review:',
+              '- The pull request description',
+              '- Linked issue descriptions',
+              '- Review comments that have already been posted (do not duplicate them)',
+              '',
+              '#### Pull Request Description',
+              '',
+              `##### ${pr.title || ''}`,
+              '',
+              (prBody || '(no description)').trim(),
+              '',
+            ];
+
+            if (linkedIssues.length > 0) {
+              sections.push('#### Linked Issues');
+              sections.push('');
+              for (const issue of linkedIssues) {
+                sections.push(`##### #${issue.number}: ${issue.title || ''}`);
+                sections.push('');
+                sections.push((issue.body || '(no description)').trim());
+                sections.push('');
+              }
+            }
+
+            if (comments.length > 0) {
+              sections.push('#### Already-posted review comments');
+              sections.push('');
+              sections.push('The following comments have ALREADY been posted on this pull request.');
+              sections.push('Do NOT generate the same or similar comments for issues already covered below.');
+              sections.push('Focus on identifying NEW issues that have not yet been pointed out.');
+              sections.push('');
+              for (const c of comments) {
+                const path = c.path || '(unknown)';
+                const start = c.start_line;
+                const end = c.line ?? c.original_line;
+                const lineInfo = start && end && start !== end
+                  ? `L${start}-L${end}`
+                  : `L${end ?? start ?? '?'}`;
+                sections.push(`##### ${path} (${lineInfo})`);
+                sections.push('');
+                sections.push((c.body || '').trim());
+                sections.push('');
+              }
+            }
+
+            fs.writeFileSync('/tmp/ocr-background.txt', sections.join('\n'));
+            console.log(
+              `Background context: PR description + ${linkedIssues.length} linked issue(s) + ${comments.length} existing comment(s).`
+            );
+
+      - name: Run OpenCodeReview
+        id: review
+        run: |
+          # Get base ref and head SHA from PR context (different for comment triggers)
+          # Note: We use HEAD_SHA instead of origin/${HEAD_REF} to support fork PRs,
+          # because fork branches don't exist on the origin remote.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE_REF="${{ steps.pr-context.outputs.base_ref }}"
+            HEAD_SHA="${{ steps.pr-context.outputs.head_sha }}"
+          fi
+
+          echo "Reviewing PR: ${HEAD_SHA} against origin/${BASE_REF}"
+
+          # Pass PR description, linked issue descriptions, and already-posted review
+          # comments as background context so OCR has full context and skips duplicates.
+          BACKGROUND_ARGS=()
+          if [ -s /tmp/ocr-background.txt ]; then
+            BACKGROUND_ARGS+=(--background "$(cat /tmp/ocr-background.txt)")
+            echo "Including $(wc -l < /tmp/ocr-background.txt) lines of background context."
+          fi
+
+          # Run OCR in range mode with JSON output
+          ocr review \
+            --from "origin/${BASE_REF}" \
+            --to "${HEAD_SHA}" \
+            --format json \
+            "${BACKGROUND_ARGS[@]}" \
+            > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log || true
+
+          echo "OCR review completed. Output:"
+          cat /tmp/ocr-result.json
+          echo "OCR review completed. Error log:"
+          cat /tmp/ocr-stderr.log
+
+      - name: Post review comments to PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = '/tmp/ocr-result.json';
+
+            // Read OCR output
+            let result;
+            try {
+              const raw = fs.readFileSync(path, 'utf8');
+              result = JSON.parse(raw);
+            } catch (e) {
+              console.log('Failed to parse OCR output:', e.message);
+              // Post a simple comment if parsing fails
+              const stderr = fs.readFileSync('/tmp/ocr-stderr.log', 'utf8').trim();
+              if (stderr) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `⚠️ **OpenCodeReview** encountered an error:\n${fencedBlock(stderr)}`
+                });
+              }
+              return;
+            }
+
+            const rawComments = result.comments || [];
+            const warnings = result.warnings || [];
+
+            // Only surface issues whose severity is "high" or above ("critical").
+            // Comments with an unknown/missing severity are kept (fail-open) so that
+            // feedback OCR could not classify is not silently dropped.
+            const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
+            const MIN_SEVERITY_RANK = SEVERITY_RANK.high;
+            const comments = rawComments.filter((c) => {
+              const rank = SEVERITY_RANK[String(c.severity || '').toLowerCase()];
+              return rank === undefined || rank >= MIN_SEVERITY_RANK;
+            });
+            const filteredOutCount = rawComments.length - comments.length;
+            if (filteredOutCount > 0) {
+              console.log(`Filtered out ${filteredOutCount} comment(s) below "high" severity.`);
+            }
+
+            // If nothing meets the "high"+ severity bar, there is nothing to address: LGTM.
+            if (comments.length === 0) {
+              let body = '✅ **OpenCodeReview**: LGTM 👍';
+              if (filteredOutCount > 0) {
+                body += `\n\n_(${filteredOutCount} comment(s) below the "high" severity threshold were omitted.)_`;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+              return;
+            }
+
+            // Prepare PR review with inline comments
+            const prNumber = context.issue.number;
+            let commitSha;
+
+            // Get commit SHA from event context
+            if (context.eventName === 'pull_request') {
+              commitSha = context.payload.pull_request.head.sha;
+            } else {
+              // For comment events, we need to fetch the PR
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              commitSha = pullRequest.head.sha;
+            }
+
+            // Build review comments array for the PR review API
+            // Only inline comments with line info can be posted via createReview
+            const reviewComments = [];
+            const commentsWithoutLine = [];
+
+            for (const comment of comments) {
+              const body = formatComment(comment);
+
+              // Check if comment has valid line information for inline comment (line >= 1)
+              const hasValidLine = (comment.start_line >= 1) || (comment.end_line >= 1);
+              if (!hasValidLine) {
+                commentsWithoutLine.push({ comment, body });
+                continue;
+              }
+
+              const reviewComment = {
+                path: comment.path,
+                body: body
+              };
+
+              // Use line range if available
+              if (comment.start_line >= 1 && comment.end_line >= 1 && comment.start_line !== comment.end_line) {
+                reviewComment.start_line = comment.start_line;
+                reviewComment.line = comment.end_line;
+                reviewComment.start_side = 'RIGHT';
+                reviewComment.side = 'RIGHT';
+              } else if (comment.end_line >= 1) {
+                reviewComment.line = comment.end_line;
+                reviewComment.side = 'RIGHT';
+              } else if (comment.start_line >= 1) {
+                reviewComment.line = comment.start_line;
+                reviewComment.side = 'RIGHT';
+              }
+
+              reviewComments.push({ comment, reviewComment });
+            }
+
+            // Submit as a single PR review with all comments
+            const totalCount = comments.length;
+            const inlineCount = reviewComments.length;
+            const summaryCount = commentsWithoutLine.length;
+            let summaryBody = buildSummaryBody(totalCount, inlineCount, summaryCount, warnings);
+
+            // Add comments without line info to summary body
+            summaryBody += formatSummaryComments(commentsWithoutLine);
+
+            // Statistics tracking
+            let successCount = 0;
+            let failedCount = 0;
+            const failedComments = [];
+
+            try {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                commit_id: commitSha,
+                body: summaryBody,
+                event: 'COMMENT',
+                comments: reviewComments.map(({ reviewComment }) => reviewComment)
+              });
+              successCount = reviewComments.length;
+              console.log(`Successfully posted review with ${successCount} inline comments (${commentsWithoutLine.length} in summary)`);
+            } catch (e) {
+              console.log('Failed to post review with inline comments:', e.message);
+              console.log('Falling back to posting comments individually...');
+
+              // Fallback: post comments one by one
+              for (const { comment, reviewComment } of reviewComments) {
+                try {
+                  await github.rest.pulls.createReview({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: prNumber,
+                    commit_id: commitSha,
+                    body: '',
+                    event: 'COMMENT',
+                    comments: [reviewComment]
+                  });
+                  successCount++;
+                  console.log(`Successfully posted comment for ${reviewComment.path}`);
+                } catch (innerE) {
+                  failedCount++;
+                  failedComments.push({ comment, error: innerE.message });
+                  console.log(`Failed to post comment for ${reviewComment.path}: ${innerE.message}`);
+                }
+              }
+
+              // Post summary comment with statistics
+              let finalBody = buildSummaryBody(totalCount, successCount, commentsWithoutLine.length + failedComments.length, warnings);
+              finalBody += formatSummaryComments(commentsWithoutLine);
+              finalBody += `\n\n---\n\n📊 **Posting Statistics:**`;
+              finalBody += `\n- ✅ Successfully posted: ${successCount} comment(s)`;
+              if (failedCount > 0) {
+                finalBody += `\n- ❌ Failed to post: ${failedCount} comment(s)`;
+              }
+
+              // Add failed comments as summary content so review feedback is not lost.
+              if (failedComments.length > 0) {
+                finalBody += '\n\n---\n\n### ⚠️ Inline comments shown in summary';
+                for (const { comment, error } of failedComments) {
+                  finalBody += '\n\n---\n\n';
+                  finalBody += formatCommentMarkdown(comment, error);
+                }
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: finalBody
+              });
+            }
+
+            function formatComment(comment) {
+              let body = '';
+
+              // Prepend a category / severity badge so reviewers can triage at a glance
+              const badge = formatBadge(comment);
+              if (badge) body += badge + '\n\n';
+
+              body += comment.content || '';
+
+              // Add code suggestion if available
+              if (comment.suggestion_code && comment.existing_code) {
+                body += '\n\n**Suggestion:**\n';
+                body += fencedBlock(comment.suggestion_code, 'suggestion');
+              }
+
+              return body;
+            }
+
+            function formatCommentMarkdown(comment, error) {
+              let md = `### 📄 \`${comment.path}\``;
+              if (comment.start_line && comment.end_line) {
+                md += ` (L${comment.start_line}-L${comment.end_line})`;
+              }
+              md += '\n\n';
+              const badge = formatBadge(comment);
+              if (badge) md += badge + '\n\n';
+              if (error) {
+                md += `⚠️ GitHub could not post this as an inline comment: ${error}\n\n`;
+              }
+              md += comment.content || '';
+
+              if (comment.suggestion_code && comment.existing_code) {
+                md += '\n\n<details><summary>💡 Suggested Change</summary>\n\n';
+                md += '**Before:**\n' + fencedBlock(comment.existing_code) + '\n\n';
+                md += '**After:**\n' + fencedBlock(comment.suggestion_code) + '\n\n';
+                md += '</details>';
+              }
+
+              return md;
+            }
+
+            function buildSummaryBody(totalCount, inlineCount, summaryCount, warnings) {
+              let body = `🔍 **OpenCodeReview** found **${totalCount}** issue(s) in this PR.`;
+              if (totalCount > 0) {
+                body += `\n- ✅ ${inlineCount} posted as inline comment(s)`;
+                body += `\n- 📝 ${summaryCount} posted as summary`;
+              }
+              if (warnings.length > 0) {
+                body += `\n\n⚠️ ${warnings.length} warning(s) occurred during review.`;
+              }
+              return body;
+            }
+
+            function formatSummaryComments(summaryComments) {
+              let body = '';
+              for (const { comment } of summaryComments) {
+                body += '\n\n---\n\n';
+                body += formatCommentMarkdown(comment);
+              }
+              return body;
+            }
+
+            // Build a `severity · category` badge line from OCR's structured fields.
+            // Both fields are optional, so render whichever are present (or nothing).
+            function formatBadge(comment) {
+              const category = comment.category ? String(comment.category).trim() : '';
+              const severity = comment.severity ? String(comment.severity).trim() : '';
+              const parts = [];
+              if (severity) {
+                parts.push(`${severityIcon(severity)} **${severity.toUpperCase()}**`);
+              }
+              if (category) {
+                parts.push(`\`${category}\``);
+              }
+              return parts.join(' · ');
+            }
+
+            function severityIcon(severity) {
+              switch (String(severity).toLowerCase()) {
+                case 'critical': return '🟥';
+                case 'high': return '🟧';
+                case 'medium': return '🟨';
+                case 'low': return '🟦';
+                default: return '⬜';
+              }
+            }
+
+            function fencedBlock(content, language = '') {
+              const text = String(content || '');
+              const fence = safeFence(text);
+              let block = fence + language + '\n' + text;
+              if (!text.endsWith('\n')) block += '\n';
+              return block + fence;
+            }
+
+            function safeFence(content) {
+              const matches = String(content || '').match(/`+/g) || [];
+              const maxTicks = matches.reduce((max, ticks) => Math.max(max, ticks.length), 0);
+              return '`'.repeat(Math.max(3, maxTicks + 1));
+            }


### PR DESCRIPTION
## 概要

`igsa-ai/github-actions-packages` の `ocr-review.yml`（reusable workflow）を元に、このリポジトリ向けの OpenCodeReview 自動レビューワークフローを追加します。

reusable workflow として呼び出さずインライン化したのは、置き場である `igsa-ai/github-actions-packages` が **PRIVATE** かつ別オーナーであり、private reusable workflow はオーナーを跨いで `workflow_call` できないためです。

## 元の reusable workflow からの変更点

| 変更 | 理由 |
|---|---|
| トリガーを `workflow_call` → `pull_request` + `issue_comment: [created]` | 元は caller 側が定義していた部分 |
| fork PR を除外（`pull_request` は same-repo ブランチのみ） | fork PR には secrets が渡らず `ocr config set` が空値で走る |
| `issue_comment` を `OWNER` / `MEMBER` / `COLLABORATOR` に限定 | public リポジトリなので、無いと誰でも `/open-code-review` と書いて LLM クレジットを消費できる |
| secrets 未設定時は fail せず skip（`preflight` job + `needs` ゲート） | secrets は job レベル `if:` から参照できない。fail-fast だと secret 未設定の現状で全 PR が赤くなる |
| `ocr config set` の値をクォート／optional secret は空なら渡さない | 元は未クォートで、空値やスペース入りの値で壊れる |

ステップ本体（severity `high` 以上のフィルタ、background context 生成、inline コメント投稿とフォールバック）は元と同一です。

## 動かすのに必要な設定

現状このリポジトリに OCR 系 secret は未設定で、その間ワークフローは skip されます（赤くはなりません）。

```
gh secret set OCR_LLM_URL
gh secret set OCR_LLM_AUTH_TOKEN
gh secret set OCR_LLM_MODEL          # 任意
gh secret set OCR_LLM_USE_ANTHROPIC  # 任意
```

## 確認したこと

- `actionlint .github/workflows/ocr-review.yml` → clean
- `npx prettier --check .github/workflows/ocr-review.yml` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)