### PR TITLE
fix(worker): 起動直前に blockedBy を実体確認してブロック中Issueの実行を防ぐ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ SKILL.md のプリアンブル（`!` インライン実行）のコマンドが�
 2. `waitForHerdrTask()` が agentステータスをポーリングし、**`done`**、または**一度 `working` を観測した後の `idle`** を完了とみなす（後者の seenWorking ガードは起動直後の `idle`/`unknown` を完了と誤判定しないため）。`blocked` は人が herdr のペインで解除する前提で待機を継続し、ステータステーブルには `running:blocked` と表示する。ペイン消失（`pane_not_found`）は失敗扱い
 3. 完了時の出力（`claude -p` の stdout・exit code の代替）は **transcript 優先・ペイン内容フォールバック**の2段構え。`agentGet` が返す claude のセッションID（`agent_session.value`）を鍵に `~/.claude/projects/*/<sessionId>.jsonl` を引き、最終アシスタント発言を Slack 通知本文に使う（`src/transcript.ts`）。引けない場合のみ `paneRead --source recent` のペイン内容を使い、空振り検知（内容が空なら失敗）もそちらで行う
    - **ペイン内容をそのまま通知に載せると装飾しか届かない**。TUI のペインは「会話ログ + 空行パディング + 入力ボックス + ステータスバー」で構成され、Slack 通知は末尾1000文字しか載せないため、実際に届くのは罫線・`❯` プロンプト・`ctx 7% │ 5h 26%` といった TUI のクロームだけになる（完了報告は空行パディングより上にあり切り落とされる）
-   - transcript のプロジェクトディレクトリ名は cwd のエンコード結果（実測で `dementia_app` → `dementia-app` と不可逆）なので再現しようとせず、UUID であるセッションIDでディレクトリを総なめして探す（`findTranscriptPath()`）
+   - transcript のプロジェクトディレクトリ名は cwd のエンコード結果（実測でアンダースコアがハイフンへ潰れる `my_app` → `my-app` のように不可逆）なので再現しようとせず、UUID であるセッションIDでディレクトリを総なめして探す（`findTranscriptPath()`）
    - サブエージェントの発言（`isSidechain: true`）は除外する。`claude -p` の stdout 相当はメインエージェントの完了報告であり、サブエージェントの報告は途中経過
 4. **出力回収 → `stopHerdrTask()` → 完了コールバック**の順で片付ける。claudeがworktreeを掴んだままだと `removeWorktree()` が失敗しうるため、セッション終了はラベル操作・worktree削除より先に行う
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,13 +57,25 @@ claude-task-worker all             # Run all workers concurrently
 2. 一定間隔（ワーカーごとに設定）でGitHub APIをポーリング
 3. ラベル・アサイン条件でフィルタリング
 4. `isRunning()` で重複実行防止
-5. トリガーラベル除去 → `cc-in-progress` ラベル付与
-6. `.claude/worktrees/<worktreeId>` にワーカー自身がworktreeを生成し（`claude --worktree` は locked worktree の残骸問題があるため不使用）、Claude CLI をそのworktreeをcwdとして起動する（`mode: "default"` は `claude -p` の非同期spawn、`mode: "herdr"` は herdr のタスク専用タブでTUI起動。後述の「`mode`（タスクの実行形態）」参照）
-7. 完了時コールバックでラベル・worktree・ローカルブランチをクリーンアップ
+5. `hasOpenBlockers()` で Open な blockedBy を持つIssueを除外（後述）
+6. トリガーラベル除去 → `cc-in-progress` ラベル付与
+7. `.claude/worktrees/<worktreeId>` にワーカー自身がworktreeを生成し（`claude --worktree` は locked worktree の残骸問題があるため不使用）、Claude CLI をそのworktreeをcwdとして起動する（`mode: "default"` は `claude -p` の非同期spawn、`mode: "herdr"` は herdr のタスク専用タブでTUI起動。後述の「`mode`（タスクの実行形態）」参照）
+8. 完了時コールバックでラベル・worktree・ローカルブランチをクリーンアップ
 
 サブIssue（`parent` を持つIssue）の worktree は `cc-epic-<parent番号>` から作られる（`issue-worker.ts`）。**分析系スキルもこのベースブランチを「ターゲットブランチ」として明示的に導出する**（`create-issue-from-issue-number` / `update-issue` / `answer-issue-questions` の冒頭ステップ。導出ロジックは `exec-issue` / `create-pr` と同一の parent → upstream → default の順）。worktree 自体は正しく epic ブランチ由来なのに、スキル本文がベースブランチの概念を持たないと、モデルが暗黙にデフォルトブランチをターゲットと見なし、**Epic PR（`cc-epic-<N>` → デフォルトブランチ）が未マージであること**を「マージされていないがどうするか」という本来不要な検討事項・確認事項として description や回答コメントへ書き込む。同ステップでは (1) デフォルトブランチとの差分を論点にしない、(2) Epic PR の未マージは正常状態として確認事項化しない、(3) `gh pr list` の関連PRは `baseRefName == BASE_BRANCH` のものだけを対象にする（Epic PR 自身を除外する）、の3点を規定している。
 
 ワーカー起動時には `removeStaleWorktrees()` が前回の異常終了で残ったworktree（`adj-noun-4桁` の生成名パターンのみ対象）を回収する。実行中タスクのworktree・lockedな対話セッションのworktreeは削除対象から保護される。
+
+#### blockedBy ガードの二重化（検索インデックス経由では取りこぼす）
+
+Open な blockedBy（GitHub Issue Dependencies）を持つIssueの除外は、`listIssuesByLabel()` の検索クエリに入れた `-is:blocked` **だけでは足りない**。同修飾子は正しく動作するが、判定材料が検索インデックスなので次の2点で「まだブロック扱いになっていない」Issueを拾いうる:
+
+1. **`gh issue create --blocked-by` が2フェーズ**。Issue作成（ラベル付与含む）と依存登録が別々のAPI呼び出しになるため、Issue の timeline 上でもラベル付与イベントと `blocked_by_added` の間に実測2〜3秒の隙間ができる。`create-issue` のポーリングは60秒間隔なので、この窓に当たると新規スコープIssueを非ブロック状態で掴む
+2. **依存が後付けされる経路がある**。依存を登録するのは `breakdown-issues`（作成時の `--blocked-by`）と `update-issue`（`gh issue edit --add-blocked-by`）だけで、`create-issue` ワーカーが回す `create-issue-from-issue-number` は `post-issue-body` を `mode=edit` で呼ぶ。同スキルは `mode=edit` で `blocked_by` を明示的に無視するため、分析中に依存を発見しても登録できない。実運用の timeline 調査では、blockedBy を持つIssueの大半が作成の数分〜数時間後に初めて `blocked_by_added` を付けられており、その間は検索側のガードでは原理的に止められない
+
+そこで `issue-worker.ts` は候補ループの中で、`isRunning()` の直後・`preflight` の手前に `hasOpenBlockers()`（`gh issue view <n> --json blockedBy`）を挟み、**検索インデックスを経由しない実体**で最終判定する。判定は `-is:blocked` と同じ意味論で、`state === "OPEN"` のブロッカーが1件でもあればスキップする（依存を貼ったまま解消済みのIssueは通す）。取得に失敗した場合は検索側のガードに委ねて続行する（`gh` の一時障害で全ワーカーが止まる方が影響が大きい）。
+
+上記2の「依存が後付けされる」構造自体は残っている（依存が未登録の間は GitHub 側にブロック情報が存在しないため、どのガードでも検出できない）。
 
 ### 同期実行ガード（`claude -p` セッションの早期終了防止）
 

--- a/docs/prd-herdr-mode.md
+++ b/docs/prd-herdr-mode.md
@@ -60,7 +60,7 @@
     "time-card": "/absolute/path/to/time-card"
   },
   "projectGroups": {
-    "igsa": ["time-card"],
+    "web": ["time-card"],
     "all-mine": ["my-app", "time-card"]
   }
 }

--- a/docs/prd-multi-project-dispatch.md
+++ b/docs/prd-multi-project-dispatch.md
@@ -46,7 +46,7 @@
     "time-card": "/absolute/path/to/time-card"
   },
   "projectGroups": {
-    "igsa": ["time-card"],
+    "web": ["time-card"],
     "all-mine": ["my-app", "time-card"]
   }
 }
@@ -84,7 +84,7 @@ claude-task-worker <command> [--project <projectName>] [既存オプション...
 ```bash
 claude-task-worker all --project all
 claude-task-worker all --project my-app --project time-card
-claude-task-worker all --project igsa            # グループ igsa に含まれる全プロジェクト
+claude-task-worker all --project web            # グループ web に含まれる全プロジェクト
 claude-task-worker exec-issue --project my-app --epic 100
 ```
 

--- a/src/gh.test.ts
+++ b/src/gh.test.ts
@@ -6,7 +6,7 @@ import type * as GhModule from "./gh";
 
 const childProcess = createRequire(import.meta.url)("node:child_process") as typeof ChildProcess;
 
-const { hasLabel, findPrNumberClosingIssue } = (await import("./gh")) as typeof GhModule;
+const { hasLabel, hasOpenBlockers, findPrNumberClosingIssue } = (await import("./gh")) as typeof GhModule;
 
 const REPO_INFO_STDOUT = JSON.stringify({
   owner: { login: "getty104" },
@@ -154,4 +154,33 @@ test("findPrNumberClosingIssue returns null when the referencing PR's headRefNam
     }),
   );
   assert.equal(await findPrNumberClosingIssue(1, "adj-noun-1234"), null);
+});
+
+test("hasOpenBlockers returns true when any blockedBy issue is still open", async (t) => {
+  mockExecFile(t, JSON.stringify({ number: 3, blockedBy: { nodes: [{ number: 1, state: "OPEN" }], totalCount: 1 } }));
+  assert.equal(await hasOpenBlockers(3), true);
+});
+
+test("hasOpenBlockers returns false when every blockedBy issue is closed", async (t) => {
+  // 検索の -is:blocked と同じ意味論（Openなブロッカーだけを見る）に揃える。
+  // 依存を貼ったまま解消済みのIssueを止め続けてはいけない。
+  mockExecFile(
+    t,
+    JSON.stringify({
+      number: 3,
+      blockedBy: {
+        nodes: [
+          { number: 1, state: "CLOSED" },
+          { number: 2, state: "CLOSED" },
+        ],
+        totalCount: 2,
+      },
+    }),
+  );
+  assert.equal(await hasOpenBlockers(3), false);
+});
+
+test("hasOpenBlockers returns false when the issue has no dependencies", async (t) => {
+  mockExecFile(t, JSON.stringify({ number: 3, blockedBy: { nodes: [], totalCount: 0 } }));
+  assert.equal(await hasOpenBlockers(3), false);
 });

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -364,6 +364,25 @@ export async function hasLabel(type: "issue" | "pr", number: number, label: stri
   });
 }
 
+/**
+ * Issue が Open な blockedBy（GitHub Issue Dependencies）を持つかを実体から判定する。
+ *
+ * listIssuesByLabel の `-is:blocked` は検索インデックス経由のため、
+ * (1) `gh issue create --blocked-by` が「Issue作成 → 依存付与」の2フェーズで動き
+ *     ラベル付与から依存登録まで実測2〜3秒の隙間があること、
+ * (2) その後もインデックス反映に遅延があること、
+ * の2点で「まだブロック扱いになっていない」Issueを拾いうる。起動直前に本関数で
+ * 引き直すことで、検索インデックスを経由しない実体の状態で最終判定する。
+ */
+export async function hasOpenBlockers(issueNumber: number): Promise<boolean> {
+  return withRetry(async () => {
+    const output = await execGh(["issue", "view", String(issueNumber), "--json", "blockedBy"]);
+    const parsed = JSON.parse(output);
+    const nodes: { state: string }[] = parsed?.blockedBy?.nodes ?? [];
+    return nodes.some((node) => node.state === "OPEN");
+  });
+}
+
 export async function removeLabel(type: "issue" | "pr", number: number, label: string): Promise<void> {
   await withRetry(async () => {
     try {

--- a/src/herdr-runner.test.ts
+++ b/src/herdr-runner.test.ts
@@ -33,7 +33,7 @@ test("toAgentName converts a task tab label into a valid herdr agent name", () =
 test("toAgentName satisfies the herdr agent name rules for tricky inputs", () => {
   // 大文字・全角・記号を含む、数字始まり、先頭記号、超長文字列でも規則を満たす。
   const cases = [
-    taskTabLabel("Dementia_App", 12),
+    taskTabLabel("My_App", 12),
     taskTabLabel("プロジェクト", 7),
     taskTabLabel("123numeric", 9),
     taskTabLabel("a".repeat(60), 999999),

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ Example:
   claude-task-worker all --label priority-high --label needs-design
   claude-task-worker yolo --epic 100 --epic 200 --label priority-high
   claude-task-worker all --project all
-  claude-task-worker all --project igsa
+  claude-task-worker all --project web
   claude-task-worker exec-issue --project my-app --epic 100`);
 }
 

--- a/src/table.test.ts
+++ b/src/table.test.ts
@@ -440,14 +440,18 @@ test("buildLogTableLines keeps every row the same display width with wide charac
 
 // --- captureConsole ---
 
+// 「端末へ出さない」の検証にあたって process.stdout.write を差し替えてはいけない。
+// node:test の子プロセスは実行結果を process.stdout 経由で親へ返すため、差し替えている
+// 間にレポーターが書き込むとその分が失われ、親のデシリアライズが
+// "Unable to deserialize cloned data" で落ちる（個々のテストは全て pass するのに
+// ファイル単位で失敗する）。captureConsole() のパッチ後の console はそもそも端末に
+// 触れないので、パッチ前の console.error が呼ばれないことだけを見れば足りる。
 test("captureConsole keeps console output in the log buffer instead of the terminal", () => {
-  const originalError = console.error;
-  const originalWrite = process.stdout.write.bind(process.stdout);
+  const original = { log: console.log, info: console.info, warn: console.warn, error: console.error };
   let wroteToTerminal = false;
-  process.stdout.write = (() => {
+  console.error = (() => {
     wroteToTerminal = true;
-    return true;
-  }) as typeof process.stdout.write;
+  }) as typeof console.error;
 
   try {
     captureConsole();
@@ -464,7 +468,11 @@ test("captureConsole keeps console output in the log buffer instead of the termi
     const widths = new Set(buildLogTableLines(pushed).map((l) => getDisplayWidth(l)));
     assert.equal(widths.size, 1);
   } finally {
-    process.stdout.write = originalWrite;
-    console.error = originalError;
+    // captureConsole() は console.log/info/warn/error の4つを差し替えるので全て戻す。
+    Object.assign(console, original);
+    // captureConsole() が登録する process.on("exit") は残ログを端末へ書き出す。
+    // 解除手段が無いので、バッファを空にして終了時の書き出し自体を起こさせない
+    // （これも上と同じ理由で stdout を汚してはいけない）。
+    logLines.length = 0;
   }
 });

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -18,8 +18,8 @@ import { join } from "node:path";
  */
 
 // cwd のエンコード規則（`/` と `.` と `_` の扱い）は Claude Code の実装依存で、
-// 実測でも `dementia_app` が `dementia-app` になるなど不可逆。ディレクトリ名を
-// 再現しようとせず、UUID であるセッションIDでディレクトリを総なめする。
+// 実測でもアンダースコアがハイフンへ潰れる（`my_app` → `my-app`）など不可逆。
+// ディレクトリ名を再現しようとせず、UUID であるセッションIDでディレクトリを総なめする。
 export function transcriptRoot(): string {
   return join(homedir(), ".claude", "projects");
 }

--- a/src/workers/issue-worker.ts
+++ b/src/workers/issue-worker.ts
@@ -1,6 +1,14 @@
 import { buildClaudeEnv, buildClaudeExecution } from "../claude-args.js";
 import { getWorkerConfig } from "../config";
-import { getCurrentUser, getRepoInfo, listIssuesByLabel, listIssuesByNumbers, removeLabel, addLabel } from "../gh";
+import {
+  getCurrentUser,
+  getRepoInfo,
+  hasOpenBlockers,
+  listIssuesByLabel,
+  listIssuesByNumbers,
+  removeLabel,
+  addLabel,
+} from "../gh";
 import type { Issue } from "../gh";
 import { syncDefaultBranch, ensureEpicBranch } from "../git";
 import { isRunning, isWorkerAtCapacity, isShuttingDown, run } from "../process-manager";
@@ -68,6 +76,20 @@ export function createIssuePollingWorker(config: IssueWorkerConfig): () => Promi
         for (const issue of candidates) {
           if (isRunning(issue.number)) continue;
           if (isWorkerAtCapacity(config.name)) break;
+
+          // 検索側の -is:blocked は検索インデックス経由で取りこぼしうるため、起動直前に
+          // 実体を引き直す。取得に失敗した場合は検索側のガードに委ねて続行する
+          // （gh の一時障害で全ワーカーが止まる方が影響が大きい）。
+          let blocked = false;
+          try {
+            blocked = await hasOpenBlockers(issue.number);
+          } catch (err) {
+            console.error(`[${config.name}] hasOpenBlockers failed for #${issue.number}: ${err}`);
+          }
+          if (blocked) {
+            console.log(`[${config.name}] #${issue.number}: skipped (blocked by an open issue)`);
+            continue;
+          }
 
           if (config.preflight) {
             const action = await config.preflight(issue);


### PR DESCRIPTION
## 概要

Open な blockedBy（GitHub Issue Dependencies）を持つIssueに対して `create-issue` などのワーカーが起動してしまう問題を修正する。あわせて、公開リポジトリのコメント・ドキュメント・テストフィクスチャに残っていたプライベートリポジトリ由来の固有名を汎用名へ置き換える。

## 原因

ブロック判定が `listIssuesByLabel()` の検索クエリに入れた `-is:blocked` 一本だった（`src/gh.ts`）。同修飾子自体は正しく動作するが、判定材料が検索インデックスのため次の2点で「まだブロック扱いになっていない」Issueを拾いうる。

1. **`gh issue create --blocked-by` が2フェーズ**。Issue作成（ラベル付与含む）と依存登録が別々のAPI呼び出しになるため、Issue の timeline 上でもラベル付与イベントと `blocked_by_added` の間に実測2〜3秒の隙間ができる。`create-issue` のポーリングは60秒間隔なので、この窓に当たると新規スコープIssueを非ブロック状態で掴む
2. **依存が後付けされる経路がある**。依存を登録するのは `breakdown-issues`（作成時の `--blocked-by`）と `update-issue`（`gh issue edit --add-blocked-by`）だけ。`create-issue` ワーカーが回す `create-issue-from-issue-number` は `post-issue-body` を `mode=edit` で呼ぶが、同スキルは `mode=edit` で `blocked_by` を明示的に無視するため、分析中に依存を発見しても登録できない。実運用の timeline 調査でも、blockedBy を持つIssueの大半は作成の数分〜数時間後に初めて `blocked_by_added` が付いており、その間は検索側のガードでは原理的に止められない

## 変更

### ブロック中Issueのガード

- `src/gh.ts`: `hasOpenBlockers(issueNumber)` を追加。`gh issue view <n> --json blockedBy` を引き、`state === "OPEN"` のブロッカーが1件でもあれば `true`。既存の `withRetry` に乗せてある
- `src/workers/issue-worker.ts`: 候補ループの `isRunning()` 直後・`preflight` の手前に共通ガードを挿入。取得失敗時は検索側のガードに委ねて続行する（`gh` の一時障害で全ワーカーが止まる方が影響が大きい）
- `src/gh.test.ts`: 3ケース（Openブロッカーあり / 全CLOSED / 依存なし）。「全CLOSEDは通す」は `-is:blocked` の意味論と揃える回帰止め
- `CLAUDE.md`: ライフサイクルに手順5を追加し、「blockedBy ガードの二重化」節に経緯を記載

`create-issue` 固有ではなく `createIssuePollingWorker` を使う全Issueワーカーが同じ検索ガード一本に依存していたため、根っこ側に1つだけ置いた。

### 固有名の除去（2コミット目）

説明のための実例として実在のプライベートリポジトリ名・組織名が入っていたため、意味を保ったまま汎用名へ置き換える。

- `src/transcript.ts` / `CLAUDE.md`: cwd エンコードの非可逆例を汎用名（`my_app` → `my-app`）へ
- `docs/prd-*.md` / `src/index.ts`: 設定例・ヘルプ中のグループ名を汎用名へ
- `src/herdr-runner.test.ts`: エージェント名の規則を検査するケース名を汎用名へ（大文字とアンダースコアを含むという入力の性質は保持）

## 残る構造的な穴（本PRでは塞いでいない）

原因2の「依存が後付けされる」構造自体は残る。依存が未登録の間は GitHub 側にブロック情報が存在しないため、どのガードでも検出できない。塞ぐならスキル側の仕様変更（`post-issue-body` の `mode=edit` で `blocked_by` を受ける、または `create-issue-from-issue-number` に `gh issue edit --add-blocked-by` を持たせる）になる。

## テスト

- `npm test`: 306件全通過
- `npx tsc --noEmit`: エラーなし
- `npx prettier --check`: 差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)