### PR TITLE
feat: uiDesign.yolo でデザインPRの自動マージ入口を切り替える

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,13 +246,13 @@ herdr は `workspace close` の際、**閉じたワークスペースがフォ�
 
 ### UIデザイン先行ワークフロー（`uiDesign`）
 
-UI実装Issueについて、実装の前に Pencil（`.pen`）でデザインを作り、独立したPRとしてマージしてから実装へ進むフロー。`claude-task-worker.json` の `uiDesign.enabled`（boolean、既定 `false`）と `uiDesign.designDir`（既定 `"designs"`）で制御する。設定は `src/config.ts` の `parseUiDesignEntry()`（不正値は警告して既定値）／`getUiDesignConfig()`（読み込み失敗時は既定＝無効へ倒す）で解決する。
+UI実装Issueについて、実装の前に Pencil（`.pen`）でデザインを作り、独立したPRとしてマージしてから実装へ進むフロー。`claude-task-worker.json` の `uiDesign.enabled`（boolean、既定 `false`）・`uiDesign.designDir`（既定 `"designs"`）・`uiDesign.yolo`（boolean、既定 `false`）で制御する。設定は `src/config.ts` の `parseUiDesignEntry()`（不正値は警告して既定値）／`getUiDesignConfig()`（読み込み失敗時は既定＝無効へ倒す）で解決する。
 
 - **`uiDesign.enabled: false` のときは2つのワーカーを起動しない**。判定は `index.ts` ではなくワーカー実装側（`create-ui-design.ts` / `apply-ui-design.ts`）の先頭に置き、`all` / `yolo` からの一括起動でも個別コマンドでも同じ経路を通す。ラベルを消費するワーカーが存在しないため、無効なリポジトリでは人が手動で `cc-create-ui-design` を付けても何も起きず、本機能の追加前と完全に同一の挙動になる
 - 経路は `triage-created-issue` のパターンE-1（パターンD通過後・パターンEの手前）で分岐する。UI実装タスクと判定した場合は `cc-exec-issue` を付けずに `cc-create-ui-design` のみを付与する。判定が割れる場合は**デザインを作らない側（パターンE）に倒す**
 - デザインPRの head は `cc-ui-design-<Issue番号>` の固定名ブランチ（`cc-epic-<N>` と同じ考え方で、後段が head ref から一意に特定できるようにするため）。ベースブランチは実装PRと揃える（`parent` があれば `cc-epic-<親>`、なければ default）。揃えないと epic 配下でデザインが実装ブランチに存在しない状態になる
 - **デザインPRの Issue 参照は `Refs #N` 固定で closing keyword を禁止する**。`Closes` を使うとデザインPRのマージで実装Issueが閉じ、実装フェーズへ進めなくなる
-- デザインPRのレビュー・マージは既存の `triage-pr` / `fix-review-point` / `resolve-pr-conflict` にそのまま乗せる（新しいマージ機構を作らない）。`.pen` のコンフリクトは `resolve-pr-conflict` → `resolve-pencil-conflict` の既存の委譲が効く。Epic PR ではないため `cc-release-ready` によるマージ保留の対象外
+- **`uiDesign.yolo` はデザインPRへ `cc-triage-scope` を付けるかだけを切り替える**（`create-ui-design.ts` の `onCompleted`）。`true` のときだけ付与し、デザインPRのレビュー・マージを既存の `triage-pr` / `fix-review-point` / `resolve-pr-conflict` にそのまま乗せる（新しいマージ機構を作らない）。`.pen` のコンフリクトは `resolve-pr-conflict` → `resolve-pencil-conflict` の既存の委譲が効く。Epic PR ではないため `cc-release-ready` によるマージ保留の対象外。`false`（既定）では `cc-triage-scope` を付けないためどのワーカーもデザインPRを拾わず、人がレビュー・マージするまで `apply-ui-design` の `preflight` が `skip`（マージ待ち）を返し続ける（＝デザインに人が介在する既定）。`cc-ui-design` は yolo に関わらず常に付ける（PRの種別マーカーであり、自動処理の入口ではないため）
 - `apply-ui-design` の `preflight` はデザインPRが `MERGED` のときだけ `proceed`、`OPEN` なら `skip`（マージ待ち）、未マージクローズ・PR不在は `cc-need-human-check` を付与して `skip`。同ラベルは `issue-worker.ts` の共通除外ラベルなので無限リトライしない
 - `exec-issue` は `cc-ui-design-ready` が付いているのに description に `## UIデザイン` セクションが無い状態を検出したら、**デザインなしで実装せず** `cc-need-human-check` に落とす。復旧はデザイン参照を自動で再生成する場合、`cc-need-human-check` と `cc-ui-design-ready` を外して `cc-ui-design-pr-created` を付け直せば `apply-ui-design` が description を再生成する。`cc-need-human-check` を外さずに `cc-ui-design-pr-created` だけ付け直しても、同ラベルは `issue-worker.ts` の共通除外ラベルのため `apply-ui-design` のポーリング候補から外れたままになり再実行されない
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ UI実装Issueについて、実装の前に Pencil（`.pen`）でデザインを
 {
   "uiDesign": {
     "enabled": true,
-    "designDir": "designs"
+    "designDir": "designs",
+    "yolo": false
   }
 }
 ```
@@ -83,6 +84,7 @@ UI実装Issueについて、実装の前に Pencil（`.pen`）でデザインを
 |---|---|---|
 | `uiDesign.enabled` | `false` | 本ワークフローの有効化。`false` の間は `triage-created-issue` がUI判定を行わず、2つのワーカーも起動しない |
 | `uiDesign.designDir` | `"designs"` | `.pen` とスナップショットの配置先（リポジトリルートからの相対パス） |
+| `uiDesign.yolo` | `false` | デザインPRを自動レビュー・自動マージへ流すか。`true` のときだけデザインPRに `cc-triage-scope` を付与する。`false`（既定）ではデザインPRは `cc-ui-design` のみが付いた状態で止まり、人がレビュー・マージするまで `apply-ui-design` は先へ進まない |
 
 フローは以下のとおり。
 
@@ -93,8 +95,9 @@ cc-issue-created + triage-created-issue（ルーティング）
         → create-ui-design ワーカー
            ・.pen を作成/更新 + snapshots/ に PNG 出力
            ・ブランチ cc-ui-design-<N> を push しデザインPRを作成（Refs #N。closing keyword は使わない）
-           ・PR に cc-triage-scope + cc-ui-design、Issue に cc-ui-design-pr-created を付与
-        → triage-pr / fix-review-point / resolve-conflict（既存フローでレビュー・マージ）
+           ・PR に cc-ui-design（uiDesign.yolo が true なら cc-triage-scope も）、Issue に cc-ui-design-pr-created を付与
+        → uiDesign.yolo: true  → triage-pr / fix-review-point / resolve-conflict（既存フローでレビュー・マージ）
+           uiDesign.yolo: false → 人がデザインPRをレビュー・マージ
         → apply-ui-design ワーカー
            ・デザインPRが MERGED になるまで skip
            ・Issue description に「## UIデザイン」セクションを追記
@@ -102,7 +105,7 @@ cc-issue-created + triage-created-issue（ルーティング）
         → exec-issue（デザインを参照元として実装）
 ```
 
-デザインPRは Epic PR ではないため `cc-release-ready` によるマージ保留の対象外で、`triage-pr` が通常どおりレビュー・マージする。`triage-pr` は `cc-ui-design` ラベル付きPRに対してコードレビューではなくデザイン向けの観点（差分が `.pen` とPNGに限定されているか、スナップショットとデザイン意図が読み取れるか、Issue要件を満たしているか）で評価する。
+デザインPRのレビュー・マージ経路は `uiDesign.yolo` で切り替わる。`true` のときはデザインPRに `cc-triage-scope` が付き、Epic PR ではないため `cc-release-ready` によるマージ保留の対象外で、`triage-pr` が通常どおりレビュー・マージする。`false`（既定）では `cc-triage-scope` を付けないためどのワーカーもデザインPRを拾わず、人がレビューしてマージするまで待つ（`apply-ui-design` はデザインPRが `MERGED` になるまでスキップし続ける）。デザインに人が介在したい場合は既定のままにする。`triage-pr` は `cc-ui-design` ラベル付きPRに対してコードレビューではなくデザイン向けの観点（差分が `.pen` とPNGに限定されているか、スナップショットとデザイン意図が読み取れるか、Issue要件を満たしているか）で評価する。
 
 デザインが不要と判明した場合は `create-ui-design` が理由をコメントして `cc-ui-design-ready` + `cc-exec-issue` を付与し、人手を介さず実装へ復帰する。Pencil が使えない環境やデザインPRが却下された場合は `cc-need-human-check` に落ちて停止する（共通除外ラベルのため無限リトライしない）。
 
@@ -506,7 +509,7 @@ advisor は main モデル以上の能力を持つモデルである必要があ
 - `claude-task-worker.json` の `uiDesign.enabled` が `true` の場合のみ起動する（`false` なら1行ログを出して即終了）
 - `cc-ui-design-pr-created` / `cc-ui-design-ready` が付いているIssueは除外
 - デザインPRは `cc-ui-design-<Issue番号>` の固定名ブランチを head とする（後段の `apply-ui-design` が一意に特定するため）
-- 完了後、デザインPRの実在を確認できた場合のみ、PRに `cc-ui-design` と `cc-triage-scope`、Issueに `cc-ui-design-pr-created` を付与する
+- 完了後、デザインPRの実在を確認できた場合のみ、PRに `cc-ui-design`（`uiDesign.yolo` が `true` の場合は `cc-triage-scope` も）、Issueに `cc-ui-design-pr-created` を付与する
 - スキルが「デザイン不要」と判定した場合（`cc-ui-design-ready` 付与済み）は完了扱いとし、そのまま実装フェーズへ流す
 - PRの実在を確認できない場合は `cc-need-human-check` を付与してIssueにコメントを残す
 
@@ -581,7 +584,7 @@ claude-task-worker -v
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|
 | `fixReviewPointCallbackCommentMessage` | string | - | fix-review-point 完了時にPRへ投稿するコメント（未設定の場合は投稿しない） |
-| `uiDesign` | object | `{ "enabled": false, "designDir": "designs" }` | UIデザイン先行ワークフローの設定（詳細は「[UIデザイン先行ワークフロー](#uiデザイン先行ワークフロー)」） |
+| `uiDesign` | object | `{ "enabled": false, "designDir": "designs", "yolo": false }` | UIデザイン先行ワークフローの設定（詳細は「[UIデザイン先行ワークフロー](#uiデザイン先行ワークフロー)」） |
 | `workers` | object | `{}` | ワーカーごとに Claude CLI に渡すスキル、`--model` / `--advisor` / `--effort`、ポーリング間隔、クールダウン時間、最大同時実行数を上書きする設定（詳細は下記） |
 
 ### ワーカーごとの設定

--- a/plugin/skills/create-ui-design/SKILL.md
+++ b/plugin/skills/create-ui-design/SKILL.md
@@ -21,7 +21,7 @@ UI実装Issue `$0` に対して、実装に先立って Pencil のデザイン�
 
 ## 実行モードの制約
 
-本スキル固有のリスク: 本スキルは `claude-task-worker` の `create-ui-design` ワーカー（`cc-create-ui-design` ラベル）から自動起動され、ワーカーはスキルプロセスの同期完了を根拠にラベル遷移（`cc-ui-design-pr-created` の付与、デザインPRへの `cc-triage-scope` / `cc-ui-design` 付与）を進める。処理が未完のままターンを終えると、デザインPR未作成のままトリガーラベルが外れてIssueが停滞したり、デザインなしで実装フェーズへ流れたりする状態壊れが起きる。
+本スキル固有のリスク: 本スキルは `claude-task-worker` の `create-ui-design` ワーカー（`cc-create-ui-design` ラベル）から自動起動され、ワーカーはスキルプロセスの同期完了を根拠にラベル遷移（`cc-ui-design-pr-created` の付与、デザインPRへの `cc-ui-design` 付与と、`uiDesign.yolo` が `true` の場合の `cc-triage-scope` 付与）を進める。処理が未完のままターンを終えると、デザインPR未作成のままトリガーラベルが外れてIssueが停滞したり、デザインなしで実装フェーズへ流れたりする状態壊れが起きる。
 
 > **プリアンブル（`!` インライン実行）に失敗しうるコマンドを置かないこと**: プリアンブルのコマンドが失敗すると、セッションはモデル未起動のまま何も出力せず exit 0 で終了し、ワーカーが空振り実行を延々と繰り返す。`pencil` の疎通確認はフェーズ0の本文で行う。
 
@@ -273,7 +273,7 @@ EOF
 
 **`Closes #$0` / `Fixes #$0` などの closing keyword は絶対に使わない。** デザインPRのマージで実装Issueが閉じてしまい、実装フェーズへ進めなくなるため。参照は必ず `Refs #$0` にする。
 
-ラベルは付与しない（`cc-triage-scope` / `cc-ui-design` はワーカーが `onCompleted` で付与する）。
+ラベルは付与しない（`cc-ui-design` はワーカーが `onCompleted` で付与する。`cc-triage-scope` も同様にワーカー側の担当で、`claude-task-worker.json` の `uiDesign.yolo` が `true` の場合のみ付与される）。
 
 ### PR作成の検証
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -12,15 +12,16 @@ function silenceWarn(t: TestContext): void {
 
 test("parseUiDesignEntry defaults to disabled with designs/ as the design dir", (t) => {
   silenceWarn(t);
-  assert.deepEqual(parseUiDesignEntry(undefined), { enabled: false, designDir: "designs" });
-  assert.deepEqual(DEFAULT_UI_DESIGN_CONFIG, { enabled: false, designDir: "designs" });
+  assert.deepEqual(parseUiDesignEntry(undefined), { enabled: false, designDir: "designs", yolo: false });
+  assert.deepEqual(DEFAULT_UI_DESIGN_CONFIG, { enabled: false, designDir: "designs", yolo: false });
 });
 
 test("parseUiDesignEntry reads enabled and designDir", (t) => {
   silenceWarn(t);
-  assert.deepEqual(parseUiDesignEntry({ enabled: true, designDir: "docs/designs" }), {
+  assert.deepEqual(parseUiDesignEntry({ enabled: true, designDir: "docs/designs", yolo: true }), {
     enabled: true,
     designDir: "docs/designs",
+    yolo: true,
   });
 });
 
@@ -53,15 +54,22 @@ test("parseUiDesignEntry falls back to the default for a path-traversal designDi
 
 test("parseUiDesignEntry falls back to defaults when uiDesign is not an object", (t) => {
   silenceWarn(t);
-  assert.deepEqual(parseUiDesignEntry("designs"), { enabled: false, designDir: "designs" });
-  assert.deepEqual(parseUiDesignEntry([]), { enabled: false, designDir: "designs" });
-  assert.deepEqual(parseUiDesignEntry(null), { enabled: false, designDir: "designs" });
+  assert.deepEqual(parseUiDesignEntry("designs"), { enabled: false, designDir: "designs", yolo: false });
+  assert.deepEqual(parseUiDesignEntry([]), { enabled: false, designDir: "designs", yolo: false });
+  assert.deepEqual(parseUiDesignEntry(null), { enabled: false, designDir: "designs", yolo: false });
 });
 
 test("parseUiDesignEntry warns once per invalid key", (t) => {
   const warn = t.mock.method(console, "warn", () => {});
-  parseUiDesignEntry({ enabled: 1, designDir: 2 });
-  assert.equal(warn.mock.callCount(), 2);
+  parseUiDesignEntry({ enabled: 1, designDir: 2, yolo: 3 });
+  assert.equal(warn.mock.callCount(), 3);
+});
+
+test("parseUiDesignEntry falls back to the default for a non-boolean yolo", (t) => {
+  silenceWarn(t);
+  // yolo を文字列で有効扱いすると、人のレビューを挟むつもりのデザインPRが
+  // cc-triage-scope 付きで自動マージへ流れる。必ず既定（無効）へ倒す。
+  assert.equal(parseUiDesignEntry({ enabled: true, yolo: "true" }).yolo, false);
 });
 
 test("advisorModel defaults to opus for sonnet workers and to none for opus workers", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,9 @@ export interface WorkerRuntimeConfig {
 export interface UiDesignConfig {
   enabled: boolean;
   designDir: string;
+  // デザインPRを人のレビュー無しで自動マージまで流すか。false（既定）ではデザインPRに
+  // cc-triage-scope を付けないため、triage-pr が拾わず人がレビュー・マージするまで止まる。
+  yolo: boolean;
 }
 
 interface Config {
@@ -45,6 +48,7 @@ interface Config {
 export const DEFAULT_UI_DESIGN_CONFIG: UiDesignConfig = {
   enabled: false,
   designDir: "designs",
+  yolo: false,
 };
 
 export const DEFAULT_WORKER_CONFIG: WorkerRuntimeConfig = {
@@ -267,6 +271,15 @@ export function parseUiDesignEntry(val: unknown): UiDesignConfig {
     } else {
       console.warn(
         `[config] invalid uiDesign.enabled: ${String(entry.enabled)}, using default ${DEFAULT_UI_DESIGN_CONFIG.enabled}`,
+      );
+    }
+  }
+  if ("yolo" in entry) {
+    if (typeof entry.yolo === "boolean") {
+      result.yolo = entry.yolo;
+    } else {
+      console.warn(
+        `[config] invalid uiDesign.yolo: ${String(entry.yolo)}, using default ${DEFAULT_UI_DESIGN_CONFIG.yolo}`,
       );
     }
   }

--- a/src/workers/create-ui-design.ts
+++ b/src/workers/create-ui-design.ts
@@ -3,11 +3,17 @@ import { addLabel, commentOnIssue, findPrNumberByHeadRef, hasLabel } from "../gh
 import { createIssuePollingWorker } from "./issue-worker";
 import { designBranchName, designPrNotCreatedComment } from "./ui-design";
 
-export function designPrLabelingFailedComment(issueNumber: number, prNumber: number, error: unknown): string {
+export function designPrLabelingFailedComment(
+  issueNumber: number,
+  prNumber: number,
+  error: unknown,
+  yolo = false,
+): string {
   const message = error instanceof Error ? error.message : String(error);
+  const prLabels = yolo ? "`cc-ui-design` / `cc-triage-scope`" : "`cc-ui-design`";
   return [
     "## デザインPRへのラベル付与に失敗しました（要人手確認）",
-    `デザインPR #${prNumber}（ブランチ \`${designBranchName(issueNumber)}\`）は作成されましたが、後続ラベル（\`cc-ui-design\` / \`cc-triage-scope\` / \`cc-ui-design-pr-created\`）の付与に失敗しました。`,
+    `デザインPR #${prNumber}（ブランチ \`${designBranchName(issueNumber)}\`）は作成されましたが、後続ラベル（${prLabels} / \`cc-ui-design-pr-created\`）の付与に失敗しました。`,
     "",
     "## 起こりうる原因",
     "- 本ワークフロー追加時のラベルが未作成の可能性があります。`claude-task-worker init` を再実行してラベルを作成してください",
@@ -18,7 +24,7 @@ export function designPrLabelingFailedComment(issueNumber: number, prNumber: num
     "```",
     "",
     "## 対応後の進め方",
-    "- ラベル作成後にやり直す場合: `cc-need-human-check` ラベルを外し、`cc-ui-design`・`cc-triage-scope`（PR側）と `cc-ui-design-pr-created`（Issue側）を手動で付けてください",
+    `- ラベル作成後にやり直す場合: \`cc-need-human-check\` ラベルを外し、${yolo ? "`cc-ui-design`・`cc-triage-scope`" : "`cc-ui-design`"}（PR側）と \`cc-ui-design-pr-created\`（Issue側）を手動で付けてください`,
   ].join("\n");
 }
 
@@ -27,10 +33,12 @@ export const createUiDesignWorker = async (
 ): Promise<void> => {
   // uiDesign.enabled が false のリポジトリでは、手動で cc-create-ui-design を付けても
   // 何も起きないようワーカー自体を起動しない（本機能追加前と完全に同一の挙動にする）。
-  if (!getUiDesignConfig().enabled) {
+  const uiDesignConfig = getUiDesignConfig();
+  if (!uiDesignConfig.enabled) {
     console.log("[create-ui-design] uiDesign.enabled is false, skipping");
     return;
   }
+  const yolo = uiDesignConfig.yolo;
   await createIssuePollingWorker({
     name: "create-ui-design",
     command: "/claude-task-worker:create-ui-design",
@@ -66,10 +74,18 @@ export const createUiDesignWorker = async (
         return false;
       }
       try {
-        // triage-pr がレビュー・マージへ進められるよう cc-triage-scope を、
         // レビュー観点を切り替えられるよう cc-ui-design（デザインPRのマーカー）を付ける。
         await addLabel("pr", prNumber, "cc-ui-design");
-        await addLabel("pr", prNumber, "cc-triage-scope");
+        // cc-triage-scope は triage-pr の自動レビュー・自動マージ入口なので、
+        // uiDesign.yolo が true のときだけ付ける。false（既定）ではデザインPRを
+        // 人がレビュー・マージするまで止め、デザインへの人の介在を担保する。
+        if (yolo) {
+          await addLabel("pr", prNumber, "cc-triage-scope");
+        } else {
+          console.log(
+            `[create-ui-design] #${issueNumber}: uiDesign.yolo is false, leaving design PR #${prNumber} for human review (no cc-triage-scope)`,
+          );
+        }
         await addLabel("issue", issueNumber, "cc-ui-design-pr-created");
       } catch (err) {
         // 本ワークフロー追加時のラベルが init 未実行で存在しない場合、addLabel は
@@ -77,7 +93,7 @@ export const createUiDesignWorker = async (
         // 残るため、既存の「PR不在」分岐と同じパターンで人手確認に倒す。
         console.error(`[create-ui-design] #${issueNumber}: labeling design PR #${prNumber} failed: ${err}`);
         await addLabel("issue", issueNumber, "cc-need-human-check");
-        await commentOnIssue(issueNumber, designPrLabelingFailedComment(issueNumber, prNumber, err)).catch(
+        await commentOnIssue(issueNumber, designPrLabelingFailedComment(issueNumber, prNumber, err, yolo)).catch(
           (commentErr) => console.error(`[create-ui-design] commentOnIssue failed for #${issueNumber}: ${commentErr}`),
         );
         return false;


### PR DESCRIPTION
## 概要

デザインには人が介在したい場合があるため、`claude-task-worker.json` の `uiDesign` に `yolo` オプション（boolean、既定 `false`）を追加した。`true` のときだけ `create-ui-design` が作るデザインPRへ `cc-triage-scope` を付与する。

## 変更内容

- `src/config.ts` — `UiDesignConfig.yolo` を追加。`parseUiDesignEntry()` は非 boolean を警告して既定（`false`）へ倒す
- `src/workers/create-ui-design.ts` — `onCompleted` で `cc-ui-design` は常に付与、`cc-triage-scope` は `yolo === true` のときのみ。false 時は理由をログ出力。ラベル付与失敗コメントも yolo に応じてラベル一覧を出し分け
- `src/config.test.ts` — 既定値・読み取り・非 boolean フォールバック・警告件数
- `README.md` / `CLAUDE.md` / `plugin/skills/create-ui-design/SKILL.md` — 設定表・フロー図・レビュー経路の記述を更新

## 挙動

- `yolo: false`（既定）: デザインPRは `cc-ui-design` のみ。`triage-pr` が拾わないので人がレビュー・マージするまで停止し、`apply-ui-design` の preflight が MERGED まで skip し続ける
- `yolo: true`: 従来どおり `cc-triage-scope` が付き、`triage-pr` / `fix-review-point` / `resolve-conflict` の既存フローで自動レビュー・自動マージまで流れる

既存の `uiDesign.enabled: true` なリポジトリは、設定を追記しない限りデザインPRの自動マージが止まる方向に挙動が変わる。従来挙動を維持するには `"yolo": true` を明示する。

## 検証

- `npx tsc --noEmit`: エラーなし
- `npm test`: 288 tests pass
- `npx eslint src plugin`: 警告なし
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * UIデザイン先行ワークフローに `uiDesign.yolo` 設定を追加しました。
  * 有効にすると、デザインPRを通常の自動トリアージ経路へ進められます。
  * 無効時（既定）は、人によるレビュー・マージ完了まで後続処理を待機します。
  * デザインPRには、設定に応じたラベルが自動付与されます。

* **ドキュメント**
  * 設定項目、ラベル、ブランチ条件、レビュー・マージフローの説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->