### PR TITLE
fix: OCRレビューがbotコメントでキャンセルされる問題を修正

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -25,8 +25,12 @@ on:
   issue_comment:
     types: [created]
 
+# The group key includes the event name on purpose. GitHub evaluates `concurrency`
+# before any job-level `if:`, so an `issue_comment` run (e.g. a bot comment that the
+# preflight guard immediately skips) would otherwise take over the group and cancel
+# the in-progress `pull_request` review, leaving the PR without a review.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## 概要

`OpenCodeReview PR Review` ワークフローが `cancelled` になり、レビューが投稿されない事象を修正する。

## 原因

`concurrency.group` が PR 番号のみをキーにしていたため、`pull_request` run と `issue_comment` run が同一グループに入っていた。

1. PR 更新で `pull_request` run が起動、レビュー実行中
2. bot（実例: `coderabbitai[bot]`）が同 PR にコメント → `issue_comment` run が生成
3. 同一グループのため `cancel-in-progress: true` が 1 を即キャンセル
4. GitHub は `concurrency` をジョブの `if:` より**先に**評価するので、2 はグループを奪ってから preflight の `if`（`/open-code-review` で始まるコメントのみ許可）で false になり skip
5. 実質 no-op の run だけが残り、本物のレビューは消える

実例: run [30162708408](https://github.com/getty104/claude-task-worker/actions/runs/30162708408)（PR #154）が
`Canceling since a higher priority waiting request for OpenCodeReview PR Review-154 exists` でキャンセルされ、
奪った側の run 30162719663 は `issue_comment` / `coderabbitai[bot]` / conclusion `skipped`。

## 変更内容

`concurrency.group` に `github.event_name` を追加し、`pull_request` run と `issue_comment` run を別グループにした。これでコメント由来の run が実行中のレビューを kill しなくなる。

`cancel-in-progress: ${{ github.event_name == 'pull_request' }}` とする案もあるが、その場合コメント run が pending でグループ待ちし、PR run 完了まで詰まるため採用しなかった。

## 動作確認

- ワークフロー定義のみの変更。この PR 自体の OpenCodeReview run がキャンセルされずに完走することで確認できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * コードレビューの同時実行制御を改善しました。
  * コメントによる実行がスキップされた場合でも、進行中のプルリクエストレビューが意図せずキャンセルされにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->