### PR TITLE
fix: commit-push の push 先と amend 対象を分岐元から切り離す

### DIFF
--- a/plugin/skills/commit-push/SKILL.md
+++ b/plugin/skills/commit-push/SKILL.md
@@ -3,7 +3,6 @@ name: commit-push
 description: コード変更を適切なgitコミット戦略でgit commitし、pushします。基本的には既存のgitコミットへのsquash戦略を採用し、必要に応じてブランチ全体のgitコミット履歴を再構成します。実装完了時やユーザーがgit commitを依頼した時に使用します。
 model: sonnet
 effort: medium
-context: fork
 ---
 
 # Commit and Push Code Changes
@@ -40,26 +39,41 @@ git status
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-# DEFAULT_BRANCH が正常に取得できた場合のみ git log を実行
-if [ -n "${DEFAULT_BRANCH}" ]; then
-  git log --oneline --graph "origin/${DEFAULT_BRANCH}..HEAD"
+# 分岐元（BASE_BRANCH）を確定する。upstream を最優先し、無ければデフォルトブランチへ倒す。
+# ワーカーは worktree 作成時に `git worktree add --track origin/<base>` で分岐元を upstream に記録している。
+BASE_BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null | sed 's|^origin/||')
+if [ -z "${BASE_BRANCH}" ] || [ "${BASE_BRANCH}" = "${CURRENT_BRANCH}" ]; then
+  BASE_BRANCH="${DEFAULT_BRANCH}"
+fi
+
+# BASE_BRANCH が確定した場合のみ git log を実行
+if [ -n "${BASE_BRANCH}" ]; then
+  git log --oneline --graph "origin/${BASE_BRANCH}..HEAD"
 fi
 ```
 
-確認事項: 現在のブランチ名／デフォルトブランチから何gitコミット進んでいるか（DEFAULT_BRANCH取得成功時）／各gitコミットの内容と粒度
+確認事項: 現在のブランチ名／分岐元（`BASE_BRANCH`）から何gitコミット進んでいるか／各gitコミットの内容と粒度
+
+`CURRENT_BRANCH` が `HEAD`（detached HEAD）の場合は push 先を確定できないため、**commitもpushもせず中断**し、状況を報告して終了する。
+
+**差分の基準を `DEFAULT_BRANCH` ではなく `BASE_BRANCH` にすること**。epic ブランチ（`cc-epic-<N>`）等から派生した作業ブランチでデフォルトブランチを基準にすると、**分岐元に既に載っている他タスクのgitコミットが「このブランチのgitコミット」として並ぶ**。それを既存gitコミットとみなして戦略A（`--amend`）を選ぶと、他タスクのgitコミットを書き換えて自分の変更を混ぜ込むことになる（実際に epic 配下のサブIssueで発生した事故）。
 
 取得した `CURRENT_BRANCH` と `DEFAULT_BRANCH` から、以降のモードを決める:
 
 - **デフォルトブランチモード**（`CURRENT_BRANCH` と `DEFAULT_BRANCH` が一致する場合、**または `DEFAULT_BRANCH` の取得に失敗した場合**）: 公開済み履歴を壊さないため、ステップ2では**戦略B（新規gitコミット）のみ**を採用し（`--amend`＝戦略A・interactive rebase＝戦略Cは使わない）、ステップ5では**force無しのfast-forward push**（`git push origin HEAD`）を使う。取得失敗時もこのモードへ倒すのは、判定できない状態で force push してデフォルトブランチ履歴を壊す事故を避けるため（fail-safe。取得失敗時は `git log` の差分確認はスキップしてよい）。
 - **通常モード**（両者が一致せず、かつ `DEFAULT_BRANCH` も取得できている場合）: feature branch上での作業とみなす。ステップ2の戦略A/B/Cすべてを選べ、ステップ5は `--force-with-lease` 付きpushを使う。
 
+いずれのモードでも、**push 先は必ず `CURRENT_BRANCH`**（ステップ5参照）。`BASE_BRANCH` は差分の基準とPRのベース決定に使う情報であり、push の宛先ではない。
+
 ### ステップ2: gitコミット戦略の判断
 
 > **デフォルトブランチモードでは戦略Bのみを使う**。デフォルトブランチの履歴は既にリモートへ公開されており、`--amend`（戦略A）や interactive rebase（戦略C）で書き換えると他のクローン・CI・オープン中のPRと齟齬が出るため。以下の戦略A/Cは通常モード（feature branch）でのみ選択できる。
 
+> **`git log origin/${BASE_BRANCH}..HEAD` が空（＝このブランチ独自のgitコミットが1件も無い）なら、通常モードでも戦略Bのみを使う**。このとき `HEAD` が指しているのは分岐元のgitコミット（他タスクが作ったもの）であり、`--amend` するとそれを書き換えて自分の変更を混ぜ込むことになる。「既存のgitコミット」とは `origin/${BASE_BRANCH}..HEAD` に現れるgitコミットだけを指す。
+
 #### 戦略A: Squash（基本戦略）
 
-以下を満たす場合、既存のgitコミットにsquashする: ブランチに既にgitコミットが存在し、変更内容が既存のgitコミットと同じテーマ・機能に関連し、gitコミットを分ける合理的な理由がない。
+以下を満たす場合、既存のgitコミットにsquashする: **`origin/${BASE_BRANCH}..HEAD` にこのブランチのgitコミットが存在し**、変更内容が既存のgitコミットと同じテーマ・機能に関連し、gitコミットを分ける合理的な理由がない。
 
 ```bash
 git add -A
@@ -70,7 +84,7 @@ gitコミットメッセージを適切に更新すること。
 
 #### 戦略B: 新規gitコミット
 
-以下の場合は新規gitコミットを作成: ブランチに初めてのgitコミット／既存のgitコミットとは異なる独立した変更／gitコミットを分けることで履歴がより理解しやすくなる。
+以下の場合は新規gitコミットを作成: ブランチに初めてのgitコミット（`origin/${BASE_BRANCH}..HEAD` が空）／既存のgitコミットとは異なる独立した変更／gitコミットを分けることで履歴がより理解しやすくなる。
 
 ```bash
 git add -A
@@ -82,8 +96,10 @@ git commit
 以下の場合はブランチ全体を再構成: 複数の小さなgitコミットの論理的な整理／順序変更／不要なgitコミットの削除／意味のある単位への再編成。
 
 ```bash
-git rebase -i "origin/$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)"
+git rebase -i "origin/${BASE_BRANCH}"
 ```
+
+再構成の対象はステップ1で確定した `BASE_BRANCH` 以降のみ。デフォルトブランチを起点にすると、分岐元に既に載っている他タスクのgitコミットまで書き換え対象に入る。
 
 エディタでの操作: `pick`=そのまま維持／`squash`（`s`）=前のgitコミットと統合／`reword`（`r`）=メッセージ変更／行の順序変更=gitコミット順の変更
 
@@ -113,18 +129,20 @@ gitコミットが正しく作成されたか／意図したファイルがす�
 
 ### ステップ5: 変更のpush
 
+**push 先は常に `CURRENT_BRANCH`**。refspec を `HEAD:${CURRENT_BRANCH}` の形で明示し、宛先を取り違える余地を残さない。`git status` が表示する upstream（`Your branch is up to date with 'origin/<base>'`）は**分岐元であって push 先ではない**。ワーカーの worktree は `--track` で分岐元（例: `origin/cc-epic-<N>`）を upstream に持つため、upstream へ push すると共有ブランチへ直接コミットが載り、PRを作れなくなる（実際に発生した事故）。
+
 ステップ1で判定したモードに応じてpush方法を分ける。
 
 - **通常モード（feature branch）**: rebaseやamendで履歴が変わり得るため `--force-with-lease` を使う。
 
 ```bash
-git push origin HEAD --force-with-lease
+git push origin "HEAD:${CURRENT_BRANCH}" --force-with-lease
 ```
 
 - **デフォルトブランチモード**: 新規コミットを積んだだけのfast-forwardなので、force系フラグは**付けずに**通常pushする。デフォルトブランチへ `--force` / `--force-with-lease` を使うと公開履歴を巻き戻す事故につながるため絶対に付けない。
 
 ```bash
-git push origin HEAD
+git push origin "HEAD:${CURRENT_BRANCH}"
 ```
 
 デフォルトブランチモードのpushがnon-fast-forwardで弾かれた場合は、リモートに未取得のコミットがある状態。force pushで押し込まず、`git fetch` してから `git log origin/${DEFAULT_BRANCH}..HEAD` と `git log HEAD..origin/${DEFAULT_BRANCH}` で差分を確認し、追従（`git pull --ff-only` など）してから再pushする。
@@ -136,18 +154,20 @@ git push origin HEAD
 3. **一貫性**: プロジェクトの既存のgitコミットスタイルに従う
 4. **作業ディレクトリを動かさない**: ステップ0の判定に従う
 5. **デフォルトブランチ上では履歴を書き換えない**: ステップ1のモード判定に従い、新規コミットの追加とforce無しのfast-forward pushに限定する
+6. **push 先は現在ブランチ以外にしない**: upstream・分岐元・epic ブランチ（`cc-epic-<N>`）など、`CURRENT_BRANCH` 以外を宛先にする refspec は使わない
+7. **分岐元のgitコミットを書き換えない**: `--amend` / interactive rebase の対象は `origin/${BASE_BRANCH}..HEAD` に現れるgitコミットに限る
 
 ## 戦略選択のフローチャート
 
 ```
 デフォルトブランチにいる？（DEFAULT_BRANCH 取得失敗も Yes 扱い）
-  ├─ Yes（デフォルトブランチモード）→ 新規gitコミットのみ作成 → force無しでpush（fast-forward）
+  ├─ Yes（デフォルトブランチモード）→ 新規gitコミットのみ作成 → force無しで push origin HEAD:${CURRENT_BRANCH}
   └─ No（feature branch / 通常モード）→ ↓
-ブランチにgitコミットがある？
-  ├─ No → 新規gitコミット作成 → --force-with-lease でpush
+origin/${BASE_BRANCH}..HEAD にgitコミットがある？
+  ├─ No（HEAD は分岐元のgitコミット）→ 新規gitコミット作成（--amend 禁止）→ --force-with-lease で push origin HEAD:${CURRENT_BRANCH}
   └─ Yes → 変更は既存のgitコミットと同じテーマ？
-      ├─ Yes → Squash（git commit --amend）→ --force-with-lease でpush
+      ├─ Yes → Squash（git commit --amend）→ --force-with-lease で push origin HEAD:${CURRENT_BRANCH}
       └─ No → gitコミットを分ける合理性がある？
-          ├─ Yes → 新規gitコミット作成 → --force-with-lease でpush
-          └─ 履歴を整理したい → Interactive Rebase → --force-with-lease でpush
+          ├─ Yes → 新規gitコミット作成 → --force-with-lease で push origin HEAD:${CURRENT_BRANCH}
+          └─ 履歴を整理したい → Interactive Rebase（origin/${BASE_BRANCH} 起点）→ --force-with-lease で push origin HEAD:${CURRENT_BRANCH}
 ```


### PR DESCRIPTION
## 背景

igsa-ai/dementia_app#5482 で、サブIssueの実装が feature ブランチではなく共有の epic ブランチ `cc-epic-5324` へ直接 push され、PRを作成できなくなった。調査したところ、同じ原因で兄弟Issue #5487 の実行が **他タスクのコミットを `git commit --amend` で書き換える** 事故も連鎖して起きていた（#5482 の変更が `Closes #5487` のPRに紛れて混入）。

原因は `commit-push` が「このブランチ独自のコミット」と「push 先」の判定材料を持っていなかったこと。epic 由来 worktree では判定材料が2つとも嘘をつく。

1. `git status` の `Your branch is up to date with 'origin/cc-epic-5324'`
   ワーカーは `git worktree add --track origin/<base>` で分岐元を upstream に記録している（`create-pr` のベース導出用）。この表示を push 先と誤読した。
2. 差分基準が `origin/${DEFAULT_BRANCH}..HEAD` 固定
   epic 由来 worktree では他サブIssueのコミットが全部並ぶため、戦略A（squash = `--amend`）の条件「既存コミットがあり同じテーマ」が成立してしまう。#5487 のケースでは tip が同じ「声メモボタンの色」を触る #5482 のコミットで、テーマまで一致していた。

モード判定は `CURRENT_BRANCH` vs `DEFAULT_BRANCH` の比較しかなく、epic ブランチは default ではないので通常モード（amend 可・force-with-lease 可）に落ちていた。

## What

- ステップ1: `BASE_BRANCH` を導出（upstream 優先 → 未設定/自分自身なら `DEFAULT_BRANCH`）。差分表示を `origin/${BASE_BRANCH}..HEAD` へ変更
- ステップ2: `origin/${BASE_BRANCH}..HEAD` が空なら戦略Bのみ（`--amend` 禁止）。戦略Aの条件を同 range 内のコミット存在へ厳密化。戦略Cの rebase 起点を `origin/${BASE_BRANCH}` へ
- ステップ5: push を `git push origin "HEAD:${CURRENT_BRANCH}"` に固定（両モード）
- detached HEAD（`CURRENT_BRANCH` が `HEAD`）は push 先を確定できないため中断
- 注意事項・フローチャートを上記に整合

## 検証

`dementia_app` の実 worktree 3件でステップ1のスニペットを実行:

```
wt=exotic-comet-8016   CURRENT=exotic-comet-8016  BASE=cc-epic-5324   own_commits=0
wt=radiant-lark-9088   CURRENT=dependabot/...     BASE=自分自身→main へ fallback
wt=recursing-heyrovsky CURRENT=HEAD               BASE=空→中断
```

1件目が #5487 の事故と同じ状態（epic 由来・独自コミット0件）。新ルールでは `--amend` に入れず、push 先も自ブランチに固定される。3件目の detached HEAD は検証中に判明したケースで、`HEAD:HEAD` という壊れた refspec を組まないよう中断ガードを追加した。

## 未対応

- `resolve-pr-conflict` の `git push origin HEAD --force-with-lease` は据え置き。`gh pr checkout` 起点で upstream が自分自身のため、誤読を誘う `git status` 表示が出ない
- 既に `cc-epic-5324` へ載ったコミットの巻き戻しは行っていない（共有ブランチのため人手判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * コミット対象の基準ブランチを明確化し、履歴確認の精度を向上しました。
  * ブランチ固有の変更がない場合、不要な squash や rebase を実行しないようにしました。
  * 通常の push では安全な強制更新を使用し、デフォルトブランチへの push では強制更新を行わないようにしました。
* **ドキュメント**
  * ブランチの分岐元、コミット、push の流れと注意事項を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->