### PR TITLE
fix: UIデザインフロー進行中に triage-created-issue が走り続ける問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ advisor は main モデル以上の能力を持つモデルである必要があ
 `cc-issue-created` と `cc-triage-scope` の両方のラベルが付いたIssueを定期取得し、Claude Codeでトリアージを実行する。（1分間隔）
 
 - `cc-pr-created` / `cc-update-issue` / `cc-answer-issue-questions` / `cc-exec-issue` のいずれかが付いているIssueは除外
+- `cc-create-ui-design` / `cc-ui-design-pr-created`（UIデザイン先行フローの進行中マーカー）が付いているIssueも除外。トリガーラベルはトリアージ完了後に付き直されるため、除外しないとデザインPRのマージまで再トリアージが走り続け、パターンE-1の前提ゲートが満たされない再実行が `cc-exec-issue` を付けてデザイン合意前に実装を始めてしまう
 - 確認事項の有無に応じて `cc-answer-issue-questions` または `cc-exec-issue` ラベルを付与（または不要ならクローズ）
 
 ### triage-pr

--- a/docs/prd-ui-design-workflow.md
+++ b/docs/prd-ui-design-workflow.md
@@ -94,6 +94,8 @@ cc-triage-scope
 
 **手動オプトイン/オプトアウト**: 人が `cc-create-ui-design` を直接付ければトリアージ判定を経ずにデザインフローへ入れる。逆に `cc-ui-design-ready` を手で付ければ E-1 はスキップされる。
 
+**デザインフロー進行中のトリアージ停止**: `triage-created-issue` の除外ラベルに `cc-create-ui-design` と `cc-ui-design-pr-created` を追加する。トリガーラベル（`cc-issue-created` / `cc-triage-scope`）はトリアージ完了時に付き直されるため、除外しないとデザイン PR の作成〜マージが終わるまで毎ポーリングで再トリアージが走る。さらに再実行では前提ゲート 2（デザイン系ラベルが付いていないこと）を満たさず E-1 がスキップされるため、パターン E に落ちて `cc-exec-issue` が付き、デザイン合意前に実装が始まる。`cc-ui-design-ready` は同時に付く `cc-exec-issue` 側で除外されるため追加しない。
+
 ### 4.3 `create-ui-design` ワーカー（新規）
 
 `createIssuePollingWorker` を使う Issue ワーカー。

--- a/src/workers/triage-created-issue.ts
+++ b/src/workers/triage-created-issue.ts
@@ -6,7 +6,22 @@ export const triageCreatedIssueWorker = (opts: { epicFilters?: number[]; labelFi
     name: "triage-created-issue",
     command: "/claude-task-worker:triage-created-issue",
     triggerLabels: ["cc-issue-created", "cc-triage-scope"],
-    excludeLabels: ["cc-pr-created", "cc-update-issue", "cc-answer-issue-questions", "cc-exec-issue"],
+    // cc-create-ui-design / cc-ui-design-pr-created はUIデザイン先行フローの進行中マーカー。
+    // 除外しないと、トリガーラベル（cc-issue-created / cc-triage-scope）はトリアージ完了後も
+    // 付き直されるため、デザインPRの作成〜レビュー〜マージが終わるまでの間ずっと再トリアージが
+    // 走り続ける。しかもスキルのパターンE-1は「cc-create-ui-design / cc-ui-design-pr-created が
+    // 付いていない」ことを前提ゲートにしているため、再実行では E-1 がスキップされてパターンE
+    // （cc-exec-issue 付与）へ落ち、デザイン合意前に実装フェーズが始まってしまう。
+    // cc-ui-design-ready はデザイン確定後のマーカーで、同時に付く cc-exec-issue 側で除外されるため
+    // ここには含めない（実装完了後の再トリアージ可能性を残す）。
+    excludeLabels: [
+      "cc-pr-created",
+      "cc-update-issue",
+      "cc-answer-issue-questions",
+      "cc-exec-issue",
+      "cc-create-ui-design",
+      "cc-ui-design-pr-created",
+    ],
     epicFilters: opts.epicFilters,
     labelFilters: opts.labelFilters,
     onCompleted: async (issueNumber) => {


### PR DESCRIPTION
## 概要

UIデザイン先行ワークフローの実行中、`triage-created-issue` を止める仕組みが無く、デザインPRのマージが終わるまでトリアージが走り続ける問題を修正した。

## 問題

`triage-created-issue` のトリガーラベル（`cc-issue-created` / `cc-triage-scope`）は、タスク完了時に `issue-worker.ts` が付き直す。除外ラベルにUIデザインフローの進行中マーカーが無いため、以下が起きる。

1. トリアージがパターンE-1でUI実装タスクと判定し `cc-create-ui-design` を付与
2. トリガーラベルが付き直されるため、次ポーリングで同じIssueが再びトリアージ対象になる
3. 再実行では、スキルのパターンE-1の前提ゲート2（`cc-create-ui-design` / `cc-ui-design-pr-created` / `cc-ui-design-ready` のいずれも付いていない）を満たさないため **E-1がスキップされパターンEへ落ちる**
4. 結果 `cc-exec-issue` が付与され、**デザイン合意前に `exec-issue` が実装を始める**

無駄な再実行だけでなく、ワークフローの前提そのものが壊れる。

## 修正

`triage-created-issue` の `excludeLabels` に `cc-create-ui-design` と `cc-ui-design-pr-created` を追加。

ラベル連鎖 `cc-create-ui-design` → `cc-ui-design-pr-created` → `cc-exec-issue` でフロー全区間をカバーする。ラベル遷移の隙間（トリガーラベル除去〜次ラベル付与の間）は共通除外ラベルの `cc-in-progress` がガードするため、レースは発生しない。

`cc-ui-design-ready` は追加しない。同時に付与される `cc-exec-issue` で既に除外されるうえ、実装完了後の再トリアージ余地を残すため。

## ラベル解除の経路（座礁しないことの確認）

- **自動**: `apply-ui-design` の `triggerLabels` が `cc-ui-design-pr-created` なので、タスクが起動して終われば成否に関わらずフレームワークが剥がす
- **preflight skip 中**: デザインPRがOPENの間は起動しないため付いたまま（＝意図どおりトリアージ停止）
- **失敗時**: プロセス失敗ならラベルが剥がれてトリアージへ復帰しデザインフローへ再投入、検証失敗なら `cc-need-human-check`（共通除外）
- **人手**: `ui-design.ts` のコメント文面と `exec-issue` スキルが復旧手順として明示

既知の制約として、`cc-ui-design-pr-created` が付いた状態で `uiDesign.enabled` を `false` に戻すと、剥がす主体（`apply-ui-design` ワーカー）が起動しないため停止する。手動でラベルを外せば復帰する（`cc-create-ui-design` も同条件で同じ性質）。

## テスト

`npm run build` / `npm test`（287 pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * UIデザインフロー中のIssueが、デザインPRの完了前に再トリアージされる問題を防止しました。
  * デザイン作業中は、誤って実行工程へ進まないよう処理を抑制します。

* **ドキュメント**
  * UIデザインフローにおける除外条件と、トリガー再付与の運用を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->