### PR TITLE
fix(breakdown-issues): AskUserQuestion を使えるよう context: fork を外す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,9 @@ Open な blockedBy（GitHub Issue Dependencies）を持つIssueの除外は、`l
 
 効かない宣言を残すと「このスキルは sonnet で動いている」という誤った前提でコスト試算やモデル調整をしてしまうため、`src/skill-frontmatter.test.ts` の「a skill declaring model/effort also declares context: fork」で機械的に固定してある。あわせて**ワーカー起動スキル（12個）には `model:` も `context:` も書かない**ことも同ファイルで固定している（ワーカーのモデルは `claude-task-worker.json` の `workers.<name>.model` が決めるため、スキル側に書くとその設定を上書きしてしまう）。
 
-fork するスキル: `create-pr` / `check-library` / `create-review-fix-plan` / `resolve-pr-comments` / `commit-push` / `resolve-pencil-conflict` / `breakdown-issues` / `update-coding-guidelines` / `update-requirement-rules` / `update-design-md`。
+fork するスキル: `create-pr` / `check-library` / `create-review-fix-plan` / `resolve-pr-comments` / `commit-push` / `resolve-pencil-conflict` / `update-coding-guidelines` / `update-requirement-rules` / `update-design-md`。
+
+**`AskUserQuestion` を使うスキルは fork してはいけない**。fork したスキルは別コンテキストのサブエージェントとして走り、ユーザーと直接会話できないため同ツールが使えない。`breakdown-issues` はステップ3で不明点をユーザーへ質問する設計なので `context: fork`（および fork 前提の `model:` / `effort:`）を持たせず、呼び出し元セッションのモデルでそのまま走らせる。
 
 **`context: fork` へ Skill ツール経由の args は届く**。かつて Claude Code のバグ（anthropics/claude-code#34164）で届かず argsファイルの二重チャネルで回避していたが、上流で修正済み。実運用のPRで `create-pr` に渡した Issue 番号が `Closes #<N>` とベースブランチ（`cc-epic-<N>`）の両方に正しく反映されていることを確認している。
 

--- a/plugin/skills/breakdown-issues/SKILL.md
+++ b/plugin/skills/breakdown-issues/SKILL.md
@@ -2,9 +2,6 @@
 name: breakdown-issues
 description: "依頼された内容を要件とTODOに分解し、タスクごとにGitHub Issueを作成するスキル。タスクの整理・分解、複数Issueの一括作成、依存関係の明示が必要な場合に使用する。「この機能をIssueに分けて」「タスクを洗い出してIssueにして」「要件を整理してチケット化して」といったリクエストで発動する。"
 argument-hint: "[task-description]"
-model: opus
-effort: high
-context: fork
 ---
 
 # Breakdown Issues


### PR DESCRIPTION
## 概要

`/breakdown-issues` を実行すると「`AskUserQuestion` が使えない」という返答になる問題を修正する。

## 原因

`plugin/skills/breakdown-issues/SKILL.md` に `context: fork` が宣言されていた。fork したスキルは別コンテキストのサブエージェントとして実行されるため、ユーザーと直接会話できず `AskUserQuestion` を呼べない。一方、同スキルのステップ3は「不明点があれば `AskUserQuestion` でユーザーに質問し、解消するまで繰り返す」という設計になっており、フロントマターと本文が矛盾していた。

`src/claude-args.ts` の `DISALLOWED_TOOLS` は無関係（ワーカー起動の `claude -p` にのみ適用され、対話セッションからの `/breakdown-issues` には掛からない）。

## 変更内容

- `plugin/skills/breakdown-issues/SKILL.md` から `context: fork` を削除。あわせて `model: opus` / `effort: high` も削除する（fork が無いと無視される宣言であり、`src/skill-frontmatter.test.ts` の「model/effort 宣言は `context: fork` を併記する」テストが両者のセットを強制するため）
- `CLAUDE.md` の fork スキル一覧から `breakdown-issues` を除外し、「`AskUserQuestion` を使うスキルは fork してはいけない」という制約を追記

## 影響

`breakdown-issues` は呼び出し元セッションのモデルで実行される。ステップ3の質問フローが意図どおり動作するようになる。

## テスト

`npm test` — 306件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更点**
  - `breakdown-issues` スキルをフォーク対象から除外しました。
  - ユーザーへの質問処理を、呼び出し元のコンテキストで実行するよう更新しました。
  - スキルの実行設定を見直し、専用モデル・高負荷設定・フォーク実行の指定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->