### PR TITLE
feat: GitHubラベルの配色をビビッドに変更

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,37 +3,40 @@ import { createLabel } from "../gh";
 import { DEFAULT_CONFIG, DEFAULT_UI_DESIGN_CONFIG, CONFIG_PATH } from "../config.js";
 import { ensureCodegraphGitIgnore, runCodegraphInit } from "./codegraph.js";
 
-// 全16色は「色相・明度・彩度の3軸すべて」を使って散らしてある。旧配色は彩度を100%に固定し色相
-// だけで散らしていたため、色相環上で等間隔でも実際の見分けは付きにくかった（高彩度域では色相差
-// あたりの知覚差が小さく、ΔE(CIE76) 上は離れていても人の目には近い色になる）。そこで下記の制約
-// 下で「全ペアの最小 ΔE(CIE2000) を最大化する16色」を数値最適化して選び直した。
-// - 全ペアの色差: 最小 ΔE(CIE2000) ≈ 21.6（旧配色は 7.4。CIE76 では旧 30.3 / 新 29.0 とほぼ同値
-//   になるが、CIE76 は高彩度域の色差を過大評価するため実際の見分けやすさを反映しない）
-// - 明度 L* は 30〜89、彩度 C* は 32〜120（平均 58）に分布させ、同系色相でも明度・彩度で分離する
+// cc-triage-scope を除く15色は**ビビッド固定**（HSL 彩度 90〜100 / L* 26〜92 / C* 56〜111、平均
+// C* 75）。その制約下で「全ペアの最小 ΔE(CIE2000) を最大化する15色」を数値最適化して選んである。
+// - 全ペアの色差: 最小 ΔE(CIE2000) ≈ 17.5。彩度を高域に固定すると使える色空間の体積が減るため、
+//   彩度を 32〜120 まで許した旧配色（≈ 21.6）より色差は下がる。見た目のビビッドさを優先した
+//   トレードオフで、17.5 は「隣に並べれば別色と分かる」水準（旧々配色は 7.4 で判別不能だった）
+// - 同系色相は明度で分離する（例: 緑は L*49 の 078834 と L*89 の 3dff64）
 // - 文字とのコントラスト比は全色 4.5:1 以上。GitHub は Primer の perceived-lightness
 //   （= (0.2126R + 0.7152G + 0.0722B) / 255、しきい値 0.6）で文字色を黒/白に自動で振り分ける
 //   ため、その境界（0.50〜0.68）を避けてどちらに転んでも読める側へ寄せてある
+// cc-triage-scope だけは明るいグレー（C* 3）で、ビビッド15色に対する ΔE(CIE2000) が 25 以上ある
+// ことを最適化の制約に入れてある（無彩色を1色だけ置くことで、ラベル一覧上で「まだスコープが
+// 決まっていない」状態が彩度の有無だけで見分けられる）。
 // 見分けやすさを優先した結果、意味的な系統（警告=暖色など）は保証しない（cc-need-human-check の
 // 赤だけは意味を保持するため最適化時に固定した）。色を変更するときは、(1) 他の15色すべてとの
-// ΔE(CIE2000) が 20 以上、(2) perceived-lightness が 0.16〜0.50 か 0.68〜0.93 に収まる、
-// (3) 自動選択される文字色とのコントラスト比が 4.5:1 以上、の3点を確認すること。
+// ΔE(CIE2000) が 17 以上、(2) perceived-lightness が 0.16〜0.50 か 0.68〜0.93 に収まる、
+// (3) 自動選択される文字色とのコントラスト比が 4.5:1 以上、(4) cc-triage-scope 以外は HSL 彩度
+// 90 以上、の4点を確認すること。
 const LABELS: { name: string; color: string }[] = [
-  { name: "cc-need-human-check", color: "e10000" }, // red (H0 S100 L44 / L*47 C*95)
-  { name: "cc-fix-onetime", color: "ffb400" }, // amber (H42 S100 L50 / L*78 C*83)
-  { name: "cc-resolve-conflict", color: "c30a78" }, // magenta (H324 S90 L40 / L*43 C*71)
-  { name: "cc-update-issue", color: "00fae6" }, // cyan (H175 S100 L49 / L*89 C*53)
-  { name: "cc-in-progress", color: "7d6ea5" }, // muted violet (H256 S23 L54 / L*50 C*33)
-  { name: "cc-release-ready", color: "00ff00" }, // green (H120 S100 L50 / L*88 C*120)
-  { name: "cc-pr-created", color: "141edc" }, // blue (H237 S83 L47 / L*30 C*112)
-  { name: "cc-issue-created", color: "783732" }, // maroon (H4 S41 L33 / L*32 C*32)
-  { name: "cc-triage-scope", color: "5abeff" }, // sky (H204 S100 L68 / L*74 C*42)
-  { name: "cc-answer-issue-questions", color: "ff91f5" }, // pink (H305 S100 L78 / L*75 C*64)
-  { name: "cc-exec-issue", color: "285023" }, // dark green (H113 S39 L23 / L*30 C*33)
-  { name: "cc-epic-issue", color: "8c6405" }, // dark gold (H42 S93 L28 / L*45 C*52)
-  { name: "cc-create-ui-design", color: "ffa591" }, // salmon (H11 S100 L78 / L*76 C*39)
-  { name: "cc-ui-design", color: "aab478" }, // sage (H70 S29 L59 / L*71 C*32)
-  { name: "cc-ui-design-pr-created", color: "008273" }, // teal (H173 S100 L25 / L*49 C*34)
-  { name: "cc-ui-design-ready", color: "0073a0" }, // azure (H197 S100 L31 / L*45 C*33)
+  { name: "cc-need-human-check", color: "da0b0b" }, // vivid red (H0 S90 L45 / L*46 C*90)
+  { name: "cc-fix-onetime", color: "f5a542" }, // vivid orange (H33 S90 L61 / L*74 C*64)
+  { name: "cc-resolve-conflict", color: "e90c59" }, // vivid crimson (H339 S90 L48 / L*50 C*79)
+  { name: "cc-update-issue", color: "1af9d8" }, // vivid turquoise (H171 S95 L54 / L*88 C*56)
+  { name: "cc-in-progress", color: "5a3dff" }, // vivid indigo (H249 S100 L62 / L*42 C*111)
+  { name: "cc-release-ready", color: "3dff64" }, // vivid green (H132 S100 L62 / L*89 C*97)
+  { name: "cc-pr-created", color: "0073d1" }, // vivid blue (H207 S100 L41 / L*48 C*57)
+  { name: "cc-issue-created", color: "9e6700" }, // vivid bronze (H39 S100 L31 / L*48 C*58)
+  { name: "cc-triage-scope", color: "d9dde3" }, // light gray (H213 S15 L87 / L*88 C*3)
+  { name: "cc-answer-issue-questions", color: "cb0bd5" }, // vivid magenta (H297 S90 L44 / L*49 C*100)
+  { name: "cc-exec-issue", color: "078834" }, // vivid emerald (H141 S90 L28 / L*49 C*61)
+  { name: "cc-epic-issue", color: "ffeb33" }, // vivid yellow (H54 S100 L60 / L*92 C*84)
+  { name: "cc-create-ui-design", color: "760891" }, // vivid purple (H288 S90 L30 / L*30 C*76)
+  { name: "cc-ui-design", color: "98c70a" }, // vivid lime (H75 S90 L41 / L*75 C*82)
+  { name: "cc-ui-design-pr-created", color: "00398f" }, // vivid navy (H216 S100 L28 / L*26 C*56)
+  { name: "cc-ui-design-ready", color: "9f0459" }, // vivid wine (H327 S95 L32 / L*34 C*60)
 ];
 
 const ISSUE_TEMPLATE = `name: "[claude-task-worker] Issue作成依頼"


### PR DESCRIPTION
## 概要

`claude-task-worker init` が作成する GitHub ラベルの配色をビビッドな色彩へ変更する。`cc-triage-scope` のみ明るいグレーにする。

## 変更内容

- `cc-triage-scope` を除く15色を **HSL 彩度 90〜100 のビビッド域に固定**し、その制約下で全ペアの最小 ΔE(CIE2000) を最大化する組み合わせを数値最適化して選定（≈ 17.5）
- `cc-triage-scope` を明るいグレー `d9dde3`（C* 3）に変更。ビビッド15色との ΔE(CIE2000) が 25 以上あることを最適化の制約に含めた
- 選定基準のコメントを更新（変更時のチェック項目を3点→4点、彩度の下限を追加）

## トレードオフ

彩度を高域に縛ると使える色空間の体積が減るため、彩度 32〜120 を許していた旧配色（最小 ΔE ≈ 21.6）より色差は下がる（≈ 17.5）。見た目のビビッドさを優先した意図的な選択で、17.5 は隣に並べれば別色と分かる水準（さらに旧の配色は 7.4 で判別困難だった）。

## 維持している制約

- 全色のコントラスト比 4.5:1 以上（最小 4.50）
- GitHub の文字色自動切替境界（perceived-lightness 0.50〜0.68）を全色が回避
- `cc-need-human-check` の赤は意味保持のため固定

## 動作確認

- `npm run build` 通過
- 配色の検証スクリプトで最小 ΔE・コントラスト比・perceived-lightness を確認済み
- 既存ラベルの色は `createLabel(..., true)`（force）で更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * ラベルの配色を、より鮮やかで統一感のある15色に刷新しました。
  * `cc-triage-scope` ラベルを明るいグレーに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->