### PR TITLE
fix(check-dependabot): dependencies ラベルを完了時に外さない

### DIFF
--- a/src/workers/check-dependabot.ts
+++ b/src/workers/check-dependabot.ts
@@ -6,7 +6,12 @@ export const checkDependabotWorker = createPrPollingWorker({
   command: "/claude-task-worker:check-dependabot",
   triggerLabel: "dependencies",
   excludeLabels: ["cc-triage-scope"],
-  onCompleted: async (pr) => {
+  // `dependencies` は Dependabot が付けるPRの分類ラベルであり、ワーカーの作業状態を
+  // 表すものではない。マージに至らずPRが残る場合に外れると分類情報が失われるため維持する。
+  keepTriggerLabel: true,
+  // トリガーラベルを維持する以上、除外ラベルは成否に関わらず付ける必要がある
+  // （失敗時に付けないと `dependencies` のまま毎ポーリングで再実行し続ける）。
+  onFinally: async (pr) => {
     await addLabel("pr", pr.number, "cc-triage-scope");
   },
 });

--- a/src/workers/pr-worker.ts
+++ b/src/workers/pr-worker.ts
@@ -30,6 +30,13 @@ interface PrWorkerConfig {
   command: string;
   triggerLabel: string;
   excludeLabels?: string[];
+  /**
+   * 完了時にトリガーラベルを外さない。`dependencies` のように GitHub 側（Dependabot）が
+   * 付ける分類ラベルをトリガーに使うワーカー向け。ワーカーが外すとPRの分類情報が失われる。
+   * 使う場合、再ポーリングで無限に拾い続けないよう `onFinally` で `excludeLabels` に
+   * 含まれるラベルを必ず付けること。
+   */
+  keepTriggerLabel?: boolean;
   onCompleted?: (pr: PullRequestWithChecks, output: string) => Promise<void>;
   onFinally?: (pr: PullRequestWithChecks) => Promise<void>;
 }
@@ -117,11 +124,13 @@ export function createPrPollingWorker(config: PrWorkerConfig): () => Promise<voi
                 } catch (err) {
                   console.error(`[${config.name}] post-task error for PR #${pr.number}: ${err}`);
                 } finally {
-                  await removeLabel("pr", pr.number, config.triggerLabel).catch((err) =>
-                    console.error(
-                      `[${config.name}] removeLabel ${config.triggerLabel} failed for PR #${pr.number}: ${err}`,
-                    ),
-                  );
+                  if (!config.keepTriggerLabel) {
+                    await removeLabel("pr", pr.number, config.triggerLabel).catch((err) =>
+                      console.error(
+                        `[${config.name}] removeLabel ${config.triggerLabel} failed for PR #${pr.number}: ${err}`,
+                      ),
+                    );
+                  }
                   if (hadTriageScope) {
                     await addLabel("pr", pr.number, LABEL_TRIAGE_SCOPE).catch((err) =>
                       console.error(


### PR DESCRIPTION
## 概要

dependabot のタスク実行時、マージに至らなかった際に `dependencies` ラベルが外れてしまう問題を修正。

## 背景

`pr-worker` は完了時に一律で `triggerLabel` を除去する。`check-dependabot` は `dependencies` をトリガーラベルにしているが、これは Dependabot が付ける **PR の分類ラベル**であってワーカーの作業状態を表すものではない。マージされずに PR が残るケースでラベルが失われ、PR の分類情報が消えていた。

## 変更内容

- `PrWorkerConfig` に `keepTriggerLabel?: boolean` を追加し、`check-dependabot` で有効化
- `check-dependabot` の `cc-triage-scope` 付与を `onCompleted` から `onFinally` へ移動

トリガーラベルを残す以上、除外ラベルは成否に関わらず付ける必要がある（失敗時に付かないと `dependencies` が残ったまま毎ポーリングで無限に再実行される）。副次的に、失敗した Dependabot PR も `triage-pr` に載るようになる（従来は `dependencies` が外れて誰も拾わず停止していた）。

## 確認

- `npx tsc --noEmit` パス
- `npm run build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 依存関係更新の自動処理で、トリガーとなるラベルが処理後も維持されるようになりました。
  - 処理が成功した場合だけでなく、失敗した場合も終了時の後処理が実行されるようになりました。
  - プルリクエスト処理では、設定に応じてトリガーラベルを保持または削除できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->