### PR TITLE
feat: pencil-design-updater で Pencil MCP の使用を禁止する

### DIFF
--- a/plugin/agents/pencil-design-updater.md
+++ b/plugin/agents/pencil-design-updater.md
@@ -1,6 +1,7 @@
 ---
 name: pencil-design-updater
 description: "Pencilの.penデザインファイルをAIプロンプトで更新・編集・新規作成する際に使用するエージェント。ボタンやセクションの追加、レイアウト変更、色やテキストの修正、コンポーネントの調整など既存の.penデザインに手を入れるタスク全般と、新しい.penデザインファイルの作成、.penファイルのgitコンフリクト解消を担当する。編集・作成後は対象Nodeのスクリーンショットを必ず残す。例:\\n\\n<example>\\nContext: ユーザーが既存のPencilデザインに要素を追加したい。\\nuser: \"designs/login.pen のパスワード入力欄の下に『パスワードをお忘れですか？』リンクを追加して\"\\nassistant: \"pencil-design-updaterエージェントを使用してlogin.penを更新します\"\\n<commentary>\\n.penファイルのデザイン更新タスクなので、pencil-design-updaterエージェントを起動してedit-pencil-designスキル経由で安全に編集する。\\n</commentary>\\n</example>\\n\\n<example>\\nContext: ユーザーがPencilデザインのレイアウトやスタイルを変更したい。\\nuser: \"ダッシュボードのサイドバーに Reports と Billing のメニューを足しておいて。dashboard.pen ね\"\\nassistant: \"pencil-design-updaterエージェントを使用してサイドバーにメニュー項目を追加します\"\\n<commentary>\\n既存.penデザインの修正依頼なので、pencil-design-updaterエージェントを使い、編集Nodeのスクリーンショットも残す。\\n</commentary>\\n</example>\\n\\n<example>\\nContext: ユーザーがPencilで作ったデザインの文言や見た目を直したい。\\nuser: \"error-404.pen の見出しを『ページが見つかりません』に変えて\"\\nassistant: \"pencil-design-updaterエージェントを起動して404デザインの見出しを修正します\"\\n<commentary>\\n.penファイルへの編集なので、pencil-design-updaterエージェントでedit-pencil-designスキルを通して上書き更新する。\\n</commentary>\\n</example>"
+disallowedTools: mcp__pencil, mcp__pencil__get_app_state, mcp__pencil__get_guidelines, mcp__pencil__execute, mcp__pencil__get_screenshot, mcp__pencil__export_nodes, mcp__pencil__export_html, mcp__pencil__browser
 model: opus
 effort: max
 color: magenta


### PR DESCRIPTION
## 概要

`pencil-design-updater` エージェントの frontmatter に `disallowedTools` を追加し、Pencil MCP（`mcp__pencil__*`）を使えないようにする。

## 背景

このエージェントがプリロードする3スキル（`edit-pencil-design` / `inspect-pencil-node` / `resolve-pencil-conflict`）は、いずれも `pencil` CLI だけで完結する前提で手順が書かれている（各スキルの description にも「Pencil MCPには依存せず `pencil` コマンドのみで完結」と明記済み）。

MCP 経由の `execute` / `get_app_state` / `get_screenshot` などを混ぜると、スキルが規定する以下のルールが適用されない別経路になる:

- `--in`/`--out` 同パス指定での上書き更新
- `mktemp -d` ＋ `trap` による作業ディレクトリ分離
- 編集前後の Node ツリー差分による編集Node特定
- 数値正規化だけの差分を編集失敗扱いにする検証

## 変更内容

- `plugin/agents/pencil-design-updater.md` の frontmatter に `disallowedTools` を追加
  - サーバー単位指定 `mcp__pencil` に加え、個別7ツール（`get_app_state` / `get_guidelines` / `execute` / `get_screenshot` / `export_nodes` / `export_html` / `browser`）も列挙する二重指定。サーバー単位指定がマッチしない実装でも個別名で確実に落とすため

本文（プロンプト）側への追記はしていない。`disallowedTools` でツール自体が呼べなくなるため、同じ禁止をプロンプトで重複させる必要がない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * Pencil関連のツールを使用しないよう、エージェントの利用可能なツール設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->