### PR TITLE
feat: ドキュメント更新スキルを24時間おきに走らせる定期ワーカーを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ claude-task-worker create-issue    # Poll cc-triage-scope issues whose blockedBy
 claude-task-worker update-issue    # Poll update-issue labeled issues
 claude-task-worker install         # Add marketplace, install plugin, install/update the CLI itself
 claude-task-worker update          # Update the claude-task-worker plugin/marketplace and the CLI itself
+claude-task-worker update-coding-guidelines  # Run /update-coding-guidelines once per 24h
+claude-task-worker update-requirement-rules  # Run /update-requirement-rules once per 24h
+claude-task-worker update-design-md          # Run /update-design-md once per 24h (uiDesign.enabled only)
 claude-task-worker all             # Run all workers concurrently
 ```
 
@@ -38,6 +41,7 @@ claude-task-worker all             # Run all workers concurrently
 - **`src/commands/design-md.ts`** - DESIGN.md CLI（[`@google/design.md`](https://github.com/google-labs-code/design.md)）連携。`installDesignMdCli()` の1関数のみで、`install` / `update` の**どちらからも同じ関数を呼ぶ**（CodeGraph と違い self-upgrade 機構を持たないため、更新手段が `npm install -g <pkg>@latest` しかない。冪等なので分岐する意味がない）。同パッケージは bin として `design.md` と `designmd` の2つを提供するが、`.` を含む前者は環境によって解決に失敗するためスキル側は **`designmd` を既定**にしている
 - **`src/runcat.ts`** - RunCat Neo 用の利用状況スナップショット書き出し。`~/.claude/runcat-usage.json`（`RUNCAT_OUT_FILE` で上書き可）へ一時ファイル + rename で原子的に書き込む。フォーマットは `~/dotfiles/claude/statusline.py` の出力と揃えてある（`buildRuncatSnapshot`/`resetStamp`/`resetHour`）。ただしリセット時刻は `ceilToMinute()` で秒以下を切り上げて分境界に揃える（API は `:59` 秒でリセット時刻を返すため、切り捨て表示だと 1 分手前に見える）。切り上げが日付・時をまたぐ場合はそれぞれ日付付き表示・次の時に繰り上がる。書き出しは `slack.ts` の `buildTokenLimitText()` 経由で行われるため、`usage` コマンド実行時に加えてワーカーのタスク完了/失敗通知のたびに更新される（Slack webhook 未設定でも通知が no-op になるだけでスナップショットは更新される）。ただし利用状況の取得自体は `/tmp/claude-usage-cache.json` の360秒キャッシュを挟むため、値の鮮度は最大6分古くなりうる
 - **`src/workers/`** - 各ワーカー実装
+- **`src/workers/scheduled-worker.ts`** - 定期ワーカーの共通実装（`createScheduledWorker()`）。Issue/PR をポーリングせず、時刻だけを条件にスキルを起動する。`update-coding-guidelines` / `update-requirement-rules` / `update-design-md` が使う（後述の「定期ワーカー」参照）
 - **`src/workers/ui-design.ts`** - UIデザイン先行ワークフローの純粋ヘルパー（`create-ui-design` / `apply-ui-design` が共有）。`designBranchName()`（`cc-ui-design-<N>`）、`hasDesignReference()`（description のデザイン参照セクション判定）、`classifyDesignPr()`（デザインPRの状態 → preflight 判定）、各種 Issue コメント本文。gh 依存を持たないため分岐だけをユニットテストできる
 - **`plugin/`** - Claude Code プラグイン本体（`.claude-plugin/plugin.json`, `skills/`, `agents/`, `hooks/`, `scripts/`, `.mcp.json`）
 - **`.claude-plugin/marketplace.json`** - このリポジトリを Claude Code マーケットプレイスとして公開するための定義
@@ -93,7 +97,7 @@ Open な blockedBy（GitHub Issue Dependencies）を持つIssueの除外は、`l
 3. **自律実行原則のシステムプロンプト注入**（`src/claude-args.ts`）: `systemPromptFor(model)` の本文を `--append-system-prompt-file <path>` で注入する（`os.tmpdir()/claude-task-worker/append-system-prompt-<pid>-<variant>.txt` へバリアント単位で一度だけ原子的に書き出し、そのパスを渡す `systemPromptFilePath(model)`。`variant` は `opus` / `default` で、opus と sonnet のワーカーが同一プロセスで並走する `all` / `--project` 実行でも互いのファイルを上書きしないようにしている。モデル別の出し分けは後述の「モデル別システムプロンプト」参照）。**文字列を `--append-system-prompt` で直接渡さないのは herdr モードのため**。herdr は agent 引数を `herdr agent start ... -- <args>` としてターゲットシェル経由で起動するが、**改行を含む引数**を `invalid_agent_argument`（"agent arguments cannot be encoded safely for the target shell"）として拒否する。複数行のシステムプロンプトをインラインで渡すと herdr モードのタスク起動が必ずこのエラーで失敗するため、内容をファイルへ逃がして引数から改行を除く。default モード（spawn。シェルを介さないので改行自体は問題ない）でも同じファイル参照を使い、両モードの引数を一致させる。内容は「ワーカーから自動起動されている・ユーザーに質問しない・全ステップを完遂してから終了する・曖昧なら安全側を選び根拠を報告する」に加えて、サブエージェント向けの原則（委譲時に同原則を伝える・子の完了報告を鵜呑みにせず成果物を検証する）も含む。かつてサブエージェントへは `--append-subagent-system-prompt` で直接注入していたが、同フラグは `-p` 非対話モード限定で herdr モードの TUI 起動では使えず、実行形態によって原則の届き方が変わってしまうため、注入経路を `--append-system-prompt` 一本へ統合した（メインエージェントが委譲プロンプトで伝える形になり、注入の確実性は下がるトレードオフを受け入れている）。文面も実行形態に依存しない表現にしてある。スキル本文に自律実行原則を複製しないのは、対話セッションでスキルを手動実行する場合は実在するユーザーと対話してよいため。あわせて**コード探索の原則（CodeGraph 優先）**も同プロンプトに含める（テキスト検索より優先する・**利用可否は codegraph 系 MCP ツールの有無だけで判断する**・無ければ即テキスト検索へ・インデックスのセットアップはしない・返ったソースは読み終えたものとして扱う・委譲時は方針も伝える）。詳細な手順は `plugin/agents/explore-agent.md` にあるが、それはメインエージェント自身が探索する場合や explore-agent 以外のサブエージェントへ委譲する場合には届かないため、全セッション共通の原則としてシステムプロンプト側にも置いている。
 4. **ワーカーレベルの完了検証**（`src/workers/exec-issue.ts` / `epic-issue.ts` の `onCompleted`）: 上記をすり抜けて exit 0 で終了しても、期待成果物を検証できるまでラベル遷移しない最後の砦。exec-issue は「Issue がクローズ済み（変更不要パス）」または「作業ブランチ（worktreeId）を head とする PR か Issue を closing 参照する PR の実在」を確認できた場合のみ `cc-pr-created` を付与し、確認できなければ `cc-need-human-check` を付与して Issue に状況コメントを残す。epic-issue は `cc-epic-<N>` を head とする Epic PR の実在確認後にのみ `cc-pr-created` を付ける。`onCompleted` が `false` を返すと `issue-worker.ts` は完了通知ではなく失敗通知（Slack）を送る。
 
-ワーカー起動スキル12個（`exec-issue` / `fix-review-point` / `answer-issue-questions` / `create-issue-from-issue-number` / `update-issue` / `triage-created-issue` / `triage-pr` / `resolve-pr-conflict` / `check-dependabot` / `create-epic-pr` / `create-ui-design` / `apply-ui-design`）の本文の「実行モードの制約」セクションには、スキル固有のリスク（どのラベル遷移が壊れるか）のみを記述する（自律実行原則は上記 3 の CLI 注入に一元化されており、スキル本文には複製しない）。
+ワーカー起動スキル15個（`exec-issue` / `fix-review-point` / `answer-issue-questions` / `create-issue-from-issue-number` / `update-issue` / `triage-created-issue` / `triage-pr` / `resolve-pr-conflict` / `check-dependabot` / `create-epic-pr` / `create-ui-design` / `apply-ui-design` / `update-coding-guidelines` / `update-requirement-rules` / `update-design-md`）の本文の「実行モードの制約」セクションには、スキル固有のリスク（どのラベル遷移が壊れるか）のみを記述する（自律実行原則は上記 3 の CLI 注入に一元化されており、スキル本文には複製しない）。
 
 ### 実装のサブエージェント委譲（`exec-issue` / `fix-review-point`）
 
@@ -145,9 +149,9 @@ Open な blockedBy（GitHub Issue Dependencies）を持つIssueの除外は、`l
 
 実測での裏付け: opus の `exec-issue` セッション244件すべてでメインスレッドのモデルが単一だった。同スキルは毎回 `commit-push`（当時 `model: sonnet` / fork 無し）を呼んでいるのに、sonnet のターンが1つも現れない。fork 済みの `create-pr` は別コンテキストなのでそもそも同一セッションに現れない。
 
-効かない宣言を残すと「このスキルは sonnet で動いている」という誤った前提でコスト試算やモデル調整をしてしまうため、`src/skill-frontmatter.test.ts` の「a skill declaring model/effort also declares context: fork」で機械的に固定してある。あわせて**ワーカー起動スキル（12個）には `model:` も `context:` も書かない**ことも同ファイルで固定している（ワーカーのモデルは `claude-task-worker.json` の `workers.<name>.model` が決めるため、スキル側に書くとその設定を上書きしてしまう）。
+効かない宣言を残すと「このスキルは sonnet で動いている」という誤った前提でコスト試算やモデル調整をしてしまうため、`src/skill-frontmatter.test.ts` の「a skill declaring model/effort also declares context: fork」で機械的に固定してある。あわせて**ワーカー起動スキル（15個）には `model:` も `context:` も書かない**ことも同ファイルで固定している（ワーカーのモデルは `claude-task-worker.json` の `workers.<name>.model` が決めるため、スキル側に書くとその設定を上書きしてしまう）。
 
-fork するスキル: `create-pr` / `check-library` / `create-review-fix-plan` / `resolve-pr-comments` / `commit-push` / `resolve-pencil-conflict` / `update-coding-guidelines` / `update-requirement-rules` / `update-design-md`。
+fork するスキル: `create-pr` / `check-library` / `create-review-fix-plan` / `resolve-pr-comments` / `commit-push` / `resolve-pencil-conflict`。
 
 **`AskUserQuestion` を使うスキルは fork してはいけない**。fork したスキルは別コンテキストのサブエージェントとして走り、ユーザーと直接会話できないため同ツールが使えない。`breakdown-issues` はステップ3で不明点をユーザーへ質問する設計なので `context: fork`（および fork 前提の `model:` / `effort:`）を持たせず、呼び出し元セッションのモデルでそのまま走らせる。
 
@@ -210,7 +214,7 @@ SKILL.md のプリアンブル（`!` インライン実行）のコマンドが�
 1. **`docker compose down --volumes --remove-orphans`**: 実行cwd直下に compose ファイル（`docker-compose.yml` / `docker-compose.yaml` / `compose.yml` / `compose.yaml`）が存在する場合のみ実行。docker未導入・未起動でも無視して継続する。
 2. **worktree配下を作業ディレクトリに持つ残留プロセスへ `SIGTERM`**: 実行cwd（worktree、`.claude/worktrees/<adj-noun-NNNN>` で一意）を cwd に持つプロセスだけを対象にする。切り離されたプロセスも起動時の cwd を保持し、worktree名はこの実行に固有なため、「この実行が起動したプロセス」だけを、ユーザー自身や別実行のプロセスに触れずに特定できる。ただし本フック自身の祖先チェーン（node フック・そのシェル・`claude` プロセスはいずれもworktreeをcwdに持つ）は除外し、自プロセスの巻き添え停止を防ぐ。プロセス列挙は Linux では `/proc/<pid>/cwd`、macOS 等では `lsof` を用いる。
 
-判定ロジック（`selectPidsToKill` / `parseLsofCwds` / `isUnder` / `resolveTargetDir`）は純粋関数として export し、`plugin/scripts/stop-servers.test.mjs` でユニットテストする。対象スキルは同期実行ガードと同じ12スキル（`exec-issue` / `fix-review-point` / `answer-issue-questions` / `create-issue-from-issue-number` / `update-issue` / `triage-created-issue` / `triage-pr` / `resolve-pr-conflict` / `check-dependabot` / `create-epic-pr` / `create-ui-design` / `apply-ui-design`）。
+判定ロジック（`selectPidsToKill` / `parseLsofCwds` / `isUnder` / `resolveTargetDir`）は純粋関数として export し、`plugin/scripts/stop-servers.test.mjs` でユニットテストする。対象スキルは同期実行ガードと同じ15スキル（`exec-issue` / `fix-review-point` / `answer-issue-questions` / `create-issue-from-issue-number` / `update-issue` / `triage-created-issue` / `triage-pr` / `resolve-pr-conflict` / `check-dependabot` / `create-epic-pr` / `create-ui-design` / `apply-ui-design` / `update-coding-guidelines` / `update-requirement-rules` / `update-design-md`）。
 
 ### `advisor`（アドバイザーモデル）
 
@@ -339,11 +343,23 @@ UI実装Issueについて、実装の前に Pencil（`.pen`）でデザインを
 - **ループ防止**: `update-issue` は同セクションに列挙済みの項目を `confirmation_items` として再掲しない。`triage-created-issue` 側でも、実質同一の問いが再掲されていたら「未回答の新規項目」ではなく引き渡し済み（経路2の対象）として扱う。両側に置いているのは、回答不能 → 確認事項として再掲 → 再委任の往復を片側の実装漏れで作らないため
 - 委任 → `cc-update-issue` → `update-issue` → 再トリアージ、で往復は1回で決着する
 
+### 定期ワーカー（`createScheduledWorker`）
+
+`update-coding-guidelines` / `update-requirement-rules` / `update-design-md` は、Issue・PR のラベルではなく**時刻**だけを条件にスキルを起動する。24時間おきに1回、直近24時間（＝スキルへ渡す期間引数は `1`）を対象に走る。実装は `src/workers/scheduled-worker.ts` の1関数で、3ワーカーは名前・スキル・タスクIDだけが違う。
+
+- **実行記録は `claude-task-worker.json` の `lastRun.<ワーカー名>`（ISO8601）**。ワーカーは worktree 側のファイルへ書き込み、スキルの `commit-push` がその日の成果物（`CODING_GUIDELINES.md` / `.claude/requirements/` / `DESIGN.md`）と**同じコミット・同じPR**に含める。記録が恒久化するのはPRのマージ時点で、それまではプロセス内の起動時刻（`startedAt`）が二重実行を止める。両方を見るのは、PR がマージされるまでの間に毎ポーリングで再起動するのを防ぐため
+- 3スキルとも「差分の有無を判定するときに `claude-task-worker.json` を数えない」規定を持つ。ワーカーが必ず書き込む以上、これが無いと成果物が空でも毎日タイムスタンプだけのPRが立つ
+- `pollingIntervalSeconds`（既定3600）は**実行間隔ではなく「24時間経過したかを確認する頻度」**。実行間隔は `SCHEDULE_INTERVAL_HOURS`（24）で固定
+- タスクIDは `-1` / `-2` / `-3`。`process-manager` の台帳は数値キーで Issue/PR 番号（正数）と共有するため、衝突しないよう負値を割り当てている
+- **`update-design-md` は `uiDesign.enabled` が `true` のときだけ起動する**。DESIGN.md の材料である `cc-ui-design` ラベル付きのマージ済みデザインPRを作るのはデザイン先行フローだけで、無効なリポジトリでは収集対象が原理的に存在しない（毎日空振りのセッションを焼くだけになる）。判定は `index.ts` ではなくワーカー側（`enabled` コールバック）に置き、`all` / `yolo` からの一括起動でも個別コマンドでも同じ経路を通す
+- 3スキルの引数インターフェースは統一してある（`[期間（日数、省略時は1）] [関連Issue番号（任意）]`）。既定を `1` に揃えたのは、ワーカーの実行間隔（24時間）とスキル単体実行時の対象期間を一致させるため。収集スクリプトの `DAYS="${1:-1}"` も同じ既定
+- 3スキルはワーカー起動スキルになったため、`model:` / `effort:` / `context: fork` を持たない（モデルは `claude-task-worker.json` の `workers.<name>.model` が決める）。`src/skill-frontmatter.test.ts` の entrySkills リストで固定してある
+
 ### 要件ルール（`.claude/requirements/`）
 
 対象リポジトリの `.claude/requirements/` に、過去のIssueで確定した**仕様・要件レベルの判断ロジック**を要件タイプ別のマークダウンとして集約する仕組み。ワーカーは介在せず、スキル同士の読み書き契約だけで成立する。
 
-- **書き手**: `update-requirement-rules`（手動起動、`disable-model-invocation: true`）。引数の期間（既定7日）で `cc-triage-scope` / `cc-pr-created` ラベル付きIssueの description とコメントを収集し（`scripts/fetch-recent-requirement-issues.sh`）、複数Issueで反復している判断をルール化して `.claude/requirements/<category>.md` を更新、`commit-push` → `create-pr` でPRを作る（`cc-triage-scope` ラベル + 自分自身をAssignee。`update-coding-guidelines` と同じ経路で、以降のレビュー・マージは `triage-pr` に乗る）
+- **書き手**: `update-requirement-rules`（`update-requirement-rules` ワーカーから24時間おきに自動起動。手動起動も可）。引数の期間（既定7日）で `cc-triage-scope` / `cc-pr-created` ラベル付きIssueの description とコメントを収集し（`scripts/fetch-recent-requirement-issues.sh`）、複数Issueで反復している判断をルール化して `.claude/requirements/<category>.md` を更新、`commit-push` → `create-pr` でPRを作る（`cc-triage-scope` ラベル + 自分自身をAssignee。`update-coding-guidelines` と同じ経路で、以降のレビュー・マージは `triage-pr` に乗る）
 - **読み手**: `create-issue` / `create-issue-from-issue-number` / `answer-issue-questions`。`README.md`（カテゴリ表）を先に読み、**関係するカテゴリファイルだけ**を読む二段構え（全ファイル読み込みはコンテキストを食うだけで判断材料にならない）
 - **`CODING_GUIDELINES.md` との棲み分け**: 判定は「そのルールを知っていると **Issue の description（要件・実装プラン・影響範囲）の書き分けが変わるか**」の1問。変わるなら要件ルール、コードを書く段階でしか効かないなら `CODING_GUIDELINES.md`。「責務をどの層に置くか」「エラー時のふるまい」は仕様にも作法にも読めて境界が引けないため、この問いで機械的に倒す（両方に載せると片方だけ更新されて食い違う）
 - **採用基準**: 独立した2件以上のIssueでの反復（**同一Epic配下の兄弟Issue群は何件あっても1件と数える** — 同じ設計議論を相互参照しながら繰り返すため、形式的には簡単に2件を満たしてしまう）／一般方針の明示／ラベル語彙・ワーカー間の契約・設定スキーマなど共有語彙に触れる判断は1件でも採用
@@ -355,7 +371,7 @@ UI実装Issueについて、実装の前に Pencil（`.pen`）でデザインを
 
 対象リポジトリのルート `DESIGN.md` に、マージ済みUIデザインPRで確定したビジュアルアイデンティティを集約する仕組み。フォーマットは [google-labs-code/design.md](https://github.com/google-labs-code/design.md)（`@google/design.md`）の仕様に従い、YAML フロントマターの機械可読トークン（`colors` / `typography` / `spacing` / `rounded` / `components`）とマークダウン本文の設計意図の2層構成。要件ルールと同じく**ワーカーは介在せず、スキル/エージェント同士の読み書き契約だけで成立する**。
 
-- **書き手**: `update-design-md`（手動起動、`disable-model-invocation: true`）。引数の期間（既定7日）で `cc-ui-design` ラベル付きの**マージ済み**PRを収集し（`scripts/fetch-recent-ui-design-prs.sh`）、レビューコメントと `.pen` の実データからトークン・原則を抽出して `DESIGN.md` を更新、`designmd lint` を通してから `commit-push` → `create-pr` でPRを作る（`cc-triage-scope` ラベル + 自分自身をAssignee。`update-requirement-rules` / `update-coding-guidelines` と同じ経路）
+- **書き手**: `update-design-md`（`update-design-md` ワーカーから24時間おきに自動起動。`uiDesign.enabled` が `true` のリポジトリのみ。手動起動も可）。引数の期間（既定7日）で `cc-ui-design` ラベル付きの**マージ済み**PRを収集し（`scripts/fetch-recent-ui-design-prs.sh`）、レビューコメントと `.pen` の実データからトークン・原則を抽出して `DESIGN.md` を更新、`designmd lint` を通してから `commit-push` → `create-pr` でPRを作る（`cc-triage-scope` ラベル + 自分自身をAssignee。`update-requirement-rules` / `update-coding-guidelines` と同じ経路）
 - **読み手**: `pencil-design-updater` エージェント。作業プロセスのステップ1で `DESIGN.md` を読み、色・フォント・余白・角丸を定義済みトークンの値で指定する（Pencil はトークン参照を解決しないため、`{colors.primary}` ではなく `#1A1C1E` のように実値まで落として `--prompt` / `execute` の編集スニペットに渡す）
 - **`.pen` の中身は diff から読めない**。暗号化バイナリのため `Read` / `Grep` が効かず、変更ファイル一覧だけでは何が変わったか分からない。そこで収集スクリプトは変更ファイルを `pen_files` / `snapshot_files`（`snapshots/` のPNG）/ `other_files` に仕分けて返し、スキルは (1) スナップショット画像を `Read` で見て傾向を掴み、(2) `inspect-pencil-node`（読み取り専用）で Node 属性から正確なトークン値を取る、の2経路で実データに当たる。**推測値は書かない** — 一度書くと次のデザインがそれに合わせて作られ、事後的に「正」になってしまうため
 - **収集対象はマージ済みPRのみ**。マージ後なら `.pen` もスナップショットも現在のワークツリーに存在するので、head ブランチが削除済みでも実データを読める（未マージPRを含めると、後で却下された値をトークン化しうる）

--- a/plugin/skills/update-coding-guidelines/SKILL.md
+++ b/plugin/skills/update-coding-guidelines/SKILL.md
@@ -4,9 +4,12 @@ description: 直近N日（デフォルト1日）のPRレビューで繰り返し
 disable-model-invocation: true
 argument-hint: "[期間（日数、省略時は1）] [関連Issue番号（任意）]"
 allowed-tools: Bash(gh:*), Bash(git:*), Bash(jq:*), Bash(bash:*), Bash(pwd), Bash(ls:*), Bash(date:*), Bash(wc:*), Read, Write, Edit, Skill
-model: opus
-effort: high
-context: fork
+hooks:
+  Stop:
+    - matcher: ""
+      hooks:
+        - type: command
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Update Coding Guidelines
@@ -19,13 +22,17 @@ context: fork
 
 **絶対にやらないこと**:
 - レビューコメントへの返信・Resolve・既存PRへの編集（読み取りのみ）
-- `CODING_GUIDELINES.md`以外のソースコードへの修正
+- `CODING_GUIDELINES.md`以外のファイルの編集（ワーカーが書き込んだ`claude-task-worker.json`の`lastRun`をコミットに含めるのはこの制限の対象外。本スキルが同ファイルを編集することはない）
 - 単発（2回未満）の指摘のルール化（ノイズ防止）
 - スタイル好み・命名の主観・スコープ外提案など「対応不要寄り」の項目のルール化
 - 既存ルールと意味重複する項目の別ルールとしての追加（必ず統合・圧縮する）
 - デフォルトブランチ上での直接コミット（必ずfeature branchに切り替えてから`commit-push`を呼ぶ）
 
 # Instructions
+
+## 実行モードの制約
+
+本スキル固有のリスク: 本スキルは `claude-task-worker` の `update-coding-guidelines` ワーカーから24時間おきに自動起動され、ワーカーは起動時刻を `claude-task-worker.json` の `lastRun` へ書き込んだうえで次の24時間の実行を抑止する。処理が未完のままターンを終えると、その日の分の収集・ルール化が行われないまま実行済みとして扱われ、取りこぼしたレビューコメントは二度と対象期間に入らない（対象期間は常に直近N日で、遡らない）。
 
 ## フェーズ0: 事前チェック・引数パース
 
@@ -162,7 +169,15 @@ bash ${CLAUDE_SKILL_DIR}/scripts/fetch-recent-review-comments.sh <フェーズ0�
 
 **完了条件**: `CODING_GUIDELINES.md`が更新されており、追加/変更したルール、統合・圧縮した既存ルール、ファイル全体の行数が把握できていること。
 
-`git status`で差分が発生していなければ「ガイドライン更新差分なし」と報告してこのスキルを終了する（フェーズ4以降のコミット・PR作成は実行しない）。
+`git status`で差分が発生していなければ「ガイドライン更新差分なし」と報告してこのスキルを終了する（フェーズ4以降のコミット・PR作成は実行しない）。差分の判定に`claude-task-worker.json`は数えない（次節）。
+
+### `claude-task-worker.json`（実行記録）の扱い
+
+`claude-task-worker`の定期ワーカーから自動起動された場合、ワーカーが起動時に`claude-task-worker.json`の`lastRun.update-coding-guidelines`を今回の実行時刻へ書き換えている。これは本スキルの成果物ではないが、**コミットから除外しない**（成果物と同じPRに含めることで、マージ時点で次の24時間の実行抑止が恒久化する）。
+
+- 差分の有無を判定するときは`claude-task-worker.json`を数に入れない。このファイルにしか差分が無い場合は「ガイドライン更新差分なし」として終了する（タイムスタンプだけのPRは作らない）
+- `CODING_GUIDELINES.md`の差分がある場合は`claude-task-worker.json`もそのままコミットに含める（`git checkout`等で戻さない）
+- 内容の編集はしない（値はワーカーが書く。手動起動で差分が無ければ何もしない）
 
 ## フェーズ4: feature branch への切替
 

--- a/plugin/skills/update-design-md/SKILL.md
+++ b/plugin/skills/update-design-md/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: update-design-md
-description: 直近N日（デフォルト7日）にマージされた `cc-ui-design` ラベル付きPR（UIデザインPR）から確定したビジュアルアイデンティティ（カラー・タイポグラフィ・スペーシング・コンポーネント）をリポジトリルートの `DESIGN.md`（google-labs-code/design.md フォーマット）へ集約・更新し、`design.md` CLI の lint を通してから commit-push + create-pr でPRを作成する（`cc-triage-scope` ラベル + 自分自身をAssignee）。`DESIGN.md` は pencil-design-updater がデザイン時の前提として読み込む。
+description: 直近N日（デフォルト1日）にマージされた `cc-ui-design` ラベル付きPR（UIデザインPR）から確定したビジュアルアイデンティティ（カラー・タイポグラフィ・スペーシング・コンポーネント）をリポジトリルートの `DESIGN.md`（google-labs-code/design.md フォーマット）へ集約・更新し、`design.md` CLI の lint を通してから commit-push + create-pr でPRを作成する（`cc-triage-scope` ラベル + 自分自身をAssignee）。`DESIGN.md` は pencil-design-updater がデザイン時の前提として読み込む。
 disable-model-invocation: true
-argument-hint: "[期間（日数、省略時は7）] [関連Issue番号（任意）]"
+argument-hint: "[期間（日数、省略時は1）] [関連Issue番号（任意）]"
 allowed-tools: Bash(gh:*), Bash(git:*), Bash(jq:*), Bash(bash:*), Bash(pencil:*), Bash(designmd:*), Bash(npx:*), Bash(pwd), Bash(ls:*), Bash(date:*), Bash(wc:*), Bash(mkdir:*), Bash(find:*), Read, Write, Edit, Glob, Grep, Agent, Skill
-model: opus
-effort: high
-context: fork
+hooks:
+  Stop:
+    - matcher: ""
+      hooks:
+        - type: command
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Update DESIGN.md
@@ -23,7 +26,7 @@ context: fork
 
 **絶対にやらないこと**:
 - **収集対象の** PR / Issue への書き込み（コメント・ラベル・再オープンなど。収集は読み取りのみ。フェーズ7で自分が作成したPRへラベル・Assigneeを付けるのはこの制限の対象外）
-- `DESIGN.md` 以外のファイルの編集（`.pen`・ソースコード・`CODING_GUIDELINES.md`・`.claude/requirements/` を含む）
+- `DESIGN.md` 以外のファイルの編集（`.pen`・ソースコード・`CODING_GUIDELINES.md`・`.claude/requirements/` を含む。ワーカーが書き込んだ `claude-task-worker.json` の `lastRun` をコミットに含めるのはこの制限の対象外。本スキルが同ファイルを編集することはない）
 - **`.pen` の編集**（`save()` を呼ぶ操作）。調査は `inspect-pencil-node` の読み取り専用手順のみ。デザイン側の修正が必要と判断した場合も、報告に1行挙げるだけにする
 - 実データの裏付けがない値の記載（「よくある値」で埋めない。読み取れなかった項目は書かない。推測値は、次のデザインがそれに合わせて作られた時点で「正」になってしまう）
 - 1つのPRでしか使われていない画面固有の装飾のトークン化（後述の採用基準）
@@ -32,6 +35,10 @@ context: fork
 ---
 
 # Instructions
+
+## 実行モードの制約
+
+本スキル固有のリスク: 本スキルは `claude-task-worker` の `update-design-md` ワーカーから24時間おきに自動起動され（`uiDesign.enabled` が `true` のリポジトリのみ）、ワーカーは起動時刻を `claude-task-worker.json` の `lastRun` へ書き込んだうえで次の24時間の実行を抑止する。処理が未完のままターンを終えると、その日の分の収集・トークン化が行われないまま実行済みとして扱われ、取りこぼしたデザインPRは二度と対象期間に入らない（対象期間は常に直近N日で、遡らない）。
 
 ## フェーズ0: 事前チェック・引数パース
 
@@ -60,10 +67,10 @@ fi
 
 `$ARGUMENTS` を空白区切りで最大2トークンに分解する。
 
-- 1番目: 期間（日数）。省略時または非数値の場合は `7`
+- 1番目: 期間（日数）。省略時または非数値の場合は `1`
 - 2番目: 関連Issue番号（任意）。`#` プレフィックスは除去して数値部分のみ保持
 
-例: `/update-design-md` → 日数=7, Issue番号=なし ／ `/update-design-md 14 #123` → 日数=14, Issue番号=123
+例: `/update-design-md` → 日数=1, Issue番号=なし ／ `/update-design-md 14 #123` → 日数=14, Issue番号=123
 
 Issue番号はフェーズ7で `create-pr` に渡す。指定なしの場合はPR本文の `Closes #N` 行を省略する。
 
@@ -284,7 +291,15 @@ components:
 
 **完了条件**: `DESIGN.md` が更新され、追加・統合・上書き・削除したトークン数を把握できていること。
 
-`git status` で差分が発生していなければ「DESIGN.md 更新差分なし」と報告してこのスキルを終了する（フェーズ5以降は実行せず、空コミット・空PRを作らない）。
+`git status` で差分が発生していなければ「DESIGN.md 更新差分なし」と報告してこのスキルを終了する（フェーズ5以降は実行せず、空コミット・空PRを作らない）。差分の判定に `claude-task-worker.json` は数えない（次節）。
+
+### `claude-task-worker.json`（実行記録）の扱い
+
+`claude-task-worker` の定期ワーカーから自動起動された場合、ワーカーが起動時に `claude-task-worker.json` の `lastRun.update-design-md` を今回の実行時刻へ書き換えている。これは本スキルの成果物ではないが、**コミットから除外しない**（成果物と同じPRに含めることで、マージ時点で次の24時間の実行抑止が恒久化する）。
+
+- 差分の有無を判定するときは `claude-task-worker.json` を数に入れない。このファイルにしか差分が無い場合は「DESIGN.md 更新差分なし」として終了する（タイムスタンプだけのPRは作らない）
+- `DESIGN.md` の差分がある場合は `claude-task-worker.json` もそのままコミットに含める（`git checkout` 等で戻さない）
+- 内容の編集はしない（値はワーカーが書く。`uiDesign.designDir` を読むのはフェーズ0のとおり読み取りのみ。手動起動で差分が無ければ何もしない）
 
 ## フェーズ5: lint 通過（`DESIGN_MD_CMD` が使える場合は**必須**）
 

--- a/plugin/skills/update-design-md/scripts/fetch-recent-ui-design-prs.sh
+++ b/plugin/skills/update-design-md/scripts/fetch-recent-ui-design-prs.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 #                      README/docs 配下等の無関係な画像を混入させない）
 #   - other_files:    それ以外（pen_files にも snapshot_files にも該当しないもの）
 
-DAYS="${1:-7}"
+DAYS="${1:-1}"
 OUT_FILE="${2:-}"
 JOB_LIMIT="${JOB_LIMIT:-10}"
 MAX_PRS="${MAX_PRS:-50}"

--- a/plugin/skills/update-requirement-rules/SKILL.md
+++ b/plugin/skills/update-requirement-rules/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: update-requirement-rules
-description: 直近N日（デフォルト7日）に更新された `cc-triage-scope` / `cc-pr-created` ラベル付きGitHub Issueのdescriptionとコメントを横断し、繰り返し現れる仕様判断・要件決定のロジックを再利用可能なルールとして抽出して `.claude/requirements/` 配下のタイプ別マークダウンへ集約・統合・圧縮したうえで、commit-push + create-prでPRを作成する（`cc-triage-scope`ラベル + 自分自身をAssignee）。作成したルールは create-issue / create-issue-from-issue-number / answer-issue-questions が仕様作成・判断の材料として読み込む。
+description: 直近N日（デフォルト1日）に更新された `cc-triage-scope` / `cc-pr-created` ラベル付きGitHub Issueのdescriptionとコメントを横断し、繰り返し現れる仕様判断・要件決定のロジックを再利用可能なルールとして抽出して `.claude/requirements/` 配下のタイプ別マークダウンへ集約・統合・圧縮したうえで、commit-push + create-prでPRを作成する（`cc-triage-scope`ラベル + 自分自身をAssignee）。作成したルールは create-issue / create-issue-from-issue-number / answer-issue-questions が仕様作成・判断の材料として読み込む。
 disable-model-invocation: true
-argument-hint: "[期間（日数、省略時は7）] [関連Issue番号（任意）]"
+argument-hint: "[期間（日数、省略時は1）] [関連Issue番号（任意）]"
 allowed-tools: Bash(gh:*), Bash(git:*), Bash(jq:*), Bash(bash:*), Bash(pwd), Bash(ls:*), Bash(date:*), Bash(wc:*), Bash(mkdir:*), Read, Write, Edit, Glob, Grep, Agent, Skill
-model: opus
-effort: high
-context: fork
+hooks:
+  Stop:
+    - matcher: ""
+      hooks:
+        - type: command
+          command: node "${CLAUDE_PLUGIN_ROOT}/scripts/stop-servers.mjs"
 ---
 
 # Update Requirement Rules
 
-直近N日のIssue（`cc-triage-scope` / `cc-pr-created`）から**仕様・要件レベルの判断ロジック**を抽出し、`.claude/requirements/` 配下のタイプ別ルールファイルへ集約するスキル。収集 → 抽出 → ルール化 → 統合・整理 → PR作成まで一貫して実行する。
+直近N日（デフォルト1日）のIssue（`cc-triage-scope` / `cc-pr-created`）から**仕様・要件レベルの判断ロジック**を抽出し、`.claude/requirements/` 配下のタイプ別ルールファイルへ集約するスキル。収集 → 抽出 → ルール化 → 統合・整理 → PR作成まで一貫して実行する。
 
 ## なぜこれをやるのか
 
@@ -29,7 +32,7 @@ context: fork
 
 **絶対にやらないこと**:
 - **収集対象の** Issue / PR への書き込み（コメント・ラベル・クローズなど。収集は読み取りのみ。フェーズ5で自分が作成したPRへラベル・Assigneeを付けるのはこの制限の対象外）
-- `.claude/requirements/` 配下以外のファイルの編集（ソースコード・`CODING_GUIDELINES.md`・`docs/` を含む）
+- `.claude/requirements/` 配下以外のファイルの編集（ソースコード・`CODING_GUIDELINES.md`・`docs/` を含む。ワーカーが書き込んだ `claude-task-worker.json` の `lastRun` をコミットに含めるのはこの制限の対象外。本スキルが同ファイルを編集することはない）
 - **コーディング規約のルール化** — 命名・型・テストの書き方・レビュー指摘由来の実装作法は `update-coding-guidelines` の責務。境界の判定はフェーズ2の「`update-coding-guidelines` との境界」の1問（descriptionの書き分けが変わるか）で機械的に行う
 - 1件しか根拠のない判断のルール化（採用基準の例外条件を満たす場合を除く）
 - 特定Issueの経緯・議論の記録（ルールは再利用可能な判断基準であって議事録ではない。特定Issueの実装詳細・PR番号を書かない）
@@ -38,6 +41,10 @@ context: fork
 ---
 
 # Instructions
+
+## 実行モードの制約
+
+本スキル固有のリスク: 本スキルは `claude-task-worker` の `update-requirement-rules` ワーカーから24時間おきに自動起動され、ワーカーは起動時刻を `claude-task-worker.json` の `lastRun` へ書き込んだうえで次の24時間の実行を抑止する。処理が未完のままターンを終えると、その日の分の収集・ルール化が行われないまま実行済みとして扱われ、取りこぼしたIssueは二度と対象期間に入らない（対象期間は常に直近N日で、遡らない）。
 
 ## フェーズ0: 事前チェック・引数パース
 
@@ -48,10 +55,10 @@ context: fork
 
 `$ARGUMENTS` を空白区切りで最大2トークンに分解する。
 
-- 1番目: 期間（日数）。省略時または非数値の場合は `7`
+- 1番目: 期間（日数）。省略時または非数値の場合は `1`
 - 2番目: 関連Issue番号（任意）。`#` プレフィックスは除去して数値部分のみ保持
 
-例: `/update-requirement-rules` → 日数=7, Issue番号=なし ／ `/update-requirement-rules 14 #123` → 日数=14, Issue番号=123
+例: `/update-requirement-rules` → 日数=1, Issue番号=なし ／ `/update-requirement-rules 14 #123` → 日数=14, Issue番号=123
 
 Issue番号はフェーズ5で `create-pr` に渡す。指定なしの場合はPR本文の `Closes #N` 行を省略する。
 
@@ -253,7 +260,15 @@ Issue の description と確認事項への回答コメントから、**「こ�
 
 **完了条件**: `.claude/requirements/` が更新され、追加・統合・上書き・削除した件数と各ファイルのルール数が把握できていること。`README.md` のカテゴリ表が実ファイルと一致していること。
 
-`git status` で差分が発生していなければ「要件ルール更新差分なし」と報告してこのスキルを終了する（フェーズ4以降は実行しない。空コミット・空PRを作らない）。
+`git status` で差分が発生していなければ「要件ルール更新差分なし」と報告してこのスキルを終了する（フェーズ4以降は実行しない。空コミット・空PRを作らない）。差分の判定に `claude-task-worker.json` は数えない（次節）。
+
+### `claude-task-worker.json`（実行記録）の扱い
+
+`claude-task-worker` の定期ワーカーから自動起動された場合、ワーカーが起動時に `claude-task-worker.json` の `lastRun.update-requirement-rules` を今回の実行時刻へ書き換えている。これは本スキルの成果物ではないが、**コミットから除外しない**（成果物と同じPRに含めることで、マージ時点で次の24時間の実行抑止が恒久化する）。
+
+- 差分の有無を判定するときは `claude-task-worker.json` を数に入れない。このファイルにしか差分が無い場合は「要件ルール更新差分なし」として終了する（タイムスタンプだけのPRは作らない）
+- `.claude/requirements/` 配下の差分がある場合は `claude-task-worker.json` もそのままコミットに含める（`git checkout` 等で戻さない）
+- 内容の編集はしない（値はワーカーが書く。手動起動で差分が無ければ何もしない）
 
 ## フェーズ4: feature branch への切替
 

--- a/plugin/skills/update-requirement-rules/scripts/fetch-recent-requirement-issues.sh
+++ b/plugin/skills/update-requirement-rules/scripts/fetch-recent-requirement-issues.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 #   Issue本文＋全コメントはそのまま読むとコンテキストを食い潰すため、
 #   呼び出し側が jq で必要な Issue だけを取り出せるようにしている。
 
-DAYS="${1:-7}"
+DAYS="${1:-1}"
 OUT_FILE="${2:-}"
 JOB_LIMIT="${JOB_LIMIT:-10}"
 MAX_ISSUES="${MAX_ISSUES:-80}"

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,9 +1,19 @@
 import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type * as ConfigModule from "./config";
 
-const { parseUiDesignEntry, parseWorkerEntry, DEFAULT_UI_DESIGN_CONFIG, DEFAULT_WORKER_CONFIG, WORKER_DEFAULTS } =
-  (await import("./config")) as typeof ConfigModule;
+const {
+  parseLastRunEntry,
+  parseUiDesignEntry,
+  parseWorkerEntry,
+  writeLastRun,
+  DEFAULT_UI_DESIGN_CONFIG,
+  DEFAULT_WORKER_CONFIG,
+  WORKER_DEFAULTS,
+} = (await import("./config")) as typeof ConfigModule;
 
 // 不正値は console.warn を出して既定値へ倒す仕様なので、テスト出力を汚さないよう黙らせる。
 function silenceWarn(t: TestContext): void {
@@ -104,6 +114,39 @@ test("parseWorkerEntry accepts an empty advisorModel as an explicit opt-out", (t
   // 他フィールドと違い空文字は不正値ではなく「advisor を使わない」の明示指定。
   assert.equal(parseWorkerEntry("update-issue", { advisorModel: "" })?.advisorModel, "");
   assert.equal(parseWorkerEntry("update-issue", { advisorModel: "fable" })?.advisorModel, "fable");
+});
+
+test("parseLastRunEntry keeps only parseable timestamps", (t) => {
+  silenceWarn(t);
+  // 壊れた値で定期ワーカーが「実行済み」と誤判定して永久に走らなくなるのを防ぐ。
+  assert.deepEqual(parseLastRunEntry({ "update-design-md": "2026-08-17T00:00:00.000Z", broken: "yesterday", n: 1 }), {
+    "update-design-md": "2026-08-17T00:00:00.000Z",
+  });
+  assert.deepEqual(parseLastRunEntry("2026-08-17"), {});
+});
+
+test("writeLastRun records the timestamp without dropping other settings", () => {
+  const root = mkdtempSync(join(tmpdir(), "ctw-lastrun-"));
+  const path = join(root, "claude-task-worker.json");
+  writeFileSync(path, JSON.stringify({ uiDesign: { enabled: true }, lastRun: { "update-design-md": "2026-08-01" } }));
+
+  writeLastRun(root, "update-coding-guidelines", new Date("2026-08-17T09:00:00.000Z"));
+
+  assert.deepEqual(JSON.parse(readFileSync(path, "utf-8")), {
+    uiDesign: { enabled: true },
+    lastRun: {
+      "update-design-md": "2026-08-01",
+      "update-coding-guidelines": "2026-08-17T09:00:00.000Z",
+    },
+  });
+});
+
+test("writeLastRun creates the config file when the repo has none", () => {
+  const root = mkdtempSync(join(tmpdir(), "ctw-lastrun-"));
+  writeLastRun(root, "update-requirement-rules", new Date("2026-08-17T09:00:00.000Z"));
+  assert.deepEqual(JSON.parse(readFileSync(join(root, "claude-task-worker.json"), "utf-8")), {
+    lastRun: { "update-requirement-rules": "2026-08-17T09:00:00.000Z" },
+  });
 });
 
 test("parseWorkerEntry falls back to the default for a non-string advisorModel", (t) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, normalize, sep as SEP } from "node:path";
 
 export type WorkerName =
@@ -13,7 +13,10 @@ export type WorkerName =
   | "resolve-conflict"
   | "epic-issue"
   | "create-ui-design"
-  | "apply-ui-design";
+  | "apply-ui-design"
+  | "update-coding-guidelines"
+  | "update-requirement-rules"
+  | "update-design-md";
 
 export interface WorkerRuntimeConfig {
   skill: string;
@@ -41,9 +44,16 @@ export interface UiDesignConfig {
   yolo: boolean;
 }
 
+// 定期ワーカー（24時間おきに1回だけ走らせるもの）の最終実行時刻。ワーカー名 → ISO8601。
+// プロセス内のメモリではなくリポジトリの設定ファイルに置くのは、ワーカーを再起動しても
+// 間隔が保たれるようにするため。値はワーカーが worktree 側へ書き込み、スキルの
+// commit-push でその日の成果物と同じPRに含めてコミットされる。
+export type LastRunLog = Record<string, string>;
+
 interface Config {
   fixReviewPointCallbackCommentMessage?: string;
   uiDesign: UiDesignConfig;
+  lastRun: LastRunLog;
   workers: Record<string, WorkerRuntimeConfig>;
 }
 
@@ -172,11 +182,44 @@ export const WORKER_DEFAULTS: Record<string, WorkerRuntimeConfig> = {
     cooldownSeconds: 0,
     maxConcurrentTasks: 1,
   },
+  // 以下3つは定期ワーカー（createScheduledWorker）。実行間隔そのものは
+  // SCHEDULE_INTERVAL_HOURS（24時間）と実行ログで決まり、pollingIntervalSeconds は
+  // 「24時間経過したかを確認する頻度」でしかない。
+  // model が opus なのは、成果物（CODING_GUIDELINES.md / .claude/requirements/ / DESIGN.md）が
+  // 後続の全 Issue・全デザインの前提として読まれ、誤った一般化がそのまま下流の手戻りになるため。
+  "update-coding-guidelines": {
+    skill: "/claude-task-worker:update-coding-guidelines",
+    model: "opus",
+    advisorModel: "",
+    effort: "high",
+    pollingIntervalSeconds: 3600,
+    cooldownSeconds: 0,
+    maxConcurrentTasks: 1,
+  },
+  "update-requirement-rules": {
+    skill: "/claude-task-worker:update-requirement-rules",
+    model: "opus",
+    advisorModel: "",
+    effort: "high",
+    pollingIntervalSeconds: 3600,
+    cooldownSeconds: 0,
+    maxConcurrentTasks: 1,
+  },
+  "update-design-md": {
+    skill: "/claude-task-worker:update-design-md",
+    model: "opus",
+    advisorModel: "",
+    effort: "high",
+    pollingIntervalSeconds: 3600,
+    cooldownSeconds: 0,
+    maxConcurrentTasks: 1,
+  },
 };
 
 export const DEFAULT_CONFIG: Config = {
   fixReviewPointCallbackCommentMessage: "",
   uiDesign: { ...DEFAULT_UI_DESIGN_CONFIG },
+  lastRun: {},
   workers: {},
 };
 
@@ -301,6 +344,23 @@ export function parseUiDesignEntry(val: unknown): UiDesignConfig {
   return result;
 }
 
+// 値が文字列のエントリだけを残す（壊れた値で定期ワーカーが止まらないようにする）。
+export function parseLastRunEntry(val: unknown): LastRunLog {
+  if (typeof val !== "object" || val === null || Array.isArray(val)) {
+    console.warn(`[config] invalid lastRun: expected object, ignoring`);
+    return {};
+  }
+  const result: LastRunLog = {};
+  for (const [name, at] of Object.entries(val as Record<string, unknown>)) {
+    if (typeof at === "string" && !Number.isNaN(Date.parse(at))) {
+      result[name] = at;
+    } else {
+      console.warn(`[config] invalid lastRun.${name}: ${String(at)}, ignoring`);
+    }
+  }
+  return result;
+}
+
 export function loadConfig(): Config {
   const configPath = CONFIG_PATH;
   let raw: Record<string, unknown>;
@@ -308,12 +368,16 @@ export function loadConfig(): Config {
     raw = JSON.parse(readFileSync(configPath, "utf-8"));
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return { ...DEFAULT_CONFIG, uiDesign: { ...DEFAULT_UI_DESIGN_CONFIG }, workers: {} };
+      return { ...DEFAULT_CONFIG, uiDesign: { ...DEFAULT_UI_DESIGN_CONFIG }, lastRun: {}, workers: {} };
     }
     throw err;
   }
 
-  const result: Config = { ...DEFAULT_CONFIG, uiDesign: { ...DEFAULT_UI_DESIGN_CONFIG }, workers: {} };
+  const result: Config = { ...DEFAULT_CONFIG, uiDesign: { ...DEFAULT_UI_DESIGN_CONFIG }, lastRun: {}, workers: {} };
+
+  if ("lastRun" in raw) {
+    result.lastRun = parseLastRunEntry(raw["lastRun"]);
+  }
 
   if ("fixReviewPointCallbackCommentMessage" in raw) {
     const val = raw["fixReviewPointCallbackCommentMessage"];
@@ -344,6 +408,43 @@ export function loadConfig(): Config {
 export function getWorkerConfig(workerName: string): WorkerRuntimeConfig {
   const config = loadConfig();
   return config.workers[workerName] ?? { ...defaultsFor(workerName) };
+}
+
+// 定期ワーカーの最終実行時刻（epoch ms）。記録が無い・読めない場合は undefined＝実行可。
+export function getLastRunAt(workerName: string): number | undefined {
+  let at: string | undefined;
+  try {
+    at = loadConfig().lastRun[workerName];
+  } catch (err) {
+    console.warn(`[config] failed to load lastRun, treating ${workerName} as never run: ${err}`);
+    return undefined;
+  }
+  if (at === undefined) return undefined;
+  const parsed = Date.parse(at);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+// 最終実行時刻を <repoRoot>/claude-task-worker.json の lastRun へ書き込む。
+// 呼び出し側は worktree のルートを渡す。書き込んだ差分はスキルの commit-push が
+// その日の成果物（CODING_GUIDELINES.md 等）と同じコミット・同じPRに含める。
+// 既存の設定は保持する（生JSONを読み直してマージするため、パース時に落ちる不正キーも壊さない）。
+export function writeLastRun(repoRoot: string, workerName: string, at: Date = new Date()): void {
+  const path = join(repoRoot, "claude-task-worker.json");
+  let raw: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      raw = parsed as Record<string, unknown>;
+    }
+  } catch (err) {
+    // 設定ファイルが無いリポジトリでは lastRun だけを持つファイルを新規作成する。
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn(`[config] failed to read ${path}, rewriting it with lastRun only: ${err}`);
+    }
+  }
+  const current = typeof raw["lastRun"] === "object" && raw["lastRun"] !== null ? raw["lastRun"] : {};
+  raw["lastRun"] = { ...(current as Record<string, unknown>), [workerName]: at.toISOString() };
+  writeFileSync(path, `${JSON.stringify(raw, null, 2)}\n`, "utf-8");
 }
 
 // 設定ファイル不在・破損でもワークフローが勝手に有効化されないよう、

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,9 @@ import { checkDependabotWorker } from "./workers/check-dependabot";
 import { epicIssueWorker } from "./workers/epic-issue";
 import { createUiDesignWorker } from "./workers/create-ui-design";
 import { applyUiDesignWorker } from "./workers/apply-ui-design";
+import { updateCodingGuidelinesWorker } from "./workers/update-coding-guidelines";
+import { updateRequirementRulesWorker } from "./workers/update-requirement-rules";
+import { updateDesignMdWorker } from "./workers/update-design-md";
 import {
   shutdown,
   waitForAllProcesses,
@@ -54,6 +57,9 @@ const WORKERS: Record<string, (opts?: { epicFilters?: number[]; labelFilters?: s
   "epic-issue": epicIssueWorker,
   "create-ui-design": createUiDesignWorker,
   "apply-ui-design": applyUiDesignWorker,
+  "update-coding-guidelines": updateCodingGuidelinesWorker,
+  "update-requirement-rules": updateRequirementRulesWorker,
+  "update-design-md": updateDesignMdWorker,
 };
 
 function printUsage(): void {
@@ -79,6 +85,9 @@ Workers:
   epic-issue        Poll cc-epic-issue issues and create epic PR when all sub-issues are closed
   create-ui-design  Poll cc-create-ui-design issues and create a Pencil design PR (requires uiDesign.enabled)
   apply-ui-design   Poll cc-ui-design-pr-created issues and write the design reference back once the design PR is merged (requires uiDesign.enabled)
+  update-coding-guidelines  Run /update-coding-guidelines once every 24 hours over the last 24 hours
+  update-requirement-rules  Run /update-requirement-rules once every 24 hours over the last 24 hours
+  update-design-md  Run /update-design-md once every 24 hours over the last 24 hours (requires uiDesign.enabled)
   all               Poll all workers except triage-created-issue, triage-pr, check-dependabot
   yolo              Poll all workers including triage-created-issue, triage-pr, check-dependabot
 
@@ -317,6 +326,11 @@ if (hasProjectFilter()) {
       epicIssueWorker({ epicFilters, labelFilters }),
       createUiDesignWorker({ epicFilters, labelFilters }),
       applyUiDesignWorker({ epicFilters, labelFilters }),
+      // 24時間おきの定期ワーカー。update-design-md は uiDesign.enabled が false のとき
+      // 自身で no-op になる（create-ui-design / apply-ui-design と同じ扱い）。
+      updateCodingGuidelinesWorker(),
+      updateRequirementRulesWorker(),
+      updateDesignMdWorker(),
     ]);
   })();
 } else if (workerType === "yolo") {
@@ -338,6 +352,9 @@ if (hasProjectFilter()) {
       epicIssueWorker({ epicFilters, labelFilters }),
       createUiDesignWorker({ epicFilters, labelFilters }),
       applyUiDesignWorker({ epicFilters, labelFilters }),
+      updateCodingGuidelinesWorker(),
+      updateRequirementRulesWorker(),
+      updateDesignMdWorker(),
     ]);
   })();
 } else {

--- a/src/skill-frontmatter.test.ts
+++ b/src/skill-frontmatter.test.ts
@@ -51,6 +51,9 @@ test("worker entry skills do not pin a model", () => {
     "create-epic-pr",
     "create-ui-design",
     "apply-ui-design",
+    "update-coding-guidelines",
+    "update-requirement-rules",
+    "update-design-md",
   ];
   for (const name of entrySkills) {
     const fm = skills.find(([n]) => n === name)?.[1];

--- a/src/workers/scheduled-worker.ts
+++ b/src/workers/scheduled-worker.ts
@@ -1,0 +1,114 @@
+import { buildClaudeEnv, buildClaudeExecution } from "../claude-args";
+import { getLastRunAt, getWorkerConfig, writeLastRun } from "../config";
+import { getRepoInfo } from "../gh";
+import { syncDefaultBranch } from "../git";
+import { isRunning, isShuttingDown, run } from "../process-manager";
+import { generateWorktreeName } from "../random-name";
+import { notifyError, notifyTaskCompleted, notifyTaskFailed } from "../slack";
+import { getPermissionMode, getRunMode, isAdvisorEnabled } from "../user-config";
+import { createWorktreeFromBranch, getWorktreePath, removeWorktree } from "../worktree";
+
+// 定期ワーカーの実行間隔。スキルへ渡す収集期間（日数）もここから導出するため、
+// 「24時間おきに、直近24時間を対象に走る」が常に一致する。
+export const SCHEDULE_INTERVAL_HOURS = 24;
+const SCHEDULE_INTERVAL_MS = SCHEDULE_INTERVAL_HOURS * 60 * 60 * 1000;
+const SCOPE_DAYS = SCHEDULE_INTERVAL_HOURS / 24;
+
+export interface ScheduledWorkerConfig {
+  name: string;
+  command: string;
+  // process-manager の台帳・ステータステーブルのキー。Issue / PR 番号（正数）と
+  // 衝突しないよう負値を割り当てる。
+  taskId: number;
+  // false を返す間はスキルを起動しない（設定でオプトアウトされたワーカー用）。
+  enabled?: () => boolean;
+}
+
+// Issue / PR のポーリングではなく、時刻だけを条件にスキルを起動するワーカー。
+//
+// 最終実行時刻は claude-task-worker.json の `lastRun` に持つ。値を書くのはワーカーだが、
+// 書き込み先は worktree 側のファイルで、スキルの commit-push がその日の成果物と同じPRに含める。
+// つまり記録が恒久化するのはPRがマージされた時点で、それまでは下記の起動時刻（プロセス内）が
+// 二重実行を止める。設定ファイルへ寄せているのは、実行間隔をリポジトリの状態として
+// 追跡・レビューできるようにするため。
+export function createScheduledWorker(config: ScheduledWorkerConfig): () => Promise<void> {
+  return async () => {
+    const { owner, name: repoName, defaultBranch } = await getRepoInfo();
+    const { pollingIntervalSeconds } = getWorkerConfig(config.name);
+    console.log(
+      `[${config.name}] Checking every ${pollingIntervalSeconds} seconds (runs at most once per ${SCHEDULE_INTERVAL_HOURS}h for ${owner}/${repoName})`,
+    );
+
+    // 設定ファイルの lastRun が更新されるのはPRのマージ後なので、それだけを見ると
+    // マージまでの間は毎ポーリングで再起動してしまう。プロセス内の起動時刻を併用して塞ぐ。
+    let startedAt = 0;
+
+    const tick = async () => {
+      if (isShuttingDown()) return;
+      if (config.enabled && !config.enabled()) return;
+      if (isRunning(config.taskId)) return;
+
+      const now = Date.now();
+      const lastRunAt = Math.max(getLastRunAt(config.name) ?? 0, startedAt);
+      if (lastRunAt > 0 && now - lastRunAt < SCHEDULE_INTERVAL_MS) return;
+
+      const worktreeId = generateWorktreeName();
+      startedAt = now;
+      try {
+        syncDefaultBranch(defaultBranch);
+        const { model, effort, skill, advisorModel } = getWorkerConfig(config.name);
+        const command = skill || config.command;
+        const mode = getRunMode();
+        const execution = buildClaudeExecution({
+          mode,
+          prompt: `${command} ${SCOPE_DAYS}`,
+          model,
+          effort,
+          advisorModel: isAdvisorEnabled() ? advisorModel : "",
+          permissionMode: getPermissionMode(),
+        });
+
+        await createWorktreeFromBranch(worktreeId, defaultBranch);
+        const cwd = getWorktreePath(worktreeId);
+        // スキルが commit する前に書いておく（スキル側は「差分に含まれていたらそのまま
+        // コミットする」だけでよく、タイムスタンプの生成をモデルに任せない）。
+        writeLastRun(cwd, config.name, new Date(now));
+        console.log(`[${config.name}] created worktree ${worktreeId} from ${defaultBranch}`);
+
+        const repoUrl = `https://github.com/${owner}/${repoName}`;
+        run(
+          execution.command,
+          execution.args,
+          config.taskId,
+          config.name,
+          config.name,
+          worktreeId,
+          async (status, output) => {
+            try {
+              if (status === "completed") {
+                await notifyTaskCompleted(config.name, repoName, config.taskId, config.name, repoUrl, output);
+              } else {
+                await notifyTaskFailed(config.name, repoName, config.taskId, config.name, repoUrl, output);
+              }
+            } catch (err) {
+              console.error(`[${config.name}] post-task error: ${err}`);
+            } finally {
+              await removeWorktree(worktreeId).catch((err) =>
+                console.error(`[${config.name}] removeWorktree failed: ${err}`),
+              );
+            }
+          },
+          cwd,
+          buildClaudeEnv(mode),
+        );
+      } catch (err) {
+        console.error(`[${config.name}] setup error: ${err}`);
+        await removeWorktree(worktreeId).catch(() => {});
+        await notifyError(config.name, repoName, err);
+      }
+    };
+
+    await tick();
+    setInterval(tick, pollingIntervalSeconds * 1000);
+  };
+}

--- a/src/workers/update-coding-guidelines.ts
+++ b/src/workers/update-coding-guidelines.ts
@@ -1,0 +1,7 @@
+import { createScheduledWorker } from "./scheduled-worker";
+
+export const updateCodingGuidelinesWorker = createScheduledWorker({
+  name: "update-coding-guidelines",
+  command: "/claude-task-worker:update-coding-guidelines",
+  taskId: -1,
+});

--- a/src/workers/update-design-md.ts
+++ b/src/workers/update-design-md.ts
@@ -1,0 +1,12 @@
+import { getUiDesignConfig } from "../config";
+import { createScheduledWorker } from "./scheduled-worker";
+
+export const updateDesignMdWorker = createScheduledWorker({
+  name: "update-design-md",
+  command: "/claude-task-worker:update-design-md",
+  taskId: -3,
+  // DESIGN.md の材料は `cc-ui-design` ラベル付きのマージ済みデザインPRで、それを作るのは
+  // uiDesign.enabled のデザイン先行フローだけ。無効なリポジトリでは収集対象が原理的に
+  // 存在しないため、空振りのセッションを毎日起動しないようここで止める。
+  enabled: () => getUiDesignConfig().enabled,
+});

--- a/src/workers/update-requirement-rules.ts
+++ b/src/workers/update-requirement-rules.ts
@@ -1,0 +1,7 @@
+import { createScheduledWorker } from "./scheduled-worker";
+
+export const updateRequirementRulesWorker = createScheduledWorker({
+  name: "update-requirement-rules",
+  command: "/claude-task-worker:update-requirement-rules",
+  taskId: -2,
+});


### PR DESCRIPTION
## 概要

`update-coding-guidelines` / `update-requirement-rules` / `update-design-md` を、24時間おきに直近24時間を対象として自動実行する定期ワーカーとして追加する。

## 変更内容

### 定期ワーカー（`src/workers/scheduled-worker.ts`）

- Issue・PR のポーリングではなく**時刻だけ**を条件にスキルを起動する共通実装（`createScheduledWorker()`）。3ワーカーは名前・スキル・タスクIDだけが違う
- 実行間隔は `SCHEDULE_INTERVAL_HOURS`（24）で固定。スキルへ渡す期間引数（`1` 日）も同じ定数から導出するため、「24時間おきに、直近24時間を対象に走る」が常に一致する
- `pollingIntervalSeconds`（既定3600）は実行間隔ではなく「24時間経過したかを確認する頻度」
- タスクIDは `-1` / `-2` / `-3`。`process-manager` の台帳は数値キーを Issue/PR 番号と共有するため、衝突しないよう負値を割り当てている

### 実行記録（`claude-task-worker.json` の `lastRun`）

- ワーカーが worktree 側の `claude-task-worker.json` へ `lastRun.<ワーカー名>` を書き込み、スキルの `commit-push` がその日の成果物と**同じコミット・同じPR**に含める
- 記録が恒久化するのはPRのマージ時点。それまではプロセス内の起動時刻が二重実行を止める（両方の max で判定）
- 3スキルに「差分の有無を判定するときに `claude-task-worker.json` を数えない」規定を追加。ワーカーが必ず書き込む以上、これが無いと成果物が空でも毎日タイムスタンプだけのPRが立つ

### `update-design-md` のゲート

`uiDesign.enabled` が `true` のときだけ起動する。DESIGN.md の材料である `cc-ui-design` ラベル付きマージ済みデザインPRを作るのはデザイン先行フローだけで、無効なリポジトリでは収集対象が原理的に存在しない（毎日空振りのセッションを焼くだけになる）。判定は `index.ts` ではなくワーカー側に置き、`all` / `yolo` からの一括起動でも個別コマンドでも同じ経路を通す。

### スキルのインターフェース統一

- 引数を `[期間（日数、省略時は1）] [関連Issue番号（任意）]` に統一（既定を 1 日へ揃え、収集スクリプトの `DAYS="${1:-1}"` も合わせる）
- ワーカー起動スキルになったため `model:` / `effort:` / `context: fork` を削除し、Stop フックと「実行モードの制約」セクションを追加。`src/skill-frontmatter.test.ts` の entrySkills リストで固定

## テスト

- `npm run build`（`tsc --noEmit` + esbuild）: 成功
- `npm test`: 309 pass / 0 fail（`parseLastRunEntry` / `writeLastRun` のテストを追加）

## 補足

`all` / `yolo` には `update-design-md` も含めている。`uiDesign.enabled` が `false` のリポジトリでは自己 no-op になるため、実質的に動くのは `update-coding-guidelines` / `update-requirement-rules` の2つ。

同一リポジトリで複数ワーカープロセスを並走させた場合の二重起動は防いでいない（実際に並走させるときに対応する）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)