### PR TITLE
fix: ログテーブルを時刻の降順で表示する

### DIFF
--- a/src/table.test.ts
+++ b/src/table.test.ts
@@ -422,6 +422,15 @@ test("buildLogTableLines strips ANSI/control chars so the table stays aligned", 
   assert.equal(widths.size, 1);
 });
 
+test("buildLogTableLines lists newer entries first", () => {
+  const lines = buildLogTableLines([
+    log({ id: 1, text: "older", time: at("2026-07-20T12:00:01") }),
+    log({ id: 2, text: "newer", time: at("2026-07-20T12:00:02") }),
+  ]).join("\n");
+
+  assert.ok(lines.indexOf("newer") < lines.indexOf("older"));
+});
+
 test("buildLogTableLines keeps every row the same display width with wide characters", () => {
   const lines = buildLogTableLines([log({ id: 1, text: "ascii line" }), log({ id: 2, text: "日本語のログ行" })]);
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -262,12 +262,15 @@ function sanitizeLogText(text: string): string {
   return text.replace(CONTROL_CHARS, " ").replace(/\t/g, " ");
 }
 
-/** 実行中タスクの標準出力/エラー出力のログをテーブルに組み立てる純粋関数。 */
+/**
+ * 実行中タスクの標準出力/エラー出力のログをテーブルに組み立てる純粋関数。
+ * 新しい行ほど上に来るよう時刻の降順で並べる（テーブル下端はステータス表示に隠れやすいため）。
+ */
 export function buildLogTableLines(entries: LogTableEntry[]): string[] {
   if (entries.length === 0) return [];
 
   const maxTextWidth = 100;
-  const rows = entries.map((e) => {
+  const rows = [...entries].reverse().map((e) => {
     const text = sanitizeLogText(e.text);
     return [
       formatTime(e.time),


### PR DESCRIPTION
## 概要

ログテーブル（`buildLogTableLines`）の行順を時刻の降順（新しいものが上）に変更した。

## 背景

テーブル下端は他の表示に隠れやすく、昇順だと最新ログが見落とされやすい。

## 変更内容

- `buildLogTableLines` で行を反転して組み立てる（バッファ `logLines` は昇順のまま、表示のみ反転）
- 並び順のテストを追加

## テスト

`npm test` 全300件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - ログテーブルで、新しいログが上部に表示されるようになりました。

- **テスト**
  - ログが時刻の新しい順に表示されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->