### PR TITLE
fix(create-pr): 引数から Issue 番号を抽出して `Closes #` の欠落を防ぐ

### DIFF
--- a/plugin/skills/create-pr/SKILL.md
+++ b/plugin/skills/create-pr/SKILL.md
@@ -13,11 +13,30 @@ GitHubでPull Request（PR）を作成するスキルです。Instructionsに従
 
 # Instructions
 
+## ステップ0: Issue番号の確定
+
+引数（`$ARGUMENTS`）から Issue 番号を取り出し、以降のすべてのステップで `${ISSUE_NUMBER}` を使う。
+
+```bash
+ISSUE_NUMBER=$(printf '%s' "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+```
+
+**先頭トークンを指すプレースホルダを直接使わないこと**。呼び出し元が
+`Issue #1948 の実装PRを作成してください。ブランチ: ...` のような自然文を渡すと
+先頭トークンは `Issue` になり、`Closes #Issue` という壊れた本文が生成されて
+マージしてもIssueが自動クローズされない（セッションログの実測で 392 件中 15 件発生し、
+`Closes` 行が欠落したPRが実際に作られている）。呼び出し元はIssue番号だけを渡す規約だが、
+本スキル側で数字を抽出して壊れないようにする。
+
+数字が1つも取れない場合は `ISSUE_NUMBER` を空のままにし、後続のステップは
+「Issue番号が渡されなかった場合」として扱う（ベースブランチはステップ2以降で決定し、
+`Closes` 行は書かない）。
+
 ## PR作成ルール
 
 - PRのdescriptionのテンプレートは`.github/PULL_REQUEST_TEMPLATE.md`を参照し、それに従うこと
 - テンプレート内でコメントアウトされている箇所は必ず削除すること
-- PRのdescriptionには`Closes #$0`と記載すること
+- PRのdescriptionには`Closes #${ISSUE_NUMBER}`と記載すること（`ISSUE_NUMBER` が空の場合は `Closes` 行を書かない）
 - `gh api user --jq '.login'`で取得したユーザーをAssigneesに追加すること
 - PRのベースブランチは「ベースブランチの決定」の手順で決定したブランチにすること
 - PRに`cc-triage-scope`ラベルを付与すること
@@ -26,7 +45,7 @@ GitHubでPull Request（PR）を作成するスキルです。Instructionsに従
 
 ベースブランチは以下の優先順で決定する。必ず 1 → 2 → 3 の順に試すこと。
 
-1. **Epicブランチの確定的導出**: Issue `$0` が parent（Epic Issue）を持つ場合、`cc-epic-<parent番号>` をベースにする
+1. **Epicブランチの確定的導出**: Issue `${ISSUE_NUMBER}` が parent（Epic Issue）を持つ場合、`cc-epic-<parent番号>` をベースにする
 2. **upstream（追跡ブランチ）からの確定的導出**: 現在のブランチの upstream が origin の別ブランチを指している場合、それをベースにする（ワーカーが worktree 作成時に `--track` で分岐元を記録している）
 3. **分岐元ブランチの推定（fallback）**: 1・2 のいずれでも決まらない場合のみ、merge-base距離で分岐元を推定する
 
@@ -39,11 +58,11 @@ git fetch origin --prune
 
 BASE_BRANCH=""
 
-# Issue 番号が指定されている場合のみ実行
-if [ -n "$0" ]; then
+# Issue 番号を取り出せた場合のみ実行
+if [ -n "${ISSUE_NUMBER}" ]; then
   # gh issue view が失敗した場合はエラーを報告して中断
-  PARENT=$(gh issue view "$0" --json parent --jq '.parent.number // empty') || {
-    echo "Error: Failed to retrieve Issue #$0" >&2
+  PARENT=$(gh issue view "${ISSUE_NUMBER}" --json parent --jq '.parent.number // empty') || {
+    echo "Error: Failed to retrieve Issue #${ISSUE_NUMBER}" >&2
     exit 1
   }
   if [ -n "${PARENT}" ] && git rev-parse --verify --quiet "refs/remotes/origin/cc-epic-${PARENT}" >/dev/null; then
@@ -52,7 +71,7 @@ if [ -n "$0" ]; then
 fi
 ```
 
-引数のIssue番号が渡されていない場合（`$0`が空）は本ステップをスキップし、`BASE_BRANCH` を空のままステップ2へ進む。Issue番号が指定されているが `gh issue view` の実行に失敗した場合（ネットワークエラー・権限不足等）はエラーメッセージを出力して処理を中断する。
+Issue番号を取り出せなかった場合（`ISSUE_NUMBER` が空）は本ステップをスキップし、`BASE_BRANCH` を空のままステップ2へ進む。Issue番号が指定されているが `gh issue view` の実行に失敗した場合（ネットワークエラー・権限不足等）はエラーメッセージを出力して処理を中断する。
 
 ### 2. upstream（追跡ブランチ）からの確定的導出
 
@@ -109,7 +128,7 @@ fi
 ```bash
 gh pr create \
   --title "PRタイトル" \
-  --body "$(printf 'Closes #%s\n\nPRの本文' "$0")" \
+  --body "$(printf 'Closes #%s\n\nPRの本文' "${ISSUE_NUMBER}")" \
   --base "${BASE_BRANCH}" \
   --assignee "$(gh api user --jq '.login')" \
   --label "cc-triage-scope"

--- a/plugin/skills/exec-issue/SKILL.md
+++ b/plugin/skills/exec-issue/SKILL.md
@@ -347,7 +347,7 @@ git diff "origin/${BASE_BRANCH}..HEAD" --stat
 ## フェーズ7: コミットとPR作成
 
 1. `commit-push` skill を呼び出し、変更をコミット・push
-2. `create-pr` skill を `$0` で呼び出し、PRを作成
+2. `create-pr` skill を呼び出し、PRを作成。**args には Issue 番号だけを渡す**（`Skill(skill='claude-task-worker:create-pr', args='$0')`）。ブランチ名や変更内容を添えた自然文を渡さないこと（`create-pr` は数字を抽出して動くが、番号以外を渡す必要はない）
 3. **PR作成の成否を必ず検証する**。現在ブランチに対応するOpen PRが実在するかを確認する：
    ```bash
    HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
## 問題

`create-pr` は `$0`（引数の**先頭トークン**）をそのまま Issue 番号として使っていた。呼び出し元が自然文を渡すと壊れる:

```
args = 'Issue #1948 の実装PRを作成してください。ブランチ: quiet-axe-0297、ベース: main。変更内容: …'
       ↓ $0 は先頭トークンだけ
Closes #Issue
```

マージしてもIssueが自動クローズされない。`exec-issue` の `onCompleted` は「head ブランチ一致」でも `cc-pr-created` を通すため、検知もされずに素通りする。

## 実測

セッションログ（`~/.claude/projects/**/*.jsonl`、2026-07-12〜08-11）で `Skill(skill='…create-pr', args=…)` の呼び出し426件と、fork 側に注入されたスキル本文410件を突き合わせた。

args 付き392件のうち **15件が非数値の自然文**。呼び出し元は `exec-issue` 14件・`create-article` 1件で、07-12 / 07-15 / 07-23 / 07-28 / 08-01 / 08-07 に分散しており一時的な回帰ではない。

実害も確認した:

| Issue | PR | `Closes` 行 |
|---|---|---|
| stratia-app #1948 | PR #1998 | **なし** |
| stratia-app #1976 | PR #1984 | **なし** |
| stratia-app #2011 | PR #2030 | あり（モデルが文中から拾って復旧） |

## 修正

呼び出し元それぞれにルールを足すより、全呼び出しが通る `create-pr` 側で1回直すほうが小さい。ステップ0を新設した:

```bash
ISSUE_NUMBER=$(printf '%s' "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
```

以降のすべてのステップ（`Closes #` テンプレート・`gh issue view` による parent 導出・`gh pr create` の例）で `$0` の代わりに `${ISSUE_NUMBER}` を使う。数字が1つも取れない場合は従来どおり「Issue番号が渡されなかった場合」として扱い、ベースブランチはステップ2（upstream からの確定的導出）以降で決定し、`Closes` 行は書かない。

あわせて `exec-issue` フェーズ7の委譲指示を「**args には Issue 番号だけを渡す**」と明示し、自然文が渡ること自体を減らした（防御の二層目）。

## 補足: fork の args バグは解消済み

調査の副産物として、`context: fork` のスキルへ Skill ツール経由の args が届かない Claude Code のバグ（anthropics/claude-code#34164）が上流で解消済みであることを同じログで確認した。

| 呼び出し側 | fork 側の `$0` | 件数 |
|---|---|---:|
| args あり | 数値に置換 | 377 |
| args あり | 置換されたが数値でない（＝本PRで直す件） | 15 |
| args なし | `$0` のまま | 15 |
| args なし | その他 | 2 |

「args を渡したのに未置換」は **0件**。かつての argsファイル二重チャネル回避策は不要のまま。

## テスト

`npm test` 300/300 通過。変更は SKILL.md 2ファイルのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)