### PR TITLE
fix(fix-review-point): 非デフォルトブランチへのマージ時に関連Issueを連動Closeする

### DIFF
--- a/plugin/skills/fix-review-point/SKILL.md
+++ b/plugin/skills/fix-review-point/SKILL.md
@@ -114,7 +114,25 @@ GitHub PR `$0` の未解決レビューコメントに対応し、修正のコ�
 - 修正タスクの一覧（目的・対象範囲・完了条件付き）
 - タスク間の依存関係
 
-**修正点がない場合**: `gh pr checks $0` でCIの全チェックが Pass していることを確認する。Pass している場合は `gh pr merge $0 --merge --delete-branch` でPRをマージして終了する。チェックが失敗中の場合はマージせず、CI失敗状況をレビュアーに報告して終了する。
+**修正点がない場合**: `gh pr checks $0` でCIの全チェックが Pass していることを確認する。Pass している場合は `gh pr merge $0 --merge --delete-branch` でPRをマージし、下記「マージ後の関連Issue連動Close」を実行して終了する。チェックが失敗中の場合はマージせず、CI失敗状況をレビュアーに報告して終了する。
+
+### マージ後の関連Issue連動Close
+
+GitHubの `Closes #<issue番号>` 記法による自動クローズは**デフォルトブランチへのマージ時にのみ**発動する。`cc-epic-<N>` のような非デフォルトブランチへ向いたPRをマージしてもIssueは閉じず、Epic のサブIssueが未完のまま残って `create-epic-pr` の起動条件（全サブIssueのクローズ）が満たされなくなる。そのため、マージ前にベースブランチを控えておき、デフォルトブランチと**一致しない**場合のみ明示的にクローズする。
+
+```bash
+BASE_BRANCH=$(gh pr view $0 --json baseRefName -q .baseRefName)
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+```
+
+マージ成功後、`BASE_BRANCH` が `DEFAULT_BRANCH` と一致する場合はGitHubが自動でクローズするためスキップする。一致しない場合はPR本文から関連Issue番号を抽出し、抽出できたすべての番号を `--reason completed`（実装がEpicブランチへ取り込まれた完了クローズ。マージせずクローズする場合の `--reason "not planned"` とは異なる）でクローズする。
+
+```bash
+gh pr view $0 --json body --jq '.body' | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' | grep -oE '[0-9]+'
+gh issue close <issue番号> --reason completed
+```
+
+関連Issueが抽出できない場合は、その旨を最終報告に含めること。
 
 返却内容は後続フェーズで各サブエージェントに渡すため、全文を保持しておくこと。
 


### PR DESCRIPTION
## 概要

`cc-epic-<N>` をターゲットにしたPRをマージしても Issue がクローズされない問題を修正する。

## 原因

GitHub の `Closes #<N>` 記法による自動クローズは**デフォルトブランチへのマージ時にのみ**発動する。非デフォルトブランチ（`cc-epic-<N>`）へ向いたPRのマージでは発動しないため、マージ後に明示的な `gh issue close --reason completed` が必要になる。

この手順を持っているのは、マージを実行する3箇所のうち `triage-pr` だけだった。

| マージ実行箇所 | 連動Close |
|---|---|
| `plugin/skills/triage-pr/SKILL.md:236` パターンB | あり |
| `plugin/skills/fix-review-point/SKILL.md:117` 修正点なし時 | **なし** |
| `plugin/skills/check-dependabot/SKILL.md:168` パターンB | なし（実害なし） |

漏れる経路は以下:

1. `triage-pr` がパターンA（`cc-fix-onetime`）を付与
2. `fix-review-point` 起動 → `create-review-fix-plan` が「修正点なし」を返す（CI がリトライで緑になった／コメントが既に Resolve 済み 等）
3. `fix-review-point` が自分でマージして終了 → `triage-pr` の連動Closeを通らない

`8c36b45` で `triage-pr` のパターンC（`cc-need-human-check`）を「差分をどう変更しても直らないCI失敗」だけに絞り、それ以外のCI失敗を全てパターンAへ倒すようにしたため、この経路を通るPRが増えていた。

## 波及

`src/workers/epic-issue.ts:26` の `preflight` が全サブIssueのクローズを起動条件にしているため、1件でも閉じ残ると Epic PR が作られず Epic 全体が停止する。

## 変更内容

`fix-review-point` のフェーズ1「修正点がない場合」に、`triage-pr` と同じ連動Close手順を追加した。マージ前に `baseRefName` を控え、デフォルトブランチと**一致しない**場合のみ PR 本文から `Closes #<N>` を抽出して `--reason completed` でクローズする。

## 対応範囲外

`check-dependabot` は同じ手順を持たないが未修正。Dependabot PR はベースがデフォルトブランチ固定で、本文に `Closes #<N>` も持たないため。ベースが可変になった時点で同じ手順を足す。

既に閉じ残っているサブIssueは手動クローズが必要（本PRでは対応しない）。洗い出しは以下:

```bash
gh pr list --state merged --base "cc-epic-<N>" --json body --jq '.[].body' | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 修正点がない場合、PRのマージ後に本文から関連Issueを検出し、完了理由を付けて自動的にクローズできるようになりました。
  * デフォルトブランチ以外へのマージ時のみ、この処理が実行されます。
  * 関連Issueを特定できない場合は、最終報告にその旨を記載します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->