### PR TITLE
fix: GitHubラベルの色を重複なし・高コントラストな配色へ更新

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,23 +3,32 @@ import { createLabel } from "../gh";
 import { DEFAULT_CONFIG, DEFAULT_UI_DESIGN_CONFIG, CONFIG_PATH } from "../config.js";
 import { ensureCodegraphGitIgnore, runCodegraphInit } from "./codegraph.js";
 
+// 色は「色相を最低でも約20度ずつ離す」か「同系色相なら明度を大きく離す（明ラベル=黒文字 /
+// 暗ラベル=白文字）」のどちらかを満たすように選んである。GitHub はラベル色の明度から文字色を
+// 自動で決めるため、中間の明度に固めると文字が読みにくいラベルが増える。淡すぎる色
+// （旧 c5def5 / bfd4f2 など）と、同系色に密集していた紫3色・黄2色・ピンク4色は解消済み。
+// 一覧を変更するときは、既存色と色相・明度の両方が近くならないかを確認すること。
 const LABELS: { name: string; color: string }[] = [
-  { name: "cc-update-issue", color: "e4e669" },
-  { name: "cc-answer-issue-questions", color: "5319e7" },
-  { name: "cc-exec-issue", color: "7057ff" },
-  { name: "cc-fix-onetime", color: "d93f0b" },
-  { name: "cc-in-progress", color: "0e8a16" },
-  { name: "cc-need-human-check", color: "b60205" },
-  { name: "cc-issue-created", color: "f9a825" },
-  { name: "cc-pr-created", color: "006b75" },
-  { name: "cc-triage-scope", color: "c5def5" },
-  { name: "cc-resolve-conflict", color: "fbca04" },
-  { name: "cc-epic-issue", color: "8b5cf6" },
-  { name: "cc-release-ready", color: "2da44e" },
-  { name: "cc-create-ui-design", color: "ff8ad8" },
-  { name: "cc-ui-design-pr-created", color: "d4a5e8" },
-  { name: "cc-ui-design-ready", color: "bfd4f2" },
-  { name: "cc-ui-design", color: "ec4899" },
+  // 警告・修正系（暖色）
+  { name: "cc-need-human-check", color: "b60205" }, // dark red
+  { name: "cc-fix-onetime", color: "e8590c" }, // orange
+  { name: "cc-resolve-conflict", color: "ffc53d" }, // amber
+  { name: "cc-update-issue", color: "cddc39" }, // lime
+  // 進行・完了系（緑〜青緑）
+  { name: "cc-in-progress", color: "0e8a16" }, // dark green
+  { name: "cc-release-ready", color: "4ade80" }, // bright green
+  { name: "cc-pr-created", color: "006b75" }, // dark teal
+  // Issueライフサイクル（シアン〜紫）
+  { name: "cc-issue-created", color: "67e8f9" }, // cyan
+  { name: "cc-triage-scope", color: "1f6feb" }, // blue
+  { name: "cc-answer-issue-questions", color: "3730a3" }, // indigo
+  { name: "cc-exec-issue", color: "7c3aed" }, // violet
+  { name: "cc-epic-issue", color: "c4b5fd" }, // light lavender
+  // UIデザイン系（フクシア〜ピンク〜コーラル）
+  { name: "cc-create-ui-design", color: "a21caf" }, // dark fuchsia
+  { name: "cc-ui-design", color: "db2777" }, // magenta
+  { name: "cc-ui-design-pr-created", color: "f9a8d4" }, // light pink
+  { name: "cc-ui-design-ready", color: "ff8a80" }, // coral
 ];
 
 const ISSUE_TEMPLATE = `name: "[claude-task-worker] Issue作成依頼"


### PR DESCRIPTION
## 概要

`claude-task-worker init` が生成する GitHub ラベル16個の色を、重複がなく視認性の高い配色へ更新した。

## 背景

- 紫3色（`5319e7` / `7057ff` / `8b5cf6`）、黄2色（`f9a825` / `fbca04`）、ピンク4色（`ff8ad8` / `d4a5e8` / `ec4899` / `bfd4f2`）、緑2色（`0e8a16` / `2da44e`）が同系色に密集し、一覧上で判別しづらかった
- `c5def5` / `bfd4f2` は淡すぎて視認性が低かった

## 配色方針

「色相を最低でも約20度離す」か「同系色相なら明度を大きく離す」のどちらかを満たすこと。GitHub はラベル色の明度から文字色（黒/白）を自動決定するため、中間の明度に固めると読みにくいラベルが増える。方針はコード上のコメントにも残した。

## 新しい配色

| カテゴリ | ラベル | 色 |
|---|---|---|
| 警告・修正系 | `cc-need-human-check` | `b60205` dark red |
| | `cc-fix-onetime` | `e8590c` orange |
| | `cc-resolve-conflict` | `ffc53d` amber |
| | `cc-update-issue` | `cddc39` lime |
| 進行・完了系 | `cc-in-progress` | `0e8a16` dark green |
| | `cc-release-ready` | `4ade80` bright green |
| | `cc-pr-created` | `006b75` dark teal |
| Issueライフサイクル | `cc-issue-created` | `67e8f9` cyan |
| | `cc-triage-scope` | `1f6feb` blue |
| | `cc-answer-issue-questions` | `3730a3` indigo |
| | `cc-exec-issue` | `7c3aed` violet |
| | `cc-epic-issue` | `c4b5fd` light lavender |
| UIデザイン系 | `cc-create-ui-design` | `a21caf` dark fuchsia |
| | `cc-ui-design` | `db2777` magenta |
| | `cc-ui-design-pr-created` | `f9a8d4` light pink |
| | `cc-ui-design-ready` | `ff8a80` coral |

## 既存リポジトリへの反映

`claude-task-worker init` の再実行で反映される。`createLabel()` が `gh label create --force` を使うため、既存ラベルの色が上書きされる。

## 動作確認

- `npm run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * GitHubラベルを「警告」「進行」「Issueライフサイクル」「UIデザイン」のカテゴリ順に整理しました。
  * 各ラベルの色を見直し、一覧上で識別しやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->